### PR TITLE
Add TPU SparseCore embedding support to torchrec.experimental.torch_tpu (#4654)

### DIFF
--- a/torchrec/experimental/torch_tpu/README.md
+++ b/torchrec/experimental/torch_tpu/README.md
@@ -1,0 +1,391 @@
+# PyTorch TPU SparseCore Embedding (`torchrec.experimental.torch_tpu`)
+
+`torchrec.experimental.torch_tpu` provides Google TPU **SparseCore** hardware-accelerated replacements for PyTorch **TorchRec** recommendation model embedding modules.
+
+---
+
+## Overview & Why TPU SparseCore?
+
+In standard PyTorch and **TorchRec**, recommendation models handle high-cardinality categorical features using tables wrapped in an `EmbeddingBagCollection` (EBC) or `EmbeddingCollection` (EC). On GPUs and CPUs, looking up and optimizing massive sparse tables requires complex software sharding (`DistributedModelParallel`), host-to-device memory traffic, and separate optimizer kernels (`KeyedOptimizer`).
+
+Google TPUs feature specialized hardware accelerators called **SparseCore (SC)**, designed explicitly to execute sparse embedding lookups, communication, and gradient updates at high throughput.
+
+The `torchrec.experimental.torch_tpu` library provides drop-in, hardware-accelerated replacements for core TorchRec modules:
+* Executes both forward sparse lookups and backward optimizer updates natively in **SparseCore** hardware.
+* Eliminates autograd `.grad` tensor overhead on HBM by fusing optimizer step updates into the backward pass.
+* Offloads CSR-to-COO layout conversion and partition padding to a multi-threaded CPU C++ PyBind backend (`SparseCoreInputPreprocessor`).
+
+---
+
+## Architectural Comparison: TorchRec vs. `torchrec.experimental.torch_tpu`
+
+| Component | Standard TorchRec | TPU `torchrec.experimental.torch_tpu` | Key Difference / Benefit |
+| :--- | :--- | :--- | :--- |
+| **Table Configuration** | `torchrec.EmbeddingBagConfig` <br> `torchrec.EmbeddingConfig` | `SparseCoreEmbeddingConfig(config=..., max_ids_per_partition=256, ...)` | Wraps standard TorchRec configs with TPU SparseCore partition capacity and sequence bounds. |
+| **Pooled Collection (EBC)** | `torchrec.EmbeddingBagCollection` | `SparseCoreFusedEmbeddingBagCollection` | Replaces CPU/GPU EBC. Automatically handles MOD sharding across SparseCore partitions and chips. |
+| **Unpooled Collection (EC)** | `torchrec.EmbeddingCollection` | `SparseCoreFusedEmbeddingCollection` | Replaces EC for sequence models (e.g., HSTU, Shakespeare). Requires `max_seq_len` in config. |
+| **Optimizer & Backward Pass** | Separate `KeyedOptimizer` / `apply_optimizer_in_backward` | **Fused into the embedding module** via `optimizer_type` & `optimizer_kwargs` | Gradient computation and weight/momentum updates happen in-place on SparseCore during `loss.backward()`. |
+| **Input Preprocessing** | Raw `KeyedJaggedTensor` (KJT) passed directly to EBC/EC | CPU `SparseCoreInputPreprocessor` $\rightarrow$ `KeyedSparseCorePreprocessedInput` | Transforms KJT into padded COO/T8 tensors on CPU before `.to("tpu")` device transfer. |
+| **Distributed Sharding** | Explicit `DistributedModelParallel` (DMP) + `EmbeddingShardingPlanner` | **Automatic sharding** across `global_device_count` $\times$ `num_sc_per_device` | No DMP wrapper needed around embedding modules. |
+
+---
+
+## Step-by-Step Migration Guide
+
+### Step 1: Wrap Table Configurations with `SparseCoreEmbeddingConfig`
+
+In standard TorchRec, you define tables using `EmbeddingBagConfig` (for pooled embeddings) or `EmbeddingConfig` (for unpooled sequence embeddings).
+
+When migrating to `torchrec.experimental.torch_tpu`, wrap your existing configs in `SparseCoreEmbeddingConfig` to specify hardware partition capacity:
+
+```python
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
+from torchrec.experimental.torch_tpu.modules.embedding_configs import SparseCoreEmbeddingConfig
+
+# 1. Define standard TorchRec config
+base_config = EmbeddingBagConfig(
+    name="item_table",
+    embedding_dim=64,       # Must be divisible by 8
+    num_embeddings=4096,    # Will be rounded up to multiple of (num_sc * 8)
+    feature_names=["item_id"],
+    pooling=PoolingType.SUM,
+)
+
+# 2. Wrap for TPU SparseCore
+sc_table_config = SparseCoreEmbeddingConfig(
+    config=base_config,
+    max_ids_per_partition=256,
+    max_unique_ids_per_partition=256,
+    suggested_coo_buffer_size_per_device=32,
+)
+```
+
+> **Note:** For unpooled sequence tables (`EmbeddingConfig`), you **must** provide `max_seq_len` to `SparseCoreEmbeddingConfig(..., max_seq_len=64)` so the TPU compiler can statically allocate padded sequence buffers.
+
+---
+
+### Step 2: Replace Embedding Collections with Fused SparseCore Collections
+
+Replace `EmbeddingBagCollection` with `SparseCoreFusedEmbeddingBagCollection` (or `SparseCoreFusedEmbeddingCollection` for unpooled embeddings).
+
+Because TPU SparseCore fuses embedding lookups and backward optimizer updates into a single kernel (`SparseDenseMatmul`), pass your optimizer configuration directly into the module constructor:
+
+```python
+import torch
+from torchrec.experimental.torch_tpu.modules.fused_embedding_modules import SparseCoreFusedEmbeddingBagCollection
+
+embedding_layer = SparseCoreFusedEmbeddingBagCollection(
+    tables=[sc_table_config],
+    optimizer_type=torch.optim.SGD,     # Supported: torch.optim.SGD, Adagrad, Adam
+    optimizer_kwargs={"lr": 0.05},      # Learning rate & optimizer hyperparameters
+    batch_size=local_batch_size,        # Process-local batch size
+    global_device_count=world_size,     # Total TPU chips across hosts
+    num_sc_per_device=2,                # SparseCore virtual partitions per TPU chip
+)
+```
+
+#### Supported Optimizer Hyperparameters (`optimizer_kwargs`)
+`torchrec.experimental.torch_tpu` supports standard PyTorch optimizer parameter names:
+* **SGD**: `{"lr": 0.05}`
+* **Adagrad**: `{"lr": 0.1, "initial_accumulator_value": 0.1, "eps": 1e-10}`
+* **Adam**: `{"lr": 0.001, "betas": (0.9, 0.999), "eps": 1e-8}`
+
+*(Note: Legacy argument names `learning_rate`, `beta1`, `beta2`, and `epsilon` are also seamlessly accepted).*
+
+#### Modifying Learning Rate During Training
+To schedule or update the learning rate of the embedding tables across epochs, call:
+```python
+embedding_layer.set_learning_rate(new_lr)
+```
+
+---
+
+### Step 3: Setup CPU Input Preprocessing & Dataloading
+
+TPU SparseCore operates on structured CSR/COO layouts (`KeyedSparseCorePreprocessedInput`). Use `SparseCoreInputPreprocessor` to convert raw `KeyedJaggedTensor` (KJT) feature inputs on the CPU before copying to TPU.
+
+```python
+from torchrec.experimental.torch_tpu.datasets.input_preprocessing import SparseCoreInputPreprocessor
+from torchrec.experimental.torch_tpu.datasets.dataloader import SparseCoreBatch
+
+# 1. Instantiate CPU preprocessor once before the training loop
+preprocessor = SparseCoreInputPreprocessor(
+    tables=[sc_table_config],
+    batch_size=local_batch_size,
+    global_device_count=world_size,
+    num_sc_per_device=2,
+    allow_id_dropping=False,
+)
+
+# 2. Inside your dataloader / training loop:
+# Convert raw TorchRec Batch (CPU) into a TPU SparseCore batch
+tpu_batch = SparseCoreBatch.from_batch(raw_batch, preprocessor).to("tpu")
+```
+
+---
+
+### Step 4: Update Model Forward & Backward Loop
+
+The forward call syntax for `SparseCoreFusedEmbeddingBagCollection` is identical to TorchRec: it receives `tpu_batch.sparse_features` and returns a standard `torchrec.KeyedTensor`:
+
+```python
+# Forward pass
+pooled_embeddings = embedding_layer(tpu_batch.sparse_features)
+# pooled_embeddings["item_id"] -> Tensor of shape (batch_size, embedding_dim)
+
+# Combine with dense features and compute loss
+loss = compute_loss(pooled_embeddings, dense_features, labels)
+
+# Backward pass
+loss.backward()  # <--- Automatically runs TPU SparseCore backward & optimizer step!
+```
+
+> **Tip:** When defining your dense model optimizer (e.g., for MLPs and interaction layers), filter out embedding parameters so they are not doubly optimized by PyTorch autograd:
+> ```python
+> dense_params = [
+>     p for name, p in model.named_parameters() if "embedding_layer" not in name
+> ]
+> dense_optimizer = torch.optim.SGD(dense_params, lr=0.01)
+>
+> # Training step:
+> dense_optimizer.zero_grad()
+> loss.backward()
+> dense_optimizer.step()  # Only updates dense MLP parameters
+> ```
+
+---
+
+## Complete Code Comparison: DLRM Training (Before vs. After)
+
+### Before: Standard TorchRec (`DLRM`)
+
+```python
+import torch
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.models.dlrm import DLRM, DLRMTrain
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.datasets.utils import Batch
+
+# 1. Table Configs & EmbeddingBagCollection
+eb_config = EmbeddingBagConfig(
+    name="t_user",
+    embedding_dim=64,
+    num_embeddings=4096,
+    feature_names=["f_user"],
+    pooling=PoolingType.SUM,
+)
+ebc = EmbeddingBagCollection(tables=[eb_config])
+
+# 2. Model & Optimizer
+dlrm_model = DLRM(
+    embedding_bag_collection=ebc,
+    dense_in_features=100,
+    dense_arch_layer_sizes=[64, 64],
+    over_arch_layer_sizes=[32, 1],
+).to("cuda")
+
+train_model = DLRMTrain(dlrm_model)
+optimizer = torch.optim.SGD(train_model.parameters(), lr=0.1)
+
+# 3. Training Step (Raw KJT directly on GPU)
+optimizer.zero_grad()
+loss, _ = train_model(batch.to("cuda"))
+loss.backward()
+optimizer.step()  # Updates both dense and embedding weights
+```
+
+---
+
+### After: Migrated TPU SparseCore (`DLRM` with `torchrec.experimental.torch_tpu`)
+
+```python
+import torch
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
+from torchrec.experimental.torch_tpu.modules.embedding_configs import SparseCoreEmbeddingConfig
+from torchrec.experimental.torch_tpu.modules.fused_embedding_modules import SparseCoreFusedEmbeddingBagCollection
+from torchrec.experimental.torch_tpu.datasets.input_preprocessing import SparseCoreInputPreprocessor
+from torchrec.experimental.torch_tpu.datasets.dataloader import SparseCoreBatch
+from torchrec.models.dlrm import DLRM, DLRMTrain
+
+device = torch.device("tpu")
+batch_size = 128
+
+# 1. Wrap Table Config in SparseCoreEmbeddingConfig
+sc_config = SparseCoreEmbeddingConfig(
+    config=EmbeddingBagConfig(
+        name="t_user",
+        embedding_dim=64,
+        num_embeddings=4096,
+        feature_names=["f_user"],
+        pooling=PoolingType.SUM,
+    ),
+    max_ids_per_partition=256,
+    max_unique_ids_per_partition=256,
+)
+
+# 2. Fused TPU SparseCore EmbeddingBagCollection
+ebc = SparseCoreFusedEmbeddingBagCollection(
+    tables=[sc_config],
+    optimizer_type=torch.optim.SGD,      # Fused optimizer inside SparseCore
+    optimizer_kwargs={"lr": 0.1},
+    batch_size=batch_size,
+    global_device_count=1,
+    num_sc_per_device=2,
+)
+
+dlrm_model = DLRM(
+    embedding_bag_collection=ebc,
+    dense_in_features=100,
+    dense_arch_layer_sizes=[64, 64],
+    over_arch_layer_sizes=[32, 1],
+).to(device)
+
+train_model = DLRMTrain(dlrm_model)
+
+# 3. Optimize ONLY dense parameters on host/TPU
+dense_params = [
+    p for name, p in train_model.named_parameters() if "embedding_bags" not in name
+]
+dense_optimizer = torch.optim.SGD(dense_params, lr=0.1)
+
+# 4. CPU Preprocessor Setup
+preprocessor = SparseCoreInputPreprocessor(
+    tables=[sc_config],
+    batch_size=batch_size,
+)
+
+# 5. Training Step
+dense_optimizer.zero_grad()
+
+# Preprocess on CPU, then copy to TPU
+tpu_batch = SparseCoreBatch.from_batch(raw_batch, preprocessor).to(device)
+
+loss, _ = train_model(tpu_batch)
+loss.backward()          # TPU SparseCore updates embedding weights in hardware
+dense_optimizer.step()   # Host updates dense MLP parameters
+```
+
+---
+
+## Migrating Unpooled Sequence Models (`DLRM-HSTU`, `Shakespeare`)
+
+For models that require unpooled sequence embeddings (where each token or categorical ID retains its embedding vector across `max_seq_len` time steps), use **`SparseCoreFusedEmbeddingCollection`**.
+
+### Config & Layer Setup
+```python
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.experimental.torch_tpu.modules.embedding_configs import SparseCoreEmbeddingConfig
+from torchrec.experimental.torch_tpu.modules.fused_embedding_modules import SparseCoreFusedEmbeddingCollection
+
+# 1. Define unpooled EmbeddingConfig and specify max_seq_len
+seq_config = SparseCoreEmbeddingConfig(
+    config=EmbeddingConfig(
+        name="token_table",
+        embedding_dim=128,
+        num_embeddings=50000,
+        feature_names=["token_ids"],
+    ),
+    max_seq_len=64,          # REQUIRED for unpooled sequence lookups
+    max_ids_per_partition=512,
+    max_unique_ids_per_partition=512,
+)
+
+# 2. Create unpooled collection
+embedding_collection = SparseCoreFusedEmbeddingCollection(
+    tables=[seq_config],
+    optimizer_type=torch.optim.Adam,
+    optimizer_kwargs={"lr": 0.001, "betas": (0.9, 0.999), "eps": 1e-8},
+    batch_size=batch_size,
+    global_device_count=world_size,
+    num_sc_per_device=2,
+)
+```
+
+### Forward Output Format
+Unlike `EmbeddingBagCollection` (which returns a `KeyedTensor`), calling `SparseCoreFusedEmbeddingCollection` returns a dictionary of `JaggedTensor` objects keyed by feature name:
+
+```python
+# Forward call returns Dict[str, JaggedTensor]
+output_dict = embedding_collection(tpu_batch.sparse_features)
+
+token_embeddings = output_dict["token_ids"].values()
+# token_embeddings shape -> (actual_num_ids, embedding_dim)
+```
+
+---
+
+## Distributed Checkpointing (DCP) & CPU Inference Export
+
+`torchrec.experimental.torch_tpu` integrates natively with PyTorch Distributed Checkpoint (`torch.distributed.checkpoint` / `dcp`) via custom planners: **`SparseCoreSavePlanner`** and **`SparseCoreLoadPlanner`**.
+
+Because embedding tables are MOD-sharded across multiple TPU SparseCores globally, DCP allows:
+1. **Zero-Copy Distributed Save**: Each TPU rank streams its local shard to storage with global chunk metadata.
+2. **TPU Training Resumption**: Each TPU rank reloads its corresponding shard for seamless multi-device training resumption.
+3. **Cross-Topology Loading**: Allows loading checkpoints onto topologies with different number of ranks or SparseCores, enabling flexible re-sharding.
+4. **CPU Inference Unsharding**: Loads multi-device checkpoints directly into standard CPU TorchRec `EmbeddingBagCollection` / `EmbeddingCollection` models with vectorized in-memory table reconstruction.
+
+### 1. Saving Distributed Checkpoint on TPU
+
+```python
+import torch.distributed.checkpoint as dcp
+from torchrec.experimental.torch_tpu.checkpoint.planners import SparseCoreSavePlanner
+
+# Save state dict containing TPU SparseCore embedding tables
+# No need to isolate embedding tables! Pass full state_dict.
+save_state_dict = dlrm_model.state_dict()
+
+dcp.save(
+    state_dict=save_state_dict,
+    storage_writer=dcp.FileSystemWriter("/tmp/my_checkpoint_dir"),
+    planner=SparseCoreSavePlanner(num_sc_per_device=2),
+)
+```
+
+---
+
+### 2. Loading for Multi-Device TPU Training Resumption
+
+```python
+from torchrec.experimental.torch_tpu.checkpoint.planners import SparseCoreLoadPlanner
+
+# Fresh model instance on TPU
+load_state_dict = new_dlrm_model.state_dict()
+
+dcp.load(
+    state_dict=load_state_dict,
+    storage_reader=dcp.FileSystemReader("/tmp/my_checkpoint_dir"),
+    planner=SparseCoreLoadPlanner(
+        num_sc_per_device=2,
+        unshard_for_cpu=False,
+    ),
+)
+```
+
+---
+
+### 3. Loading for CPU Inference (Unsharding to Standard TorchRec)
+
+When serving models on CPU or GPUs, load the checkpoint directly into standard TorchRec `EmbeddingBagCollection` or `EmbeddingCollection`:
+
+```python
+import torch
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.experimental.torch_tpu.checkpoint.planners import SparseCoreLoadPlanner
+
+# Standard CPU TorchRec module
+cpu_ebc = EmbeddingBagCollection(tables=[base_config], device=torch.device("cpu"))
+cpu_state_dict = cpu_ebc.state_dict()
+
+# Automatically unshard MOD-sharded tables in-place during load
+dcp.load(
+    state_dict=cpu_state_dict,
+    storage_reader=dcp.FileSystemReader("/tmp/my_checkpoint_dir"),
+    planner=SparseCoreLoadPlanner(
+        num_sc_per_device=2,
+        unshard_for_cpu=True,
+    ),
+)
+```
+
+---

--- a/torchrec/experimental/torch_tpu/__init__.py
+++ b/torchrec/experimental/torch_tpu/__init__.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Re-exports resolve lazily (PEP 562) rather than at package-import time.
+#
+# Importing ANY submodule of this package runs this file first, so eager re-exports
+# made every sibling depend on the union of their requirements: `jax` (via
+# modules.embedding_modules -> pallas), `etils`, and the `pybind_input_preprocessing`
+# extension, which setup.py deliberately does not build. None of those exist in an OSS
+# install, so pure-torch modules such as `uneven_all_to_all` -- and their tests --
+# became unimportable there.
+#
+# Resolving on first attribute access keeps `from torchrec.experimental.torch_tpu
+# import <symbol>` working while confining each dependency to the code that needs it.
+# Touching a symbol whose backing module is unavailable still raises the underlying
+# ImportError, naming the missing package.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.checkpoint.planners import (
+        SparseCoreLoadPlanner,
+        SparseCoreSavePlanner,
+    )
+    from torchrec.experimental.torch_tpu.datasets.dataloader import (
+        SparseCoreBatch,
+        SparseCoreDataLoader,
+    )
+    from torchrec.experimental.torch_tpu.datasets.input_preprocessing import (
+        KeyedSparseCorePreprocessedInput,
+        SparseCoreInputPreprocessor,
+        SparseCorePreprocessedInput,
+    )
+    from torchrec.experimental.torch_tpu.modules.embedding_configs import (
+        SparseCoreEmbeddingConfig,
+    )
+    from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+        TPUEmbeddingUnfused,
+    )
+    from torchrec.experimental.torch_tpu.modules.fused_embedding_modules import (
+        SparseCoreFusedEmbeddingBagCollection,
+        SparseCoreFusedEmbeddingCollection,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "KeyedSparseCorePreprocessedInput": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+    "SparseCoreBatch": "torchrec.experimental.torch_tpu.datasets.dataloader",
+    "SparseCoreDataLoader": "torchrec.experimental.torch_tpu.datasets.dataloader",
+    "SparseCoreEmbeddingConfig": "torchrec.experimental.torch_tpu.modules.embedding_configs",
+    "SparseCoreFusedEmbeddingBagCollection": "torchrec.experimental.torch_tpu.modules.fused_embedding_modules",
+    "SparseCoreFusedEmbeddingCollection": "torchrec.experimental.torch_tpu.modules.fused_embedding_modules",
+    "SparseCoreInputPreprocessor": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+    "SparseCoreLoadPlanner": "torchrec.experimental.torch_tpu.checkpoint.planners",
+    "SparseCorePreprocessedInput": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+    "SparseCoreSavePlanner": "torchrec.experimental.torch_tpu.checkpoint.planners",
+    "TPUEmbeddingUnfused": "torchrec.experimental.torch_tpu.modules.embedding_modules",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(importlib.import_module(module_name), name)
+    # Cache on the module so subsequent lookups skip __getattr__ entirely.
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "SparseCoreEmbeddingConfig",
+    "SparseCoreFusedEmbeddingBagCollection",
+    "SparseCoreFusedEmbeddingCollection",
+    "TPUEmbeddingUnfused",
+    "SparseCoreInputPreprocessor",
+    "KeyedSparseCorePreprocessedInput",
+    "SparseCorePreprocessedInput",
+    "SparseCoreBatch",
+    "SparseCoreDataLoader",
+    "SparseCoreSavePlanner",
+    "SparseCoreLoadPlanner",
+]

--- a/torchrec/experimental/torch_tpu/checkpoint/__init__.py
+++ b/torchrec/experimental/torch_tpu/checkpoint/__init__.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Re-exports resolve lazily (PEP 562), matching the rest of this package; see the
+# package __init__ one level up for the rationale. `planners` needs only torch today,
+# so this is consistency rather than a fix, and it keeps that true for callers if the
+# planners later grow a TPU-only dependency.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.checkpoint.planners import (
+        SparseCoreLoadPlanner,
+        SparseCoreSavePlanner,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "SparseCoreLoadPlanner": "torchrec.experimental.torch_tpu.checkpoint.planners",
+    "SparseCoreSavePlanner": "torchrec.experimental.torch_tpu.checkpoint.planners",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(importlib.import_module(module_name), name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "SparseCoreSavePlanner",
+    "SparseCoreLoadPlanner",
+]

--- a/torchrec/experimental/torch_tpu/checkpoint/planners.py
+++ b/torchrec/experimental/torch_tpu/checkpoint/planners.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch DCP Save and Load Planners for PyTorch TPU Embedding."""
+
+import dataclasses
+import logging
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed.checkpoint import (
+    default_planner,
+    metadata as metadata_mod,
+    planner as planner_mod,
+)
+from torchrec.experimental.torch_tpu.checkpoint import utils
+
+__all__ = [
+    "SparseCoreSavePlanner",
+    "SparseCoreLoadPlanner",
+]
+
+
+class SparseCoreSavePlanner(default_planner.DefaultSavePlanner):
+    """Custom PyTorch DCP SavePlanner that injects SparseCore topology metadata into DCP global metadata.
+
+    Enables cross-topology loading and CPU inference unsharding by preserving
+    original sharding parameters (world_size, num_sc_per_device, etc.) in
+    `metadata.planner_data["sparsecore"]`.
+    """
+
+    def __init__(
+        self,
+        num_sc_per_device: int = 2,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.num_sc_per_device = num_sc_per_device
+
+    def create_global_plan(
+        self, all_plans: list[planner_mod.SavePlan]
+    ) -> tuple[list[planner_mod.SavePlan], metadata_mod.Metadata]:
+        global_plan, metadata = super().create_global_plan(all_plans)
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        sparsecore_metadata = {
+            "world_size": world_size,
+            "num_sc_per_device": self.num_sc_per_device,
+        }
+        loaded_planner_data = metadata.planner_data or {}
+        if isinstance(loaded_planner_data, dict):
+            loaded_planner_data["sparsecore"] = sparsecore_metadata
+            metadata = dataclasses.replace(metadata, planner_data=loaded_planner_data)
+        else:
+            logging.warning("planner_data is not a dict, skipping metadata injection.")
+        return global_plan, metadata
+
+
+class SparseCoreLoadPlanner(default_planner.DefaultLoadPlanner):
+    """Custom PyTorch DCP LoadPlanner that supports cross-topology loading and CPU inference unsharding.
+
+    - Cross-Topology: Allows loading checkpoints onto topologies with different
+      number of ranks or SparseCores. Transparently un-MOD-shards using original
+      topology and re-shards for target topology.
+    - CPU Inference (unshard_for_cpu=True): Allows loading MOD-sharded checkpoints
+      directly onto sequential CPU buffers for inference with standard TorchRec
+      modules.
+    """
+
+    def __init__(
+        self,
+        num_sc_per_device: int = 2,
+        unshard_for_cpu: bool = False,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.num_sc_per_device = num_sc_per_device
+        self.unshard_for_cpu = unshard_for_cpu
+        self.old_topology: Optional[dict[str, Any]] = None
+        self.cross_topology = False
+        self._cpu_buffers: dict[str, torch.Tensor] = {}
+        self._metadata: Optional[Any] = None
+        self._loaded_chunks: dict[str, int] = {}
+
+    def set_up_planner(
+        self,
+        state_dict: dict[str, Any],
+        metadata: Optional[Any] = None,
+        is_coordinator: bool = False,
+    ) -> None:
+        self._metadata = metadata
+        self._loaded_chunks = {}
+        if metadata and metadata.planner_data:
+            if isinstance(metadata.planner_data, dict):
+                self.old_topology = metadata.planner_data.get("sparsecore", None)
+                if self.old_topology:
+                    logging.info(
+                        "Read native SparseCore metadata: %s", self.old_topology
+                    )
+            else:
+                logging.warning(
+                    "planner_data is not a dict, cannot read sparsecore metadata."
+                )
+
+        if self.unshard_for_cpu:
+            super().set_up_planner(state_dict, metadata, is_coordinator)
+            return
+
+        self.cross_topology = False
+        if self.old_topology:
+            try:
+                curr_world_size = dist.get_world_size() if dist.is_initialized() else 1
+                curr_num_sc = self.num_sc_per_device
+                if (
+                    self.old_topology["world_size"] != curr_world_size
+                    or self.old_topology["num_sc_per_device"] != curr_num_sc
+                ):
+                    self.cross_topology = True
+                    logging.info(
+                        "SparseCoreLoadPlanner: Topology mismatch detected! Old:"
+                        " world_size=%d, num_sc=%d; Current: world_size=%d, num_sc=%d",
+                        self.old_topology["world_size"],
+                        self.old_topology["num_sc_per_device"],
+                        curr_world_size,
+                        curr_num_sc,
+                    )
+            except Exception as e:  # pylint: disable=broad-except
+                logging.warning("Failed to check topology compatibility: %s", e)
+
+        self._target_tensors: dict[str, Any] = {}
+        if (
+            self.cross_topology
+            and metadata
+            and hasattr(metadata, "state_dict_metadata")
+        ):
+            modified_sd = dict(state_dict)
+            for fqn, obj in state_dict.items():
+                is_embedding_weight = (
+                    "embedding_bags." in fqn or "embeddings." in fqn
+                ) and fqn.endswith(".weight")
+
+                is_embedding_state = any(
+                    x in fqn
+                    for x in [
+                        "accumulators.",
+                        "momentums.",
+                        "velocities.",
+                    ]
+                )
+                if (
+                    is_embedding_weight or is_embedding_state
+                ) and fqn in metadata.state_dict_metadata:
+                    meta = metadata.state_dict_metadata[fqn]
+                    self._target_tensors[fqn] = obj
+                    cpu_tensor = torch.empty(
+                        meta.size,
+                        dtype=meta.properties.dtype,
+                        layout=meta.properties.layout,
+                        device="cpu",
+                    )
+                    self._cpu_buffers[fqn] = cpu_tensor
+                    modified_sd[fqn] = cpu_tensor
+            super().set_up_planner(modified_sd, metadata, is_coordinator)
+        else:
+            super().set_up_planner(state_dict, metadata, is_coordinator)
+
+    def resolve_tensor(self, read_item: planner_mod.ReadItem) -> torch.Tensor:
+        fqn = read_item.dest_index.fqn
+        if (self.cross_topology or self.unshard_for_cpu) and fqn in self._cpu_buffers:
+            return self.transform_tensor(read_item, self._cpu_buffers[fqn])
+
+        return super().resolve_tensor(read_item)
+
+    def commit_tensor(
+        self, read_item: planner_mod.ReadItem, tensor: torch.Tensor
+    ) -> None:
+        super().commit_tensor(read_item, tensor)
+        fqn = read_item.dest_index.fqn
+
+        is_embedding_weight = (
+            "embedding_bags." in fqn or "embeddings." in fqn
+        ) and fqn.endswith(".weight")
+
+        is_embedding_state = any(
+            x in fqn
+            for x in [
+                "accumulators.",
+                "momentums.",
+                "velocities.",
+            ]
+        )
+        is_embedding = is_embedding_weight or is_embedding_state
+
+        if not is_embedding:
+            return
+
+        # Only process if post-processing is needed
+        if not (
+            self.unshard_for_cpu or (fqn in self._cpu_buffers and self.cross_topology)
+        ):
+            return
+
+        self._loaded_chunks[fqn] = self._loaded_chunks.get(fqn, 0) + 1
+
+        metadata = self._metadata
+        total_chunks = 1
+        if metadata is not None and fqn in metadata.state_dict_metadata:
+            md = metadata.state_dict_metadata[fqn]
+            if hasattr(md, "chunks"):
+                total_chunks = len(md.chunks)
+
+        if self._loaded_chunks[fqn] < total_chunks:
+            return
+
+        # Common extraction for both paths
+        assert self.old_topology is not None
+        old_world_size = self.old_topology.get("world_size", 1)
+        old_num_sc = self.old_topology.get("num_sc_per_device", 2)
+        old_num_shards = old_world_size * old_num_sc
+
+        assert metadata is not None
+        assert fqn in metadata.state_dict_metadata
+        md = metadata.state_dict_metadata[fqn]
+        vocab_size = md.size[0]
+        embedding_dim = md.size[1]
+
+        if self.unshard_for_cpu:
+            # CPU Inference Path: In-place unshard the loaded buffer
+            target = self.lookup_tensor(read_item.dest_index)
+
+            unsharded = utils.reverse_mod_shard(
+                target,
+                vocab_size=vocab_size,
+                embedding_dim=embedding_dim,
+                num_shards=old_num_shards,
+            )
+            # Copy into target, ensuring size match by slicing target to vocab_size
+            target.data[:vocab_size, :].copy_(unsharded)
+            return
+
+        # Cross Topology Path
+        full_cpu_tensor = self._cpu_buffers[fqn]
+        target_param = self._target_tensors[fqn]
+
+        # 1. Unshard from old topology
+        sequential_cpu = utils.reverse_mod_shard(
+            full_cpu_tensor,
+            vocab_size=vocab_size,
+            embedding_dim=embedding_dim,
+            num_shards=old_num_shards,
+        )
+
+        # 2. Reshard for current topology
+        curr_world_size = dist.get_world_size() if dist.is_initialized() else 1
+        curr_num_sc = self.num_sc_per_device
+        curr_num_shards = curr_world_size * curr_num_sc
+
+        target_padded_vocab = target_param.size(0)
+
+        target_padded_cpu = torch.zeros(
+            (target_padded_vocab, embedding_dim), dtype=full_cpu_tensor.dtype
+        )
+        # Handle potential padding in sequential_cpu
+        copy_limit = min(sequential_cpu.size(0), target_padded_vocab)
+        target_padded_cpu[:copy_limit, :] = sequential_cpu[:copy_limit, :]
+
+        # Apply target MOD sharding
+        target_sharded_cpu = utils.mod_shard(
+            target_padded_cpu,
+            num_shards=curr_num_shards,
+        )
+
+        # Extract local slice and copy to TPU
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        local_rows = target_padded_vocab // curr_world_size
+        local_slice = target_sharded_cpu[rank * local_rows : (rank + 1) * local_rows]
+
+        logging.info("SparseCoreLoadPlanner: Copying slice to TPU for %s", fqn)
+        with torch.no_grad():
+            if hasattr(target_param, "to_local"):
+                target_param.to_local().copy_(local_slice.to(target_param.device))
+            else:
+                target_param.copy_(local_slice.to(target_param.device))
+
+        logging.info("SparseCoreLoadPlanner: Finished processing %s", fqn)
+        del self._cpu_buffers[fqn]

--- a/torchrec/experimental/torch_tpu/checkpoint/utils.py
+++ b/torchrec/experimental/torch_tpu/checkpoint/utils.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for PyTorch TPU Embedding."""
+
+import torch
+
+
+def mod_shard(
+    unsharded_weight: torch.Tensor,
+    num_shards: int,
+) -> torch.Tensor:
+    """MOD shards a sequential global tensor.
+
+    Args:
+      unsharded_weight: Tensor of shape [vocab_size, dim]
+      num_shards: Number of shards (ranks * SCs per rank)
+
+    Returns:
+      MOD-sharded tensor of shape [vocab_size, dim] where the rows are permuted.
+    """
+    vocab_size = unsharded_weight.size(0)
+    if vocab_size % num_shards != 0:
+        raise ValueError(
+            f"Vocab size {vocab_size} must be divisible by num_shards {num_shards}"
+        )
+
+    shard_size = vocab_size // num_shards
+    extra_shape = list(unsharded_weight.shape[1:])
+
+    # Reshape: [shard_size, num_shards, *extra_shape]
+    t = unsharded_weight.view(shard_size, num_shards, *extra_shape)
+    # Transpose: [num_shards, shard_size, *extra_shape]
+    t = t.permute(1, 0, *range(2, t.ndim)).contiguous()
+    # Flatten: [vocab_size, *extra_shape]
+    return t.view(-1, *extra_shape)
+
+
+def reverse_mod_shard(
+    sharded_weight: torch.Tensor,
+    vocab_size: int,
+    embedding_dim: int,
+    num_shards: int,
+) -> torch.Tensor:
+    """Un-MOD-shards a sharded tensor back to sequential layout.
+
+    Args:
+      sharded_weight: Consolidated sharded tensor of shape [padded_vocab_size,
+        dim]
+      vocab_size: Original (unpadded) vocabulary size.
+      embedding_dim: Embedding dimension.
+      num_shards: Number of shards (ranks * SCs per rank)
+
+    Returns:
+      Sequential unpadded tensor of shape [vocab_size, embedding_dim].
+    """
+    padded_vocab_size = sharded_weight.size(0)
+    if padded_vocab_size % num_shards != 0:
+        raise ValueError(
+            f"Padded vocab size {padded_vocab_size} must be divisible by num_shards"
+            f" {num_shards}"
+        )
+
+    shard_size = padded_vocab_size // num_shards
+    extra_shape = list(sharded_weight.shape[1:])
+
+    # Reshape: [num_shards, shard_size, *extra_shape]
+    t = sharded_weight.view(num_shards, shard_size, *extra_shape)
+    # Transpose: [shard_size, num_shards, *extra_shape]
+    t = t.permute(1, 0, *range(2, t.ndim)).contiguous()
+    # Flatten: [padded_vocab_size, *extra_shape]
+    unsharded_weight = t.view(-1, *extra_shape)
+
+    # Slice to remove padding if vocab_size is smaller than padded shape
+    return unsharded_weight[:vocab_size, :embedding_dim]

--- a/torchrec/experimental/torch_tpu/datasets/__init__.py
+++ b/torchrec/experimental/torch_tpu/datasets/__init__.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Re-exports resolve lazily (PEP 562); see the package __init__ one level up for the
+# rationale. Both re-exports here reach `input_preprocessing`, which needs `etils` and
+# the `pybind_input_preprocessing` extension that setup.py deliberately does not build,
+# so neither is importable from an OSS install. Deferring keeps that confined to code
+# that actually uses them instead of anything importing a sibling, notably the `fdo`
+# subpackage.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.datasets.dataloader import (
+        SparseCoreBatch,
+        SparseCoreDataLoader,
+    )
+    from torchrec.experimental.torch_tpu.datasets.input_preprocessing import (
+        KeyedSparseCorePreprocessedInput,
+        SparseCoreInputPreprocessor,
+        SparseCorePreprocessedInput,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "KeyedSparseCorePreprocessedInput": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+    "SparseCoreBatch": "torchrec.experimental.torch_tpu.datasets.dataloader",
+    "SparseCoreDataLoader": "torchrec.experimental.torch_tpu.datasets.dataloader",
+    "SparseCoreInputPreprocessor": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+    "SparseCorePreprocessedInput": "torchrec.experimental.torch_tpu.datasets.input_preprocessing",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(importlib.import_module(module_name), name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "SparseCoreBatch",
+    "SparseCoreDataLoader",
+    "SparseCoreInputPreprocessor",
+    "KeyedSparseCorePreprocessedInput",
+    "SparseCorePreprocessedInput",
+]

--- a/torchrec/experimental/torch_tpu/datasets/dataloader.py
+++ b/torchrec/experimental/torch_tpu/datasets/dataloader.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data loading utilities for TPU SparseCore."""
+
+import dataclasses
+from typing import Any, Generator
+
+from torchrec.datasets.utils import Batch
+from torchrec.experimental.torch_tpu.datasets.input_preprocessing import (
+    KeyedSparseCorePreprocessedInput,
+    SparseCoreInputPreprocessor,
+)
+
+dataclass = dataclasses.dataclass
+
+
+@dataclass
+class SparseCoreBatch(Batch):
+    """Batch containing preprocessed sparse features for SparseCore."""
+
+    sparse_features: KeyedSparseCorePreprocessedInput
+
+    @classmethod
+    def from_batch(
+        cls, batch: Batch, preprocessor: SparseCoreInputPreprocessor
+    ) -> "SparseCoreBatch":
+        """Creates a SparseCoreBatch from a standard Batch by preprocessing sparse features on CPU."""
+        preprocessed_cpu = preprocessor(batch.sparse_features)
+        return cls(
+            dense_features=batch.dense_features,
+            sparse_features=preprocessed_cpu,
+            labels=batch.labels,
+        )
+
+
+class SparseCoreDataLoader:
+    """Wrapper around a PyTorch DataLoader to perform CPU preprocessing eagerly."""
+
+    def __init__(self, dataloader: Any, preprocessor: SparseCoreInputPreprocessor):
+        self.dataloader = dataloader
+        self.preprocessor = preprocessor
+
+    def __iter__(self) -> Generator[SparseCoreBatch, None, None]:
+        for batch in self.dataloader:
+            yield SparseCoreBatch.from_batch(batch, self.preprocessor)
+
+    def __len__(self) -> int:
+        return len(self.dataloader)

--- a/torchrec/experimental/torch_tpu/datasets/fdo/__init__.py
+++ b/torchrec/experimental/torch_tpu/datasets/fdo/__init__.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Re-exports resolve lazily (PEP 562); see the package __init__ two levels up for the
+# rationale. Here the two backing modules have disjoint requirements -- `absl` for the
+# CSV client, `etils` for the client interface -- so eager re-exports made each depend
+# on the other's.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.datasets.fdo.csv_file_fdo_client import (
+        CSVFileFDOClient,
+    )
+    from torchrec.experimental.torch_tpu.datasets.fdo.fdo_client import (
+        FDOClient,
+        KeyedSparseCoreInputStats,
+        SparseCoreInputStats,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "CSVFileFDOClient": "torchrec.experimental.torch_tpu.datasets.fdo.csv_file_fdo_client",
+    "FDOClient": "torchrec.experimental.torch_tpu.datasets.fdo.fdo_client",
+    "KeyedSparseCoreInputStats": "torchrec.experimental.torch_tpu.datasets.fdo.fdo_client",
+    "SparseCoreInputStats": "torchrec.experimental.torch_tpu.datasets.fdo.fdo_client",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(importlib.import_module(module_name), name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "FDOClient",
+    "CSVFileFDOClient",
+    "SparseCoreInputStats",
+    "KeyedSparseCoreInputStats",
+]

--- a/torchrec/experimental/torch_tpu/datasets/fdo/csv_file_fdo_client.py
+++ b/torchrec/experimental/torch_tpu/datasets/fdo/csv_file_fdo_client.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An FDO client implementation that uses CSV files as storage."""
+
+import collections
+import csv
+import glob
+import os
+from typing import Dict
+
+from absl import logging
+from torchrec.experimental.torch_tpu.datasets.fdo import fdo_client
+
+
+class CSVFileFDOClient(fdo_client.BaseFileFDOClient):
+    """FDO client that writes stats to a file in .csv format."""
+
+    _FILE_EXTENSION = "csv"
+
+    def publish(self) -> None:
+        """Publishes locally accumulated stats to a CSV file in base_dir."""
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        file_name = self._generate_file_name()
+        logging.info("Writing FDO CSV stats to %s", file_name)
+        with open(file_name, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                ["table_name", "max_ids", "max_unique_ids", "dropped_count"]
+            )
+            all_tables = set(self._observed_max_ids.keys())
+            for t_name in sorted(all_tables):
+                writer.writerow(
+                    [
+                        t_name,
+                        self._observed_max_ids[t_name],
+                        self._observed_max_unique_ids[t_name],
+                        self._dropped_counts[t_name],
+                    ]
+                )
+
+    def load(self) -> fdo_client.KeyedSparseCoreInputStats:
+        """Loads state of local FDO client from disk and returns aggregated stats."""
+        files_glob = os.fspath(
+            self._base_dir / f"{self._FILE_NAME}*.{self._FILE_EXTENSION}"
+        )
+        files = self._get_latest_files_by_process(glob.glob(files_glob))
+        if not files:
+            raise FileNotFoundError(f"No stats files found in {files_glob}")
+
+        max_ids: Dict[str, int] = collections.defaultdict(int)
+        max_unique_ids: Dict[str, int] = collections.defaultdict(int)
+        dropped_counts: Dict[str, int] = collections.defaultdict(int)
+
+        for file_name in files:
+            logging.info("Reading FDO CSV stats from %s", file_name)
+            with open(file_name, "r", newline="") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    t_name = row["table_name"]
+                    max_ids[t_name] = max(max_ids[t_name], int(row["max_ids"]))
+                    max_unique_ids[t_name] = max(
+                        max_unique_ids[t_name], int(row["max_unique_ids"])
+                    )
+                    dropped_counts[t_name] += int(row["dropped_count"])
+
+        table_stats = {}
+        for t_name in max_ids:
+            table_stats[t_name] = fdo_client.SparseCoreInputStats(
+                dropped_count=dropped_counts[t_name],
+                observed_max_ids=max_ids[t_name],
+                observed_max_unique_ids=max_unique_ids[t_name],
+            )
+
+        return fdo_client.KeyedSparseCoreInputStats(table_stats)

--- a/torchrec/experimental/torch_tpu/datasets/fdo/fdo_client.py
+++ b/torchrec/experimental/torch_tpu/datasets/fdo/fdo_client.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstract interface for FDO client in Torch TPU Embedding."""
+
+import abc
+import collections
+import dataclasses
+import itertools
+import os
+import re
+import time
+from typing import Any, Dict, List
+
+from etils import epath
+
+
+@dataclasses.dataclass
+class SparseCoreInputStats:
+    """Container for preprocessor diagnostic statistics for a single table."""
+
+    dropped_count: int = 0
+    observed_max_ids: int = 0
+    observed_max_unique_ids: int = 0
+
+
+class KeyedSparseCoreInputStats:
+    """Container for preprocessor diagnostic statistics across all tables."""
+
+    def __init__(
+        self,
+        table_stats: Dict[str, SparseCoreInputStats],
+    ):
+        """Initializes the container with a mapping from table names to diagnostic statistics.
+
+        Args:
+          table_stats: Dictionary mapping table name string to its diagnostic
+            statistics.
+        """
+        self.table_stats = table_stats
+
+
+class FDOClient(abc.ABC):
+    """Abstract interface for FDO client in Torch TPU Embedding.
+
+    This class defines the interface for a per-process client that interacts with
+    the FDO system. An implementation of this class should define how the FDO
+    stats are recorded and published to a storage location (disk, database, etc.).
+    The load method should return the current aggregated stats across all
+    processes.
+    """
+
+    @abc.abstractmethod
+    def record(
+        self,
+        data: KeyedSparseCoreInputStats,
+    ) -> None:
+        """Records the raw stats to process-local memory.
+
+        Args:
+          data: Input preprocessing diagnostic statistics to be recorded.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def publish(self) -> None:
+        """Publishes stats to the storage location."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def load(self) -> Any:
+        """Loads state of local FDO client and returns aggregated stats.
+
+        Returns:
+          Aggregated stats across processes.
+        """
+        raise NotImplementedError
+
+
+class BaseFileFDOClient(FDOClient):
+    """Base class for file-based FDO clients."""
+
+    _FILE_NAME = "fdo_stats"
+    _FILE_EXTENSION: str = ""
+
+    def __init__(
+        self,
+        base_dir: epath.PathLike,
+        process_id: int = 0,
+        initial_stats: KeyedSparseCoreInputStats | None = None,
+    ):
+        self._base_dir = epath.Path(base_dir)
+        self._process_id = process_id
+        self._observed_max_ids: Dict[str, int] = collections.defaultdict(int)
+        self._observed_max_unique_ids: Dict[str, int] = collections.defaultdict(int)
+        self._dropped_counts: Dict[str, int] = collections.defaultdict(int)
+
+        if initial_stats is not None:
+            self.record(initial_stats)
+
+    def record(
+        self,
+        data: KeyedSparseCoreInputStats,
+    ) -> None:
+        """Records stats per process."""
+        for table_name, stats in data.table_stats.items():
+            self._observed_max_ids[table_name] = max(
+                self._observed_max_ids[table_name], stats.observed_max_ids
+            )
+            self._observed_max_unique_ids[table_name] = max(
+                self._observed_max_unique_ids[table_name],
+                stats.observed_max_unique_ids,
+            )
+            self._dropped_counts[table_name] += stats.dropped_count
+
+    def _generate_file_name(self) -> str:
+        filename = f"{self._FILE_NAME}_{self._process_id}_{time.time_ns()}.{self._FILE_EXTENSION}"
+        return os.fspath(self._base_dir / filename)
+
+    def _get_latest_files_by_process(self, files: List[str]) -> List[str]:
+        if not files:
+            return []
+        pattern = rf"{self._FILE_NAME}_(\d+)_(\d+)\.{self._FILE_EXTENSION}"
+        file_groups = []
+        for file in files:
+            match = re.search(pattern, os.path.basename(file))
+            if match:
+                file_groups.append((match.group(1), int(match.group(2)), file))
+        if not file_groups:
+            return []
+        file_groups = sorted(file_groups, reverse=True)
+        latest_files = []
+        for _, file_group in itertools.groupby(file_groups, key=lambda x: x[0]):
+            _, _, file_name = next(file_group)
+            latest_files.append(file_name)
+        return latest_files

--- a/torchrec/experimental/torch_tpu/datasets/input_preprocessing.py
+++ b/torchrec/experimental/torch_tpu/datasets/input_preprocessing.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Input preprocessing utilities for TPU SparseCore."""
+
+import dataclasses
+import math
+from typing import Any, Dict, List, Optional
+
+import torch
+from etils import epath
+from torch import distributed as dist
+from torchrec.experimental.torch_tpu.datasets import pybind_input_preprocessing
+from torchrec.experimental.torch_tpu.datasets.fdo import csv_file_fdo_client
+from torchrec.experimental.torch_tpu.datasets.fdo.fdo_client import (
+    FDOClient,
+    KeyedSparseCoreInputStats,
+    SparseCoreInputStats,
+)
+from torchrec.experimental.torch_tpu.modules.embedding_configs import (
+    SparseCoreEmbeddingConfig,
+)
+from torchrec.modules.embedding_configs import (
+    EmbeddingBagConfig,
+    EmbeddingConfig,
+    PoolingType,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+@dataclasses.dataclass
+class SparseCorePreprocessedInput:
+    """Container for preprocessed TPU tensors for a single table."""
+
+    row_pointers: torch.Tensor
+    embedding_ids: torch.Tensor
+    sample_ids: torch.Tensor
+    gains: torch.Tensor
+    lengths: Dict[str, torch.Tensor] = dataclasses.field(default_factory=dict)
+    actual_num_ids: Dict[str, int] = dataclasses.field(default_factory=dict)
+    stats: Optional[SparseCoreInputStats] = None
+
+    def to(
+        self, device: torch.device, non_blocking: bool = False
+    ) -> "SparseCorePreprocessedInput":
+        """Moves all preprocessed tensors and lengths dictionaries to the target device.
+
+        Args:
+          device: The target PyTorch device (e.g., TPU or CPU).
+          non_blocking: Whether to perform asynchronous copy if in pinned memory.
+
+        Returns:
+          A new SparseCorePreprocessedInput container on the target device.
+        """
+        new_lengths = {
+            k: v.to(device, non_blocking=non_blocking) for k, v in self.lengths.items()
+        }
+        return SparseCorePreprocessedInput(
+            row_pointers=self.row_pointers.to(device, non_blocking=non_blocking),
+            embedding_ids=self.embedding_ids.to(device, non_blocking=non_blocking),
+            sample_ids=self.sample_ids.to(device, non_blocking=non_blocking),
+            gains=self.gains.to(device, non_blocking=non_blocking),
+            lengths=new_lengths,
+            actual_num_ids=self.actual_num_ids,
+            stats=self.stats,
+        )
+
+    def record_stream(self, stream: torch.Stream) -> None:
+        """Records the CUDA/TPU stream usage for all underlying tensors to prevent premature recycling.
+
+        Args:
+          stream: The execution stream to record against.
+        """
+        self.row_pointers.record_stream(stream)
+        self.embedding_ids.record_stream(stream)
+        self.sample_ids.record_stream(stream)
+        self.gains.record_stream(stream)
+        for v in self.lengths.values():
+            v.record_stream(stream)
+
+    def pin_memory(self) -> "SparseCorePreprocessedInput":
+        """Pins page-locked memory for all underlying CPU tensors for faster asynchronous device transfer.
+
+        Returns:
+          A new SparseCorePreprocessedInput container backed by pinned CPU memory.
+        """
+        new_lengths = {k: v.pin_memory() for k, v in self.lengths.items()}
+        return SparseCorePreprocessedInput(
+            row_pointers=self.row_pointers.pin_memory(),
+            embedding_ids=self.embedding_ids.pin_memory(),
+            sample_ids=self.sample_ids.pin_memory(),
+            gains=self.gains.pin_memory(),
+            lengths=new_lengths,
+            actual_num_ids=self.actual_num_ids,
+            stats=self.stats,
+        )
+
+
+class KeyedSparseCorePreprocessedInput:
+    """Container for preprocessed TPU tensors used by SparseCore custom collections."""
+
+    def __init__(
+        self,
+        table_tensors: Dict[str, SparseCorePreprocessedInput],
+        stats: Optional[KeyedSparseCoreInputStats] = None,
+    ):
+        """Initializes the container with a mapping from table names to preprocessed tensor bundles.
+
+        Args:
+          table_tensors: Dictionary mapping table name string to its preprocessed
+            input tensors.
+          stats: Optional preprocessor diagnostic statistics across all tables.
+        """
+        self.table_tensors = table_tensors
+        self.stats = stats
+
+    def to(
+        self, device: torch.device, non_blocking: bool = False
+    ) -> "KeyedSparseCorePreprocessedInput":
+        """Moves all table preprocessed tensor bundles to the specified target device.
+
+        Args:
+          device: The target PyTorch device (e.g., TPU or CPU).
+          non_blocking: Whether to perform asynchronous transfer if possible.
+
+        Returns:
+          A new KeyedSparseCorePreprocessedInput container on the target device.
+        """
+        new_tensors = {
+            table_name: table_inputs.to(device, non_blocking=non_blocking)
+            for table_name, table_inputs in self.table_tensors.items()
+        }
+        return KeyedSparseCorePreprocessedInput(new_tensors, stats=self.stats)
+
+    def record_stream(self, stream: torch.Stream) -> None:
+        """Records stream usage across all table preprocessed tensor bundles.
+
+        Args:
+          stream: The execution stream to record against.
+        """
+        for table_inputs in self.table_tensors.values():
+            table_inputs.record_stream(stream)
+
+    def pin_memory(self) -> "KeyedSparseCorePreprocessedInput":
+        """Pins page-locked memory across all table preprocessed tensor bundles.
+
+        Returns:
+          A new KeyedSparseCorePreprocessedInput container backed by pinned CPU
+          memory.
+        """
+        new_tensors = {
+            table_name: table_inputs.pin_memory()
+            for table_name, table_inputs in self.table_tensors.items()
+        }
+        return KeyedSparseCorePreprocessedInput(new_tensors, stats=self.stats)
+
+
+class SparseCoreInputPreprocessor:
+    """CPU Helper to preprocess KeyedJaggedTensor into KeyedSparseCorePreprocessedInput."""
+
+    def __init__(
+        self,
+        tables: List[SparseCoreEmbeddingConfig],
+        batch_size: int,
+        global_device_count: int = 1,
+        num_sc_per_device: int = 2,
+        allow_id_dropping: bool = False,
+        fdo_client: Optional[FDOClient] = None,
+        fdo_dir: Optional[epath.PathLike] = None,
+    ) -> None:
+        """Initializes the CPU input preprocessor and its stateful PyBind11 C++ backend.
+
+        Args:
+          tables: List of embedding table configurations defining sharding and
+            pooling.
+          batch_size: Process-local batch size per training step.
+          global_device_count: Total number of TPU devices across all distributed
+            hosts.
+          num_sc_per_device: Number of SparseCore virtual partitions per TPU chip.
+          allow_id_dropping: Whether to drop out-of-capacity embedding IDs without
+            raising errors.
+          fdo_client: Optional pre-constructed FDO client to record statistics.
+          fdo_dir: Optional directory path to automatically create a
+            CSVFileFDOClient seeded with initial table configurations.
+        """
+        self._batch_size = batch_size
+        self._local_device_count = 1  # Always 1 for PyTorch TPU.
+        self._global_device_count = global_device_count
+        self._num_sc_per_device = num_sc_per_device
+        self._last_stats: Optional[KeyedSparseCoreInputStats] = None
+
+        for table in tables:
+            if isinstance(table.config, EmbeddingConfig) and table.max_seq_len is None:
+                raise ValueError(
+                    "max_seq_len must be provided for EmbeddingConfig table"
+                    f" {table.name}"
+                )
+        self._tables = tables
+
+        if fdo_client is None and fdo_dir is not None:
+            rank = dist.get_rank() if dist.is_initialized() else 0
+            initial_stats = KeyedSparseCoreInputStats(
+                {
+                    t.name: SparseCoreInputStats(
+                        dropped_count=0,
+                        observed_max_ids=t.max_ids_per_partition,
+                        observed_max_unique_ids=t.max_unique_ids_per_partition,
+                    )
+                    for t in tables
+                }
+            )
+            fdo_client = csv_file_fdo_client.CSVFileFDOClient(
+                fdo_dir, process_id=rank, initial_stats=initial_stats
+            )
+
+        self._fdo_client = fdo_client
+
+        # Determine if we are in unpooled (EC) mode
+        self._is_unpooled = isinstance(self._tables[0].config, EmbeddingConfig)
+        self._allow_id_dropping = allow_id_dropping
+
+        self._rebuild_backend()
+
+    def _rebuild_backend(self) -> None:
+        """Rebuilds metadata and re-instantiates C++ preprocessor backend."""
+        self._tables_metadata = self._build_tables_metadata(
+            self._tables,
+            self._batch_size,
+            self._global_device_count,
+        )
+        self._backend = pybind_input_preprocessing.SparseCorePreprocessorBackend(
+            self._tables_metadata,
+            self._batch_size,
+            self._local_device_count,
+            self._global_device_count,
+            self._num_sc_per_device,
+            self._allow_id_dropping,
+        )
+
+    @property
+    def fdo_client(self) -> Optional[FDOClient]:
+        """Returns the attached FDO client if present."""
+        return self._fdo_client
+
+    @property
+    def last_stats(self) -> Optional[KeyedSparseCoreInputStats]:
+        """Returns the FDO statistics of the most recently preprocessed batch."""
+        return self._last_stats
+
+    def publish_fdo(self) -> None:
+        """Publishes FDO statistics to storage if FDO client is configured."""
+        if self._fdo_client is not None:
+            self._fdo_client.publish()
+
+    def update_preprocessing_parameters(
+        self,
+        updated_params: Optional[KeyedSparseCoreInputStats] = None,
+        scale_factor: float = 1.2,
+    ) -> bool:
+        """Updates table capacities in-place from loaded FDO stats and rebuilds backend.
+
+        Follows the JAX update_preprocessing_parameters naming convention.
+
+        Args:
+          updated_params: Aggregated FDO statistics. If None, loads from the
+            attached FDO client.
+          scale_factor: Multiplicative safety headroom factor (default 1.2 = +20%).
+
+        Returns:
+          True if any table configuration was updated, False otherwise.
+        """
+        if updated_params is None:
+            if self._fdo_client is None:
+                raise ValueError("No FDO client configured on preprocessor.")
+            updated_params = self._fdo_client.load()
+
+        changed = False
+        for table in self._tables:
+            if table.name in updated_params.table_stats:
+                t_stats = updated_params.table_stats[table.name]
+                updated_max_ids = max(
+                    table.max_ids_per_partition,
+                    int(math.ceil(t_stats.observed_max_ids * scale_factor)),
+                )
+                updated_max_unique_ids = max(
+                    table.max_unique_ids_per_partition,
+                    int(math.ceil(t_stats.observed_max_unique_ids * scale_factor)),
+                )
+                if (
+                    updated_max_ids > table.max_ids_per_partition
+                    or updated_max_unique_ids > table.max_unique_ids_per_partition
+                ):
+                    table.max_ids_per_partition = updated_max_ids
+                    table.max_unique_ids_per_partition = updated_max_unique_ids
+                    changed = True
+
+        if changed:
+            self._rebuild_backend()
+        return changed
+
+    def _build_tables_metadata(
+        self,
+        tables: List[SparseCoreEmbeddingConfig],
+        batch_size: int,
+        global_device_count: int = 1,
+    ) -> List[Dict[str, Any]]:
+        """Builds lightweight table and feature metadata dictionaries for C++ backend initialization.
+
+        Args:
+          tables: List of embedding table configurations.
+          batch_size: Process-local batch size.
+          global_device_count: Total number of TPU chips globally.
+
+        Returns:
+          A list of dictionaries containing table names, partition ID capacities,
+          and feature sharding offsets.
+        """
+        tables_metadata = []
+        for table in tables:
+            features = []
+            row_offset = 0
+            for feature_name in table.feature_names:
+                if isinstance(table.config, EmbeddingConfig):
+                    max_seq_len_table = table.max_seq_len
+                    assert max_seq_len_table is not None
+                    # For EC, fictional batch size is max_ids = batch_size * max_seq_len
+                    seq_batch_size = batch_size * max_seq_len_table
+                    batch_size_global = seq_batch_size * global_device_count
+                    feat_batch_size = seq_batch_size
+                    combiner = "sum"
+                elif isinstance(table.config, EmbeddingBagConfig):
+                    batch_size_global = batch_size * global_device_count
+                    feat_batch_size = batch_size
+                    combiner = "sum" if table.pooling == PoolingType.SUM else "mean"
+                else:
+                    raise TypeError(f"Unsupported table type: {type(table.config)}")
+
+                features.append(
+                    {
+                        "name": feature_name,
+                        "row_offset": row_offset,
+                        "col_offset": 0,
+                        "col_shift": 0,
+                        "batch_size": feat_batch_size,
+                        "combiner": combiner,
+                        "max_col_id": table.config.num_embeddings,
+                    }
+                )
+                row_offset += batch_size_global
+
+            tables_metadata.append(
+                {
+                    "name": table.name,
+                    "max_ids_per_partition": table.max_ids_per_partition,
+                    "max_unique_ids_per_partition": table.max_unique_ids_per_partition,
+                    "suggested_coo_buffer_size_per_device": (
+                        table.suggested_coo_buffer_size_per_device
+                    ),
+                    "features": features,
+                }
+            )
+        return tables_metadata
+
+    def __call__(self, features: KeyedJaggedTensor) -> KeyedSparseCorePreprocessedInput:
+        """Preprocesses a batch of sparse features on CPU into CSR-wrapped COO tensors for SparseCore.
+
+        Args:
+          features: Input KeyedJaggedTensor containing sparse feature IDs and
+            offsets.
+
+        Returns:
+          A KeyedSparseCorePreprocessedInput container ready for device transfer.
+        """
+        # This runs on CPU.
+
+        input_indices = {}
+        input_offsets = {}
+        feature_dict = features.to_dict()
+
+        if self._is_unpooled:
+            table_lengths_dict = {}
+            table_actual_num_ids_dict = {}
+
+            for table in self._tables:
+                input_indices[table.name] = []
+                input_offsets[table.name] = []
+                max_seq_len_table = table.max_seq_len
+                assert max_seq_len_table is not None
+                seq_batch_size = self._batch_size * max_seq_len_table
+                lengths_dict = {}
+                actual_num_ids_dict = {}
+                for feature_name in table.feature_names:
+                    f = feature_dict[feature_name]
+                    indices = f.values().to("cpu", torch.int32)
+                    lengths = f.lengths().to("cpu")
+                    lengths_dict[feature_name] = lengths
+
+                    actual_num_ids = indices.numel()
+                    actual_num_ids_dict[feature_name] = actual_num_ids
+
+                    # Pad indices to max_ids
+                    padded_indices = torch.zeros(seq_batch_size, dtype=torch.int32)
+                    padded_indices[:actual_num_ids] = indices
+
+                    # Build offsets: [0, 1, 2, ..., N, N, N, ..., N] of length max_ids + 1
+                    padded_offsets = torch.empty(seq_batch_size + 1, dtype=torch.int32)
+                    padded_offsets[: actual_num_ids + 1] = torch.arange(
+                        0, actual_num_ids + 1, dtype=torch.int32
+                    )
+                    padded_offsets[actual_num_ids + 1 :] = actual_num_ids
+
+                    input_indices[table.name].append(padded_indices)
+                    input_offsets[table.name].append(padded_offsets)
+
+                table_lengths_dict[table.name] = lengths_dict
+                table_actual_num_ids_dict[table.name] = actual_num_ids_dict
+
+            # Call official TPU preprocess op (CPU) via PyBind
+            res = self._backend.preprocess(
+                input_indices,
+                input_offsets,
+            )
+
+            table_tensors = {}
+            table_stats = {}
+            for name, t in res.items():
+                table_stats[name] = SparseCoreInputStats(
+                    dropped_count=int(t["dropped_count"].item()),
+                    observed_max_ids=int(t["observed_max_ids"].item()),
+                    observed_max_unique_ids=int(t["observed_max_unique_ids"].item()),
+                )
+                table_tensors[name] = SparseCorePreprocessedInput(
+                    row_pointers=t["row_pointers"],
+                    embedding_ids=t["embedding_ids"],
+                    sample_ids=t["sample_ids"],
+                    gains=t["gains"],
+                    lengths=table_lengths_dict.get(name, {}),
+                    actual_num_ids=table_actual_num_ids_dict.get(name, {}),
+                    stats=table_stats[name],
+                )
+
+            stats = KeyedSparseCoreInputStats(table_stats)
+            self._last_stats = stats
+            if self._fdo_client is not None:
+                self._fdo_client.record(stats)
+            return KeyedSparseCorePreprocessedInput(table_tensors, stats=stats)
+
+        else:  # EBC mode
+            for table in self._tables:
+                input_indices[table.name] = []
+                input_offsets[table.name] = []
+                for feature_name in table.feature_names:
+                    f = feature_dict[feature_name]
+                    input_indices[table.name].append(f.values().to("cpu", torch.int32))
+                    input_offsets[table.name].append(f.offsets().to("cpu", torch.int32))
+
+            res = self._backend.preprocess(
+                input_indices,
+                input_offsets,
+            )
+
+            table_tensors = {}
+            table_stats = {}
+            for name, t in res.items():
+                table_stats[name] = SparseCoreInputStats(
+                    dropped_count=int(t["dropped_count"].item()),
+                    observed_max_ids=int(t["observed_max_ids"].item()),
+                    observed_max_unique_ids=int(t["observed_max_unique_ids"].item()),
+                )
+                table_tensors[name] = SparseCorePreprocessedInput(
+                    row_pointers=t["row_pointers"],
+                    embedding_ids=t["embedding_ids"],
+                    sample_ids=t["sample_ids"],
+                    gains=t["gains"],
+                    stats=table_stats[name],
+                )
+
+            stats = KeyedSparseCoreInputStats(table_stats)
+            self._last_stats = stats
+            if self._fdo_client is not None:
+                self._fdo_client.record(stats)
+            return KeyedSparseCorePreprocessedInput(table_tensors, stats=stats)

--- a/torchrec/experimental/torch_tpu/datasets/pybind_input_preprocessing.cc
+++ b/torchrec/experimental/torch_tpu/datasets/pybind_input_preprocessing.cc
@@ -1,0 +1,311 @@
+/*
+ * Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Eigen/Core"
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/absl_check.h"
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "jax_tpu_embedding/sparsecore/lib/core/abstract_input_batch.h"
+#include "jax_tpu_embedding/sparsecore/lib/core/input_preprocessing.h"
+#include "jax_tpu_embedding/sparsecore/lib/core/input_preprocessing_util.h"
+#include "jax_tpu_embedding/sparsecore/lib/core/ragged_tensor_input_batch.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+#include "torch/extension.h" // IWYU pragma: keep for aten::Tensor pybind type
+
+namespace torchrec::torch_tpu {
+namespace {
+
+namespace py = ::pybind11;
+
+class SparseCorePreprocessorBackend {
+ public:
+  SparseCorePreprocessorBackend(
+      const py::list& tables_metadata,
+      int64_t batch_size,
+      int64_t local_device_count,
+      int64_t global_device_count,
+      int64_t num_sc_per_device,
+      bool allow_id_dropping)
+      : local_device_count_(local_device_count),
+        global_device_count_(global_device_count),
+        jax_options_{
+            .local_device_count = static_cast<int>(local_device_count),
+            .global_device_count = static_cast<int>(global_device_count),
+            .num_sc_per_device = static_cast<int>(num_sc_per_device),
+            .sharding_strategy = jax_sc_embedding::ShardingStrategy::kMod,
+            .allow_id_dropping = allow_id_dropping,
+        },
+        row_pointers_size_per_device_(
+            jax_options_.GetRowPointersSizePerDevice()) {
+    int global_feat_idx = 0;
+    for (const py::handle& table_obj : tables_metadata) {
+      py::dict table_dict = py::cast<py::dict>(table_obj);
+      std::string table_name = py::cast<std::string>(table_dict["name"]);
+      table_names_.push_back(table_name);
+      int max_ids = py::cast<int>(table_dict["max_ids_per_partition"]);
+      int max_unique_ids =
+          py::cast<int>(table_dict["max_unique_ids_per_partition"]);
+      int buffer_size =
+          py::cast<int>(table_dict["suggested_coo_buffer_size_per_device"]);
+
+      py::list features = py::cast<py::list>(table_dict["features"]);
+      jax_stacked_tables_[table_name].reserve(features.size());
+      for (const py::handle& feat_obj : features) {
+        py::dict feat_dict = py::cast<py::dict>(feat_obj);
+        std::string feat_name = py::cast<std::string>(feat_dict["name"]);
+        int row_offset = py::cast<int>(feat_dict["row_offset"]);
+        int col_offset = py::cast<int>(feat_dict["col_offset"]);
+        int col_shift = py::cast<int>(feat_dict["col_shift"]);
+        int feat_batch_size = py::cast<int>(feat_dict["batch_size"]);
+        std::string combiner_str = py::cast<std::string>(feat_dict["combiner"]);
+        int max_col_id = feat_dict.contains("max_col_id")
+            ? py::cast<int>(feat_dict["max_col_id"])
+            : std::numeric_limits<int>::max();
+
+        jax_stacked_tables_[table_name].push_back(
+            jax_sc_embedding::FeatureMetadataInStack(
+                feat_name,
+                global_feat_idx++,
+                max_ids,
+                max_unique_ids,
+                row_offset,
+                col_offset,
+                col_shift,
+                feat_batch_size,
+                buffer_size > 0 ? std::make_optional(buffer_size)
+                                : std::nullopt,
+                jax_sc_embedding::GetRowCombiner(combiner_str),
+                max_col_id));
+      }
+      required_buffer_sizes_[table_name] =
+          jax_sc_embedding::ComputeCooBufferSizePerDevice(
+              jax_options_, jax_stacked_tables_.at(table_name));
+    }
+  }
+
+  std::map<std::string, std::map<std::string, at::Tensor>> Preprocess(
+      const std::map<std::string, std::vector<at::Tensor>>& input_indices,
+      const std::map<std::string, std::vector<at::Tensor>>& input_offsets) {
+    std::vector<std::unique_ptr<jax_sc_embedding::AbstractInputBatch>>
+        input_batches;
+    std::vector<at::Tensor> contiguous_tensors_holder;
+
+    int total_features = 0;
+    for (const auto& [table_name, meta_list] : jax_stacked_tables_) {
+      total_features += meta_list.size();
+    }
+    contiguous_tensors_holder.reserve(total_features * 2);
+    input_batches.reserve(total_features);
+
+    // Loop 1 (Pre-execution Input Processing & Validation):
+    for (const std::string& table_name : table_names_) {
+      const auto& meta_list = jax_stacked_tables_.at(table_name);
+
+      auto indices_it = input_indices.find(table_name);
+      ABSL_CHECK(indices_it != input_indices.end())
+          << "input_indices missing table " << table_name;
+
+      auto offsets_it = input_offsets.find(table_name);
+      ABSL_CHECK(offsets_it != input_offsets.end())
+          << "input_offsets missing table " << table_name;
+
+      const auto& indices_list = indices_it->second;
+      const auto& offsets_list = offsets_it->second;
+
+      ABSL_CHECK_EQ(indices_list.size(), meta_list.size())
+          << "indices list size mismatch for table " << table_name;
+      ABSL_CHECK_EQ(offsets_list.size(), meta_list.size())
+          << "offsets list size mismatch for table " << table_name;
+
+      for (size_t i = 0; i < meta_list.size(); ++i) {
+        const at::Tensor& indices = indices_list[i];
+        const at::Tensor& offsets = offsets_list[i];
+
+        ABSL_CHECK_EQ(indices.dtype(), at::kInt) << "indices must be int32";
+        ABSL_CHECK_EQ(offsets.dtype(), at::kInt) << "offsets must be int32";
+
+        auto contiguous_indices = indices.contiguous();
+        auto contiguous_offsets = offsets.contiguous();
+        contiguous_tensors_holder.push_back(contiguous_indices);
+        contiguous_tensors_holder.push_back(contiguous_offsets);
+
+        absl::Span<const int32_t> val_span(
+            contiguous_indices.data_ptr<int32_t>(), contiguous_indices.numel());
+        absl::Span<const int32_t> off_span(
+            contiguous_offsets.data_ptr<int32_t>(), contiguous_offsets.numel());
+
+        input_batches.push_back(
+            std::make_unique<jax_sc_embedding::RaggedTensorInputBatch<
+                absl::Span<const int32_t>,
+                absl::Span<const int32_t>>>(val_span, off_span, table_name));
+      }
+    }
+
+    std::map<std::string, std::map<std::string, at::Tensor>> outputs;
+    jax_sc_embedding::OutputCsrArrays jax_output_buffers;
+
+    // Loop 2 (Pre-execution Output Allocation & Buffer Setup):
+    for (const std::string& table_name : table_names_) {
+      const auto& meta_list = jax_stacked_tables_.at(table_name);
+      if (meta_list.empty())
+        continue;
+
+      int32_t required_buffer_size = required_buffer_sizes_.at(table_name);
+
+      int total_row_pointers_size =
+          local_device_count_ * row_pointers_size_per_device_;
+      int total_coo_buffer_size = local_device_count_ * required_buffer_size;
+
+      at::Tensor row_pointers = at::zeros({total_row_pointers_size}, at::kInt);
+      at::Tensor embedding_ids = at::empty({total_coo_buffer_size}, at::kInt);
+      at::Tensor sample_ids = at::empty({total_coo_buffer_size}, at::kInt);
+      at::Tensor gains = at::empty({total_coo_buffer_size}, at::kFloat);
+
+      Eigen::Map<jax_sc_embedding::MatrixXi> row_pointers_map(
+          row_pointers.data_ptr<int32_t>(),
+          local_device_count_,
+          row_pointers_size_per_device_);
+      Eigen::Map<jax_sc_embedding::MatrixXi> embedding_ids_map(
+          embedding_ids.data_ptr<int32_t>(),
+          local_device_count_,
+          required_buffer_size);
+      Eigen::Map<jax_sc_embedding::MatrixXi> sample_ids_map(
+          sample_ids.data_ptr<int32_t>(),
+          local_device_count_,
+          required_buffer_size);
+      Eigen::Map<jax_sc_embedding::MatrixXf> gains_map(
+          gains.data_ptr<float>(), local_device_count_, required_buffer_size);
+
+      jax_output_buffers.lhs_row_pointers.emplace(table_name, row_pointers_map);
+      jax_output_buffers.lhs_embedding_ids.emplace(
+          table_name, embedding_ids_map);
+      jax_output_buffers.lhs_sample_ids.emplace(table_name, sample_ids_map);
+      jax_output_buffers.lhs_gains.emplace(table_name, gains_map);
+
+      std::map<std::string, at::Tensor> table_dict;
+      table_dict["row_pointers"] = row_pointers;
+      table_dict["embedding_ids"] = embedding_ids;
+      table_dict["sample_ids"] = sample_ids;
+      table_dict["gains"] = gains;
+
+      outputs[table_name] = table_dict;
+    }
+
+    // Execute C++ Preprocess
+    auto result = jax_sc_embedding::PreprocessSparseDenseMatmulInput(
+        absl::MakeSpan(input_batches),
+        jax_stacked_tables_,
+        jax_options_,
+        &jax_output_buffers);
+    ABSL_CHECK(result.ok()) << result.status().message();
+
+    // Loop 3 (Post-execution): Extract stats for each table
+    const auto& stats = result.value().stats;
+    for (const std::string& table_name : table_names_) {
+      auto table_it = outputs.find(table_name);
+      if (table_it == outputs.end())
+        continue;
+
+      int dropped_count = 0;
+      auto dropped_it = stats.dropped_id_count.find(table_name);
+      if (dropped_it != stats.dropped_id_count.end()) {
+        dropped_count = dropped_it->second;
+      }
+
+      int observed_max_ids = 0;
+      auto max_ids_it = stats.max_ids_per_partition.find(table_name);
+      if (max_ids_it != stats.max_ids_per_partition.end()) {
+        observed_max_ids = static_cast<int>(max_ids_it->second.maxCoeff());
+      }
+
+      int observed_max_unique_ids = 0;
+      auto max_unique_it = stats.max_unique_ids_per_partition.find(table_name);
+      if (max_unique_it != stats.max_unique_ids_per_partition.end()) {
+        observed_max_unique_ids =
+            static_cast<int>(max_unique_it->second.maxCoeff());
+      }
+
+      table_it->second["dropped_count"] =
+          at::scalar_tensor(dropped_count, at::kInt);
+      table_it->second["observed_max_ids"] =
+          at::scalar_tensor(observed_max_ids, at::kInt);
+      table_it->second["observed_max_unique_ids"] =
+          at::scalar_tensor(observed_max_unique_ids, at::kInt);
+    }
+
+    return outputs;
+  }
+
+ private:
+  int64_t local_device_count_;
+  int64_t global_device_count_;
+  jax_sc_embedding::PreprocessSparseDenseMatmulInputOptions jax_options_;
+  int row_pointers_size_per_device_;
+  absl::flat_hash_map<
+      std::string,
+      std::vector<jax_sc_embedding::FeatureMetadataInStack>>
+      jax_stacked_tables_;
+  absl::flat_hash_map<std::string, int32_t> required_buffer_sizes_;
+  std::vector<std::string> table_names_;
+};
+
+} // namespace
+
+PYBIND11_MODULE(pybind_input_preprocessing, m) {
+  py::module_::import("torch");
+  py::class_<SparseCorePreprocessorBackend>(
+      m,
+      "SparseCorePreprocessorBackend",
+      "Stateful C++ backend for CPU dataset preprocessing of SparseCore "
+      "embedding tables.")
+      .def(
+          py::init<py::list, int64_t, int64_t, int64_t, int64_t, bool>(),
+          py::arg("tables_metadata"),
+          py::arg("batch_size"),
+          py::arg("local_device_count"),
+          py::arg("global_device_count"),
+          py::arg("num_sc_per_device"),
+          py::arg("allow_id_dropping") = false,
+          "Initializes the preprocessor backend, pre-computing stacked table "
+          "metadata and required buffer sizes.")
+      .def(
+          "preprocess",
+          &SparseCorePreprocessorBackend::Preprocess,
+          py::arg("input_indices"),
+          py::arg("input_offsets"),
+          "Preprocesses per-batch input indices and offsets into CSR-wrapped "
+          "COO format.");
+}
+
+} // namespace torchrec::torch_tpu

--- a/torchrec/experimental/torch_tpu/modules/__init__.py
+++ b/torchrec/experimental/torch_tpu/modules/__init__.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Re-exports resolve lazily (PEP 562); see the package __init__ one level up for the
+# rationale. Here specifically: `embedding_modules` reaches jax through `pallas`, so
+# eager re-exports made the cheap, torch-only `embedding_configs` unreachable without
+# it.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.modules.embedding_configs import (
+        SparseCoreEmbeddingConfig,
+    )
+    from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+        TPUEmbeddingUnfused,
+    )
+    from torchrec.experimental.torch_tpu.modules.fused_embedding_modules import (
+        SparseCoreFusedEmbeddingBagCollection,
+        SparseCoreFusedEmbeddingCollection,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "SparseCoreEmbeddingConfig": "torchrec.experimental.torch_tpu.modules.embedding_configs",
+    "SparseCoreFusedEmbeddingBagCollection": "torchrec.experimental.torch_tpu.modules.fused_embedding_modules",
+    "SparseCoreFusedEmbeddingCollection": "torchrec.experimental.torch_tpu.modules.fused_embedding_modules",
+    "TPUEmbeddingUnfused": "torchrec.experimental.torch_tpu.modules.embedding_modules",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(importlib.import_module(module_name), name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "SparseCoreEmbeddingConfig",
+    "SparseCoreFusedEmbeddingBagCollection",
+    "SparseCoreFusedEmbeddingCollection",
+    "TPUEmbeddingUnfused",
+]

--- a/torchrec/experimental/torch_tpu/modules/custom_ops.py
+++ b/torchrec/experimental/torch_tpu/modules/custom_ops.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom torch.library operators for SparseCore embedding lookups and optimizer backward passes."""
+
+import torch
+
+
+# --- SGD Custom Ops ---
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_sgd_fwd", mutates_args=()
+)
+def sparse_dense_matmul_sgd_fwd(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    learning_rate: torch.Tensor,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> torch.Tensor:
+    """Executes the forward pass of sparse-dense matrix multiplication for SGD."""
+    return torch.ops.tpu.sparse_dense_matmul(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+    )
+
+
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_sgd_bwd",
+    mutates_args=("embedding_table",),
+)
+def sparse_dense_matmul_sgd_bwd(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    learning_rate: torch.Tensor,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> None:
+    """Executes the backward pass and inplace SGD weight update."""
+    updated_table = torch.ops.tpu.sparse_dense_matmul_grad_with_sgd(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        grad_output.contiguous(),
+        learning_rate,
+        device_batch_size=batch_size,
+        max_ids_per_partition=max_ids_per_partition,
+        max_unique_ids_per_partition=max_unique_ids_per_partition,
+        computation_name=f"sgd_{table_name}",
+    )
+    embedding_table.copy_(updated_table)
+    return None
+
+
+@sparse_dense_matmul_sgd_fwd.register_fake
+def _sgd_fwd_fake(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    learning_rate: torch.Tensor,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for SGD forward pass during tracing."""
+    return torch.empty(
+        (batch_size, embedding_table.size(1)),
+        dtype=embedding_table.dtype,
+        device=embedding_table.device,
+    )
+
+
+@sparse_dense_matmul_sgd_bwd.register_fake
+def _sgd_bwd_fake(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    learning_rate: torch.Tensor,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for SGD backward pass during tracing."""
+    embedding_table.add_(0)
+    return None
+
+
+def _sgd_setup_context(ctx, inputs, output):
+    """Saves tensors and hyperparameters to autograd context for SGD backward."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        learning_rate,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+        table_name,
+    ) = inputs
+    ctx.save_for_backward(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        learning_rate,
+    )
+    ctx.batch_size = batch_size
+    ctx.max_ids_per_partition = max_ids_per_partition
+    ctx.max_unique_ids_per_partition = max_unique_ids_per_partition
+    ctx.table_name = table_name
+
+
+def _sgd_backward(ctx, grad_output):
+    """Autograd backward function for SGD sparse-dense matrix multiplication."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        learning_rate,
+    ) = ctx.saved_tensors
+    sparse_dense_matmul_sgd_bwd(
+        grad_output,
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        learning_rate,
+        ctx.batch_size,
+        ctx.max_ids_per_partition,
+        ctx.max_unique_ids_per_partition,
+        ctx.table_name,
+    )
+    return (None,) * 10
+
+
+sparse_dense_matmul_sgd_fwd.register_autograd(
+    _sgd_backward, setup_context=_sgd_setup_context
+)
+
+
+# --- Adagrad Custom Ops ---
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_adagrad_fwd", mutates_args=()
+)
+def sparse_dense_matmul_adagrad_fwd(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    accumulator: torch.Tensor,
+    learning_rate: torch.Tensor,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> torch.Tensor:
+    """Executes the forward pass of sparse-dense matrix multiplication for Adagrad."""
+    return torch.ops.tpu.sparse_dense_matmul(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+    )
+
+
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_adagrad_bwd",
+    mutates_args=("embedding_table", "accumulator"),
+)
+def sparse_dense_matmul_adagrad_bwd(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    accumulator: torch.Tensor,
+    learning_rate: torch.Tensor,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> None:
+    """Executes the backward pass and inplace Adagrad weight and accumulator update."""
+    updated_table, updated_accumulator = (
+        torch.ops.tpu.sparse_dense_matmul_grad_with_adagrad(
+            row_pointers,
+            embedding_ids,
+            sample_ids,
+            gains,
+            embedding_table,
+            accumulator,
+            grad_output.contiguous(),
+            learning_rate,
+            epsilon,
+            device_batch_size=batch_size,
+            max_ids_per_partition=max_ids_per_partition,
+            max_unique_ids_per_partition=max_unique_ids_per_partition,
+            computation_name=f"adagrad_{table_name}",
+        )
+    )
+    embedding_table.copy_(updated_table)
+    accumulator.copy_(updated_accumulator)
+    return None
+
+
+@sparse_dense_matmul_adagrad_fwd.register_fake
+def _adagrad_fwd_fake(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    accumulator: torch.Tensor,
+    learning_rate: torch.Tensor,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for Adagrad forward pass during tracing."""
+    return torch.empty(
+        (batch_size, embedding_table.size(1)),
+        dtype=embedding_table.dtype,
+        device=embedding_table.device,
+    )
+
+
+@sparse_dense_matmul_adagrad_bwd.register_fake
+def _adagrad_bwd_fake(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    accumulator: torch.Tensor,
+    learning_rate: torch.Tensor,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for Adagrad backward pass during tracing."""
+    embedding_table.add_(0)
+    accumulator.add_(0)
+    return None
+
+
+def _adagrad_setup_context(ctx, inputs, output):
+    """Saves tensors and hyperparameters to autograd context for Adagrad backward."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        accumulator,
+        learning_rate,
+        epsilon,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+        table_name,
+    ) = inputs
+    ctx.save_for_backward(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        accumulator,
+        learning_rate,
+    )
+    ctx.epsilon = epsilon
+    ctx.batch_size = batch_size
+    ctx.max_ids_per_partition = max_ids_per_partition
+    ctx.max_unique_ids_per_partition = max_unique_ids_per_partition
+    ctx.table_name = table_name
+
+
+def _adagrad_backward(ctx, grad_output):
+    """Autograd backward function for Adagrad sparse-dense matrix multiplication."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        accumulator,
+        learning_rate,
+    ) = ctx.saved_tensors
+    sparse_dense_matmul_adagrad_bwd(
+        grad_output,
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        accumulator,
+        learning_rate,
+        ctx.epsilon,
+        ctx.batch_size,
+        ctx.max_ids_per_partition,
+        ctx.max_unique_ids_per_partition,
+        ctx.table_name,
+    )
+    return (None,) * 12
+
+
+sparse_dense_matmul_adagrad_fwd.register_autograd(
+    _adagrad_backward, setup_context=_adagrad_setup_context
+)
+
+
+# --- Adam Custom Ops ---
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_adam_fwd", mutates_args=()
+)
+def sparse_dense_matmul_adam_fwd(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    momentum: torch.Tensor,
+    velocity: torch.Tensor,
+    learning_rate: torch.Tensor,
+    beta1: float,
+    beta2: float,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> torch.Tensor:
+    """Executes the forward pass of sparse-dense matrix multiplication for Adam."""
+    return torch.ops.tpu.sparse_dense_matmul(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+    )
+
+
+@torch.library.custom_op(
+    "torchrec_torch_tpu::sparse_dense_matmul_adam_bwd",
+    mutates_args=("embedding_table", "momentum", "velocity"),
+)
+def sparse_dense_matmul_adam_bwd(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    momentum: torch.Tensor,
+    velocity: torch.Tensor,
+    learning_rate: torch.Tensor,
+    beta1: float,
+    beta2: float,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+) -> None:
+    """Executes the backward pass and inplace Adam weight, momentum, and velocity update."""
+    updated_table, updated_momentum, updated_velocity = (
+        torch.ops.tpu.sparse_dense_matmul_grad_with_adam(
+            row_pointers,
+            embedding_ids,
+            sample_ids,
+            gains,
+            embedding_table,
+            momentum,
+            velocity,
+            grad_output.contiguous(),
+            learning_rate,
+            beta1,
+            beta2,
+            epsilon,
+            device_batch_size=batch_size,
+            max_ids_per_partition=max_ids_per_partition,
+            max_unique_ids_per_partition=max_unique_ids_per_partition,
+            computation_name=f"adam_{table_name}",
+        )
+    )
+    embedding_table.copy_(updated_table)
+    momentum.copy_(updated_momentum)
+    velocity.copy_(updated_velocity)
+    return None
+
+
+@sparse_dense_matmul_adam_fwd.register_fake
+def _adam_fwd_fake(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    momentum: torch.Tensor,
+    velocity: torch.Tensor,
+    learning_rate: torch.Tensor,
+    beta1: float,
+    beta2: float,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for Adam forward pass during tracing."""
+    return torch.empty(
+        (batch_size, embedding_table.size(1)),
+        dtype=embedding_table.dtype,
+        device=embedding_table.device,
+    )
+
+
+@sparse_dense_matmul_adam_bwd.register_fake
+def _adam_bwd_fake(
+    grad_output: torch.Tensor,
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    momentum: torch.Tensor,
+    velocity: torch.Tensor,
+    learning_rate: torch.Tensor,
+    beta1: float,
+    beta2: float,
+    epsilon: float,
+    batch_size: int,
+    max_ids_per_partition: int = 256,
+    max_unique_ids_per_partition: int = 256,
+    table_name: str = "table",
+):
+    """Fake implementation for Adam backward pass during tracing."""
+    embedding_table.add_(0)
+    momentum.add_(0)
+    velocity.add_(0)
+    return None
+
+
+def _adam_setup_context(ctx, inputs, output):
+    """Saves tensors and hyperparameters to autograd context for Adam backward."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        momentum,
+        velocity,
+        learning_rate,
+        beta1,
+        beta2,
+        epsilon,
+        batch_size,
+        max_ids_per_partition,
+        max_unique_ids_per_partition,
+        table_name,
+    ) = inputs
+    ctx.save_for_backward(
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        momentum,
+        velocity,
+        learning_rate,
+    )
+    ctx.beta1 = beta1
+    ctx.beta2 = beta2
+    ctx.epsilon = epsilon
+    ctx.batch_size = batch_size
+    ctx.max_ids_per_partition = max_ids_per_partition
+    ctx.max_unique_ids_per_partition = max_unique_ids_per_partition
+    ctx.table_name = table_name
+
+
+def _adam_backward(ctx, grad_output):
+    """Autograd backward function for Adam sparse-dense matrix multiplication."""
+    (
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        momentum,
+        velocity,
+        learning_rate,
+    ) = ctx.saved_tensors
+    sparse_dense_matmul_adam_bwd(
+        grad_output,
+        row_pointers,
+        embedding_ids,
+        sample_ids,
+        gains,
+        embedding_table,
+        momentum,
+        velocity,
+        learning_rate,
+        ctx.beta1,
+        ctx.beta2,
+        ctx.epsilon,
+        ctx.batch_size,
+        ctx.max_ids_per_partition,
+        ctx.max_unique_ids_per_partition,
+        ctx.table_name,
+    )
+    return (None,) * 15
+
+
+sparse_dense_matmul_adam_fwd.register_autograd(
+    _adam_backward, setup_context=_adam_setup_context
+)

--- a/torchrec/experimental/torch_tpu/modules/embedding_configs.py
+++ b/torchrec/experimental/torch_tpu/modules/embedding_configs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom Embedding Configurations using SparseCore on TPU."""
+
+import dataclasses
+from typing import Any, List, Optional, Union
+
+from torchrec.modules import embedding_configs
+
+PoolingType = embedding_configs.PoolingType
+EmbeddingConfig = embedding_configs.EmbeddingConfig
+EmbeddingBagConfig = embedding_configs.EmbeddingBagConfig
+dataclass = dataclasses.dataclass
+
+
+# TODO: Add support for table stacking here.
+# We should think about how to take the list of EmbeddingConfigs and stack them
+# properly.
+@dataclass
+class SparseCoreEmbeddingConfig:
+    """Wrapper config class that attaches TPU sequence bounds to a standard BaseEmbeddingConfig."""
+
+    config: Union[EmbeddingConfig, EmbeddingBagConfig]
+    max_seq_len: Optional[int] = None
+    max_ids_per_partition: int = 256
+    max_unique_ids_per_partition: int = 256
+    suggested_coo_buffer_size_per_device: int = 32
+
+    @property
+    def name(self) -> str:
+        return self.config.name
+
+    # TODO: We need to make sure that this number is divisible by 8.
+    @property
+    def embedding_dim(self) -> int:
+        return self.config.embedding_dim
+
+    # TODO: We need to make sure that this number is divisible by
+    # the total number of SC devices.
+    @property
+    def num_embeddings(self) -> int:
+        return self.config.num_embeddings
+
+    @property
+    def feature_names(self) -> List[str]:
+        return self.config.feature_names
+
+    @property
+    def init_fn(self) -> Any:
+        return self.config.init_fn
+
+    @property
+    def pooling(self) -> PoolingType:
+        if isinstance(self.config, EmbeddingBagConfig):
+            return self.config.pooling
+        raise AttributeError("Wrapped config is not an EmbeddingBagConfig")

--- a/torchrec/experimental/torch_tpu/modules/fused_embedding_modules.py
+++ b/torchrec/experimental/torch_tpu/modules/fused_embedding_modules.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom Embedding Collections using SparseCore on TPU."""
+
+import abc
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+import torch.distributed as dist
+import torch.distributed.tensor as dt
+from torch import nn
+from torchrec.experimental.torch_tpu.datasets import input_preprocessing
+from torchrec.experimental.torch_tpu.modules import custom_ops
+from torchrec.experimental.torch_tpu.modules.embedding_configs import (
+    SparseCoreEmbeddingConfig,
+)
+
+# import torch_tpu._internal.device_utils.annotations as tpu_annotations
+from torchrec.modules import embedding_configs
+from torchrec.optim import fused, keyed
+from torchrec.sparse import jagged_tensor
+
+KeyedOptimizer = keyed.KeyedOptimizer
+FusedOptimizer = fused.FusedOptimizer
+FusedOptimizerModule = fused.FusedOptimizerModule
+
+KeyedSparseCorePreprocessedInput = input_preprocessing.KeyedSparseCorePreprocessedInput
+EmbeddingConfig = embedding_configs.EmbeddingConfig
+KeyedTensor = jagged_tensor.KeyedTensor
+JaggedTensor = jagged_tensor.JaggedTensor
+EmbeddingBagConfig = embedding_configs.EmbeddingBagConfig
+
+_DISPATCH_TABLE = {
+    torch.optim.SGD: custom_ops.sparse_dense_matmul_sgd_fwd,
+    torch.optim.Adagrad: custom_ops.sparse_dense_matmul_adagrad_fwd,
+    torch.optim.Adam: custom_ops.sparse_dense_matmul_adam_fwd,
+}
+
+
+def _round_up_to_multiple(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y
+
+
+class SparseCoreFusedOptimizer(FusedOptimizer):
+    """FusedOptimizer replacement using TPU SparseCore SparseDenseMatmul."""
+
+    def __init__(self, emb_module) -> None:
+        self._emb_module = emb_module
+        params = {}
+        state = {}
+        for name in emb_module._table_configs:
+            if (
+                hasattr(emb_module, "embedding_bags")
+                and name in emb_module.embedding_bags
+            ):
+                weight = emb_module.embedding_bags[name].weight
+            elif hasattr(emb_module, "embeddings") and name in emb_module.embeddings:
+                weight = emb_module.embeddings[name].weight
+            elif (
+                hasattr(emb_module, "embedding_tables")
+                and name in emb_module.embedding_tables
+            ):
+                weight = emb_module.embedding_tables[name]
+            else:
+                continue
+            param_key = f"{name}.weight"
+            params[param_key] = weight
+            state[weight] = {}
+            # Adagrad state
+            if name in emb_module.accumulators:
+                state[weight][f"{param_key}.accumulator"] = emb_module.accumulators[
+                    name
+                ]
+            # Adam states
+            if name in emb_module.momentums:
+                state[weight][f"{param_key}.momentum"] = emb_module.momentums[name]
+            if name in emb_module.velocities:
+                state[weight][f"{param_key}.velocity"] = emb_module.velocities[name]
+        initial_lr = emb_module.get_initial_lr()
+        super().__init__(
+            params, state, [{"params": list(params.values()), "lr": initial_lr}]
+        )
+
+    def _sync_lr(self) -> None:
+        param_groups = list(self.param_groups)
+        if param_groups:
+            new_lr = float(param_groups[0]["lr"])
+            self._emb_module.set_learning_rate(new_lr)
+
+    def zero_grad(self, set_to_none: bool = False) -> None:
+        self._sync_lr()
+
+    def step(self, closure: Any = None) -> None:
+        self._sync_lr()
+
+
+def run_sparse_dense_matmul(
+    row_pointers: torch.Tensor,
+    embedding_ids: torch.Tensor,
+    sample_ids: torch.Tensor,
+    gains: torch.Tensor,
+    embedding_table: torch.Tensor,
+    learning_rate: torch.Tensor,
+    batch_size: int,
+    max_ids_per_partition: int,
+    max_unique_ids_per_partition: int,
+    optimizer_type: type[torch.optim.Optimizer],
+    table_name: str,
+    accumulator: Optional[torch.Tensor] = None,
+    momentum: Optional[torch.Tensor] = None,
+    velocity: Optional[torch.Tensor] = None,
+    epsilon: float = 1e-10,
+    beta1: float = 0.9,
+    beta2: float = 0.999,
+) -> torch.Tensor:
+    """Runs SparseCore SparseDenseMatmul with the given optimizer."""
+    if optimizer_type not in _DISPATCH_TABLE:
+        raise ValueError(
+            f"Unsupported optimizer: {optimizer_type}. Only 'sgd', 'adagrad', and"
+            " 'adam' are supported."
+        )
+    op = _DISPATCH_TABLE[optimizer_type]
+    if optimizer_type == torch.optim.SGD:
+        return op(
+            row_pointers,
+            embedding_ids,
+            sample_ids,
+            gains,
+            embedding_table,
+            learning_rate,
+            batch_size,
+            max_ids_per_partition,
+            max_unique_ids_per_partition,
+            table_name,
+        )
+    elif optimizer_type == torch.optim.Adagrad:
+        assert accumulator is not None, "accumulator must be provided for Adagrad"
+        return op(
+            row_pointers,
+            embedding_ids,
+            sample_ids,
+            gains,
+            embedding_table,
+            accumulator,
+            learning_rate,
+            epsilon,
+            batch_size,
+            max_ids_per_partition,
+            max_unique_ids_per_partition,
+            table_name,
+        )
+    elif optimizer_type == torch.optim.Adam:
+        assert momentum is not None, "momentum must be provided for Adam"
+        assert velocity is not None, "velocity must be provided for Adam"
+        return op(
+            row_pointers,
+            embedding_ids,
+            sample_ids,
+            gains,
+            embedding_table,
+            momentum,
+            velocity,
+            learning_rate,
+            beta1,
+            beta2,
+            epsilon,
+            batch_size,
+            max_ids_per_partition,
+            max_unique_ids_per_partition,
+            table_name,
+        )
+
+
+class SparseCoreEmbeddingBagCollectionInterface(abc.ABC, nn.Module):
+    """Interface for `SparseCoreEmbeddingBagCollection`.
+
+    Args:
+        features: Preprocessed sparse features keyed by table name.
+
+    Example:
+        module = SparseCoreFusedEmbeddingBagCollection(tables, optimizer_type, optimizer_kwargs)
+        pooled_embeddings = module(features)
+    """
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        features: KeyedSparseCorePreprocessedInput,
+    ) -> KeyedTensor:
+        """Looks up pooled embeddings for preprocessed SparseCore features.
+
+        Args:
+            features: Preprocessed sparse feature tensors.
+
+        Returns:
+            Pooled embeddings as a keyed tensor.
+        """
+        pass
+
+    @abc.abstractmethod
+    def embedding_bag_configs(
+        self,
+    ) -> List[EmbeddingBagConfig]:
+        pass
+
+
+class SparseCoreEmbeddingCollectionInterface(abc.ABC, nn.Module):
+    """Interface for `SparseCoreEmbeddingCollection`.
+
+    Args:
+        features: Preprocessed sparse features keyed by table name.
+
+    Example:
+        module = SparseCoreFusedEmbeddingCollection(tables, optimizer_type, optimizer_kwargs)
+        sequence_embeddings = module(features)
+    """
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        features: KeyedSparseCorePreprocessedInput,
+    ) -> Dict[str, JaggedTensor]:
+        """Looks up unpooled embeddings for preprocessed SparseCore features.
+
+        Args:
+            features: Preprocessed sparse feature tensors.
+
+        Returns:
+            Unpooled embedding jagged tensors keyed by feature name.
+        """
+        pass
+
+    @abc.abstractmethod
+    def embedding_configs(
+        self,
+    ) -> List[EmbeddingConfig]:
+        pass
+
+
+class _SparseCoreFusedEmbeddingBase(FusedOptimizerModule):
+    """Shared base for SparseCoreFused{EmbeddingBag,Embedding}Collection.
+
+    Holds all common initialization (weights, optimizer states, learning rates,
+    TPU layout, sync) and utility methods. Subclasses provide only `forward()`
+    and their config accessor.
+    """
+
+    def __init__(
+        self,
+        tables: List[SparseCoreEmbeddingConfig],
+        optimizer_type: Type[torch.optim.Optimizer],
+        optimizer_kwargs: Dict[str, Any],
+        weight_dict_name: str,
+        batch_size: int = 1,
+        global_device_count: int = 1,
+        num_sc_per_device: int = 2,
+    ) -> None:
+        super().__init__()
+        self._tables = tables
+        self._optimizer_type = optimizer_type
+
+        self._optimizer_kwargs = self._normalize_optimizer_kwargs(optimizer_kwargs)
+
+        self._global_device_count = global_device_count
+        self._num_sc_per_device = num_sc_per_device
+        if batch_size % num_sc_per_device != 0:
+            raise ValueError(
+                f"batch_size ({batch_size}) must be divisible by num_sc_per_device"
+                f" ({num_sc_per_device})."
+            )
+        self._batch_size = batch_size
+
+        # Always use TPU device for embedding tables.
+        self._device = torch.device("tpu")
+        self._device_mesh = None
+        if dist.is_initialized() and self._global_device_count > 1:
+            self._device_mesh = dt.init_device_mesh("tpu", (self._global_device_count,))
+
+        self.learning_rates = self._init_learning_rates(tables)
+
+        # Weight modules dict — aliased as `embedding_bags` or `embeddings`
+        # by each subclass for backward compatibility.
+        weight_modules = nn.ModuleDict()
+        setattr(self, weight_dict_name, weight_modules)
+
+        # Optimizer states.
+        self.accumulators = nn.ParameterDict()
+        self.momentums = nn.ParameterDict()
+        self.velocities = nn.ParameterDict()
+        self._table_configs: Dict[str, SparseCoreEmbeddingConfig] = {}
+        self._feature_to_table_config: Dict[str, SparseCoreEmbeddingConfig] = {}
+
+        # layout = tpu_annotations.TpuLayout(minor_to_major=[0, 1], tiles=[[8, 128]])
+        for config in tables:
+            self._table_configs[config.name] = config
+            for feature_name in config.feature_names:
+                self._feature_to_table_config[feature_name] = config
+
+            weight_param, table_shape = self._create_weight_parameter(config)
+            weight_modules[config.name] = torch.nn.Module()
+            weight_modules[config.name].register_parameter("weight", weight_param)
+            self._register_optimizer_state(config, table_shape)
+
+        # Synchronize TPU devices to ensure all tables are initialized
+        # before the first forward pass.
+        if hasattr(torch, "tpu") and self._device.type == "tpu":
+            torch.tpu.synchronize()
+
+    @staticmethod
+    def _normalize_optimizer_kwargs(
+        optimizer_kwargs: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        kwargs = dict(optimizer_kwargs) if optimizer_kwargs is not None else {}
+        if "learning_rate" in kwargs:
+            kwargs["lr"] = kwargs.pop("learning_rate")
+        if "epsilon" in kwargs:
+            kwargs["eps"] = kwargs.pop("epsilon")
+        if "betas" in kwargs:
+            kwargs["beta1"], kwargs["beta2"] = kwargs.pop("betas")
+        return kwargs
+
+    def _init_learning_rates(
+        self, tables: List[SparseCoreEmbeddingConfig]
+    ) -> nn.ParameterDict:
+        learning_rates = nn.ParameterDict()
+        for config in tables:
+            learning_rates[config.name] = nn.Parameter(
+                torch.tensor(
+                    self._optimizer_kwargs.get("lr", 0.01),
+                    dtype=torch.float32,
+                    device=self._device,
+                ),
+                requires_grad=False,
+            )
+        return learning_rates
+
+    def _create_weight_parameter(
+        self, config: SparseCoreEmbeddingConfig
+    ) -> tuple[nn.Parameter, tuple[int, int]]:
+        num_embeddings = _round_up_to_multiple(
+            config.num_embeddings,
+            self._global_device_count * self._num_sc_per_device * 8,
+        )
+        embedding_dim = _round_up_to_multiple(config.embedding_dim, 8)
+        table_shape = (num_embeddings // self._global_device_count, embedding_dim)
+        embedding_table = torch.empty(table_shape, dtype=torch.float32)
+        if config.init_fn:
+            config.init_fn(embedding_table)
+        else:
+            nn.init.uniform_(embedding_table, -0.01, 0.01)
+
+        embedding_table_device = embedding_table.to(self._device)
+        if self._device_mesh is None:
+            return nn.Parameter(embedding_table_device), table_shape
+
+        sharded_weight = dt.DTensor.from_local(
+            embedding_table_device,
+            device_mesh=self._device_mesh,
+            placements=[dt.Shard(0)],
+        )
+        return nn.Parameter(sharded_weight), table_shape
+
+    def _to_parameter(self, tensor: torch.Tensor) -> nn.Parameter:
+        if self._device_mesh is None:
+            return nn.Parameter(tensor)
+        return nn.Parameter(
+            dt.DTensor.from_local(
+                tensor,
+                device_mesh=self._device_mesh,
+                placements=[dt.Shard(0)],
+            )
+        )
+
+    def _register_optimizer_state(
+        self,
+        config: SparseCoreEmbeddingConfig,
+        table_shape: tuple[int, int],
+    ) -> None:
+        if self._optimizer_type == torch.optim.SGD:
+            return
+        if self._optimizer_type == torch.optim.Adagrad:
+            accumulator = torch.full(
+                table_shape,
+                self._optimizer_kwargs.get("initial_accumulator_value", 0.0),
+                dtype=torch.float32,
+                device=self._device,
+            )
+            self.accumulators[config.name] = self._to_parameter(accumulator)
+            return
+        if self._optimizer_type == torch.optim.Adam:
+            momentum = torch.zeros(
+                table_shape, dtype=torch.float32, device=self._device
+            )
+            velocity = torch.zeros(
+                table_shape, dtype=torch.float32, device=self._device
+            )
+            self.momentums[config.name] = self._to_parameter(momentum)
+            self.velocities[config.name] = self._to_parameter(velocity)
+
+    @property
+    def fused_optimizer(self) -> KeyedOptimizer:
+        return SparseCoreFusedOptimizer(self)
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def optimizer_type(self) -> Type[torch.optim.Optimizer]:
+        return self._optimizer_type
+
+    def optimizer_kwargs(self) -> Dict[str, Any]:
+        return self._optimizer_kwargs
+
+    def get_initial_lr(self) -> float:
+        for tensor in self.learning_rates.values():
+            return tensor.item()
+        lr = self._optimizer_kwargs.get("lr")
+        if lr is not None:
+            return float(lr)
+        return 0.01
+
+    def set_learning_rate(self, lr: float) -> None:
+        for name in self._table_configs:
+            if name in self.learning_rates:
+                self.learning_rates[name].copy_(
+                    torch.tensor(lr, dtype=torch.float32, device=self._device)
+                )
+
+    def _shard_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        num_shards = self._global_device_count * self._num_sc_per_device
+        return torch.cat([tensor[i::num_shards] for i in range(num_shards)], dim=0).to(
+            self._device
+        )
+
+    def _unstack_activation(
+        self,
+        out: torch.Tensor,
+        num_features: int,
+        feature_batch_size: int,
+    ) -> torch.Tensor:
+        """Unstacks and uninterleaves activations across SparseCore cores.
+
+        Args:
+          out: The output tensor from sparse-dense matmul of shape
+            [feature_batch_size * num_features, embedding_dim].
+          num_features: Number of features stacked on this table.
+          feature_batch_size: Batch size per feature (process-local batch size for
+            EBC, or batch_size * max_seq_len for EC).
+
+        Returns:
+          Tensor of shape [num_features, feature_batch_size, embedding_dim].
+        """
+        assert feature_batch_size % self._num_sc_per_device == 0, (
+            f"feature_batch_size ({feature_batch_size}) must be divisible by"
+            f" num_sc_per_device ({self._num_sc_per_device})"
+        )
+        per_sc_batch_size = feature_batch_size // self._num_sc_per_device
+        return (
+            out.view(self._num_sc_per_device, num_features, per_sc_batch_size, -1)
+            .transpose(0, 1)
+            .reshape(num_features, feature_batch_size, -1)
+        )
+
+    def _run_table_lookup(
+        self,
+        table: SparseCoreEmbeddingConfig,
+        features: KeyedSparseCorePreprocessedInput,
+        weight: torch.Tensor,
+        batch_size: int,
+    ) -> torch.Tensor:
+        """Runs sparse-dense matmul for a single table."""
+        table_inputs = features.table_tensors[table.name]
+
+        # Unwrap DTensors to local tensors for custom ops.
+        local_weight = weight.to_local() if isinstance(weight, dt.DTensor) else weight
+
+        accumulator = self.accumulators._parameters.get(table.name, None)
+        local_accumulator = (
+            accumulator.to_local()
+            if isinstance(accumulator, dt.DTensor)
+            else accumulator
+        )
+
+        momentum = self.momentums._parameters.get(table.name, None)
+        local_momentum = (
+            momentum.to_local() if isinstance(momentum, dt.DTensor) else momentum
+        )
+
+        velocity = self.velocities._parameters.get(table.name, None)
+        local_velocity = (
+            velocity.to_local() if isinstance(velocity, dt.DTensor) else velocity
+        )
+
+        return run_sparse_dense_matmul(
+            table_inputs.row_pointers,
+            table_inputs.embedding_ids,
+            table_inputs.sample_ids,
+            table_inputs.gains,
+            local_weight,
+            self.learning_rates[table.name],
+            batch_size,
+            table.max_ids_per_partition,
+            table.max_unique_ids_per_partition,
+            self._optimizer_type,
+            table.name,
+            local_accumulator,
+            local_momentum,
+            local_velocity,
+            self._optimizer_kwargs.get("eps", 1e-10),
+            self._optimizer_kwargs.get("beta1", 0.9),
+            self._optimizer_kwargs.get("beta2", 0.999),
+        )
+
+
+class SparseCoreFusedEmbeddingBagCollection(
+    SparseCoreEmbeddingBagCollectionInterface, _SparseCoreFusedEmbeddingBase
+):
+    """EmbeddingBagCollection replacement using TPU SparseCore SparseDenseMatmul with preprocessed inputs."""
+
+    def __init__(
+        self,
+        tables: List[SparseCoreEmbeddingConfig],
+        optimizer_type: Type[torch.optim.Optimizer],
+        optimizer_kwargs: Dict[str, Any],
+        batch_size: int = 1,
+        global_device_count: int = 1,
+        num_sc_per_device: int = 2,
+    ) -> None:
+        super().__init__(
+            tables=tables,
+            optimizer_type=optimizer_type,
+            optimizer_kwargs=optimizer_kwargs,
+            weight_dict_name="embedding_bags",
+            batch_size=batch_size,
+            global_device_count=global_device_count,
+            num_sc_per_device=num_sc_per_device,
+        )
+
+    def embedding_bag_configs(self) -> List[EmbeddingBagConfig]:
+        configs: List[EmbeddingBagConfig] = []
+        for t in self._tables:
+            config = t.config
+            if isinstance(config, EmbeddingBagConfig):
+                configs.append(config)
+        return configs
+
+    def forward(self, features: KeyedSparseCorePreprocessedInput) -> KeyedTensor:
+        pooled_embeddings = []
+        embedding_names = []
+
+        for table in self._tables:
+            embedding_table = self.embedding_bags[table.name].weight
+            num_features = len(table.feature_names)
+            total_batch_size = self._batch_size * num_features
+
+            out = self._run_table_lookup(
+                table, features, embedding_table, total_batch_size
+            )
+
+            # Unstack and uninterleave features across SparseCore cores.
+            unstacked = self._unstack_activation(out, num_features, self._batch_size)
+            for f_idx, feature_name in enumerate(table.feature_names):
+                pooled_embeddings.append(unstacked[f_idx][:, : table.embedding_dim])
+                embedding_names.append(feature_name)
+
+        concat_values = torch.cat(pooled_embeddings, dim=1)
+        length_per_key = [
+            self._feature_to_table_config[name].embedding_dim
+            for name in embedding_names
+        ]
+        return KeyedTensor(
+            keys=embedding_names,
+            values=concat_values,
+            length_per_key=length_per_key,
+        )
+
+
+class SparseCoreFusedEmbeddingCollection(
+    SparseCoreEmbeddingCollectionInterface, _SparseCoreFusedEmbeddingBase
+):
+    """EmbeddingCollection replacement using TPU SparseCore SparseDenseMatmul with preprocessed inputs."""
+
+    def __init__(
+        self,
+        tables: List[SparseCoreEmbeddingConfig],
+        optimizer_type: Type[torch.optim.Optimizer] = torch.optim.SGD,
+        optimizer_kwargs: Optional[Dict[str, Any]] = None,
+        batch_size: int = 1,
+        global_device_count: int = 1,
+        num_sc_per_device: int = 2,
+    ) -> None:
+        if optimizer_kwargs is None:
+            optimizer_kwargs = {"lr": 0.01}
+        else:
+            optimizer_kwargs = dict(optimizer_kwargs)
+
+        for table in tables:
+            if isinstance(table.config, EmbeddingConfig) and table.max_seq_len is None:
+                raise ValueError(
+                    "max_seq_len must be provided for EmbeddingConfig table"
+                    f" {table.name}"
+                )
+
+        super().__init__(
+            tables=tables,
+            optimizer_type=optimizer_type,
+            optimizer_kwargs=optimizer_kwargs,
+            weight_dict_name="embeddings",
+            batch_size=batch_size,
+            global_device_count=global_device_count,
+            num_sc_per_device=num_sc_per_device,
+        )
+
+    def embedding_configs(self) -> List[EmbeddingConfig]:
+        configs: List[EmbeddingConfig] = []
+        for t in self._tables:
+            config = t.config
+            if isinstance(config, EmbeddingConfig):
+                configs.append(config)
+        return configs
+
+    def forward(
+        self, features: KeyedSparseCorePreprocessedInput
+    ) -> Dict[str, JaggedTensor]:
+        output_dict = {}
+        for table in self._tables:
+            embedding_table = self.embeddings[table.name].weight
+
+            max_seq_len_table = table.max_seq_len
+            assert max_seq_len_table is not None
+            seq_batch_size = self._batch_size * max_seq_len_table
+            num_features = len(table.feature_names)
+            total_batch_size = seq_batch_size * num_features
+
+            out = self._run_table_lookup(
+                table, features, embedding_table, total_batch_size
+            )
+
+            # out has shape [seq_batch_size * num_features, D].
+            # Unstack and uninterleave features across SparseCore cores, then slice
+            # back to the actual length.
+            unstacked = self._unstack_activation(out, num_features, seq_batch_size)
+            table_inputs = features.table_tensors[table.name]
+
+            for f_idx, feature_name in enumerate(table.feature_names):
+                lengths = table_inputs.lengths[feature_name]
+                actual_num_ids = table_inputs.actual_num_ids[feature_name]
+                feature_out = unstacked[f_idx][:actual_num_ids, : table.embedding_dim]
+                output_dict[feature_name] = JaggedTensor(
+                    values=feature_out,
+                    lengths=lengths,
+                )
+
+        return output_dict

--- a/torchrec/experimental/torch_tpu/modules/utils.py
+++ b/torchrec/experimental/torch_tpu/modules/utils.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""General utility functions for Torch TPU Embedding modules."""
+
+import torch
+
+
+def get_device() -> torch.device:
+    """Returns the TPU PyTorch device."""
+    return torch.device("tpu")
+
+
+def get_compile_count() -> int:
+    """Returns total PyTorch Dynamo frame compile count."""
+    return sum(torch._dynamo.convert_frame.FRAME_COMPILE_COUNTER.values())

--- a/torchrec/experimental/torch_tpu/pallas/__init__.py
+++ b/torchrec/experimental/torch_tpu/pallas/__init__.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Re-exports resolve lazily (PEP 562); see the package __init__ one level up for the
+# rationale. Here specifically: `lookup` imports jax, which an OSS install does not
+# have, and `modules.embedding_modules` imports `pallas.ops`. Eagerly, that made jax a
+# hard requirement of the embedding modules even though `ops` itself only needs torch.
+
+import importlib
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchrec.experimental.torch_tpu.pallas import ops
+    from torchrec.experimental.torch_tpu.pallas.lookup import (
+        batched_tpu_embedding_lookup,
+        single_tpu_embedding_lookup,
+    )
+
+
+_SYMBOL_TO_MODULE: dict[str, str] = {
+    "batched_tpu_embedding_lookup": "torchrec.experimental.torch_tpu.pallas.lookup",
+    "ops": "torchrec.experimental.torch_tpu.pallas.ops",
+    "single_tpu_embedding_lookup": "torchrec.experimental.torch_tpu.pallas.lookup",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _SYMBOL_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(module_name)
+    # `ops` is a re-exported submodule, so it resolves to the module itself; every
+    # other entry names a symbol defined inside its module.
+    attr = module if module_name.endswith(f".{name}") else getattr(module, name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_SYMBOL_TO_MODULE])
+
+
+__all__ = [
+    "ops",
+    "batched_tpu_embedding_lookup",
+    "single_tpu_embedding_lookup",
+]


### PR DESCRIPTION
Summary:

- Add SparseCoreEmbeddingConfig for TPU SparseCore capacity wrapping
- Add SparseCoreFusedEmbeddingBagCollection and SparseCoreFusedEmbeddingCollection
- Add custom ops registration for SGD, Adagrad, and Adam with fake tracing implementations
- Add SparseCoreInputPreprocessor, SparseCoreBatch, and C++ pybind extension
- Add SparseCoreSavePlanner and SparseCoreLoadPlanner for PyTorch DCP
- Add documentation and migration guide in README.md

Ref Pull Request: https://github.com/meta-pytorch/torchrec/pull/4616

Reviewed By: Ali-Tehrani

Differential Revision: D118329155

Pulled By: kausv


