### PR TITLE
Put the sweep dtype in the relay bench snapshot filenames (#4659)

### DIFF
--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -540,6 +540,7 @@ def reduce_scatter_tensors_with_sharded_relay(
     annotation: str,
     op: dist.ReduceOp = dist.ReduceOp.SUM,
     in_place: bool = False,
+    low_precision: bool = False,
 ) -> None:
     """
     Perform reduce-scatter using the fused sharded relay algorithm.
@@ -577,6 +578,15 @@ def reduce_scatter_tensors_with_sharded_relay(
         annotation: Profiling annotation string for record_function.
         op: Reduction op (ReduceOp.SUM or ReduceOp.AVG).
         in_place: Select the internal output-buffer strategy / kernel path.
+        low_precision: Request the fp8e4m3 wire format where it pays. An
+            internal size-only gate decides -- an unsupported dtype, per-group
+            counts that are not a multiple of 128, or a message below the
+            measured crossover all decline to full precision SILENTLY, so a
+            caller that cares must assert engagement rather than assume it.
+            COLLECTIVE: every rank of the call must pass the same value, exactly
+            like the dtype and the counts. Ranks that disagree disagree on how
+            many bytes cross each link, so the call hangs or corrupts rather
+            than degrading.
     """
     sparse_group_size = state.sparse_group_size
     my_sparse_group = state.my_sparse_group
@@ -702,6 +712,7 @@ def reduce_scatter_tensors_with_sharded_relay(
                 all_active_ranks=precomputed_active_ranks,
                 op=op,
                 skip_validation=True,
+                low_precision=low_precision,
             )
 
             # --- Step 5: Unpack the active-group result into caller tensors ---
@@ -715,6 +726,7 @@ def allreduce_tensors_with_sharded_relay(
     annotation: str,
     op: dist.ReduceOp | dist.ReduceOp.RedOpType = dist.ReduceOp.AVG,
     output_tensors_dict: dict[torch.dtype, list[torch.Tensor]] | None = None,
+    low_precision: bool = False,
 ) -> None:
     """
     Perform allreduce using the fused sharded relay algorithm.
@@ -759,6 +771,9 @@ def allreduce_tensors_with_sharded_relay(
             preserved; per dtype, ``output_tensors_dict[dtype]`` must mirror
             ``tensors_dict[dtype]`` in per-tensor shapes and total element
             count.
+        low_precision: Request the fp8e4m3 wire format where it pays. Same
+            silently-declining gate and same COLLECTIVE contract as
+            ``reduce_scatter_tensors_with_sharded_relay``.
     """
     sparse_group_size = state.sparse_group_size
     my_sparse_group = state.my_sparse_group
@@ -873,6 +888,7 @@ def allreduce_tensors_with_sharded_relay(
                 output_tensors=(
                     output_group_tensors if output_tensors_dict is not None else None
                 ),
+                low_precision=low_precision,
             )
 
             # --- Step 5: Unpack the active-group result into caller tensors ---
@@ -885,6 +901,7 @@ def all_to_all_tensors_with_sharded_relay(
     input_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
     output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
     annotation: str,
+    low_precision: bool = False,
 ) -> None:
     """
     Perform all-to-all using the fused sharded relay algorithm.
@@ -908,6 +925,9 @@ def all_to_all_tensors_with_sharded_relay(
             tensors for a dtype must total the same number of elements as the
             input (nActiveRanks x segment_count).
         annotation: Profiling annotation string for record_function.
+        low_precision: Request the fp8e4m3 wire format where it pays. Same
+            silently-declining gate and same COLLECTIVE contract as
+            ``reduce_scatter_tensors_with_sharded_relay``.
     """
     sparse_group_size = state.sparse_group_size
     my_sparse_group = state.my_sparse_group
@@ -1018,6 +1038,7 @@ def all_to_all_tensors_with_sharded_relay(
                 per_group_segment_counts=per_group_segment_counts,
                 all_active_ranks=precomputed_active_ranks,
                 skip_validation=True,
+                low_precision=low_precision,
             )
             # --- Step 5: Unpack the active-group result into caller tensors ---
             if unpack_flat is not None:
@@ -1030,6 +1051,7 @@ def all_gather_tensors_with_sharded_relay(
     output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
     annotation: str,
     in_place: bool = False,
+    low_precision: bool = False,
 ) -> None:
     """
     Perform all-gather using the fused sharded relay algorithm.
@@ -1061,6 +1083,9 @@ def all_gather_tensors_with_sharded_relay(
             elements.
         annotation: Profiling annotation string for record_function.
         in_place: Select the internal input-buffer strategy / kernel path.
+        low_precision: Request the fp8e4m3 wire format where it pays. Same
+            silently-declining gate and same COLLECTIVE contract as
+            ``reduce_scatter_tensors_with_sharded_relay``.
     """
     sparse_group_size = state.sparse_group_size
     my_sparse_group = state.my_sparse_group
@@ -1182,6 +1207,7 @@ def all_gather_tensors_with_sharded_relay(
                 per_group_send_counts=per_group_send_counts,
                 all_active_ranks=precomputed_active_ranks,
                 skip_validation=True,
+                low_precision=low_precision,
             )
 
             # --- Step 5: Unpack the active-group result into caller tensors ---

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -130,6 +130,7 @@ import tempfile
 import unittest
 from functools import partial
 from typing import Any
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -2328,31 +2329,66 @@ def _sweep_fmt_speedup(nccl: float, relay: float) -> str:
     return f"{nccl / relay:.2f}x" if nccl > 0 and relay > 0 else "N/A"
 
 
-def _emit_report(lines: list[str], default_basename: str) -> None:
+_EMITTED_BASENAMES: list[str] = []
+
+
+def _emit_report(lines: list[str], default_basename: str) -> str:
     """Write the assembled results tables to a dedicated file AND to stdout as a
-    single atomic write.
+    single atomic write. Returns the path written, or "" if the write failed.
 
     The sweep spawns up to N * NUM_GPUS worker processes, each emitting glog /
     thrift / RCCLX C++ init logging to the shared stdout/stderr. Interleaving
     that firehose with per-line print() mangles the tables (a stray token can
     land mid-row). Assembling the whole report as one string and writing it once
     — and also to an isolated file no other process touches — keeps the results
-    clean and diffable. BENCH_RESULTS_FILE overrides the file path.
+    clean and diffable.
+
+    TWO env vars, and the distinction only started to matter once a run emitted
+    more than one report:
+
+      BENCH_RESULTS_DIR   directory; every report keeps its own basename. Use
+                          this. It is the only one that works for a run emitting
+                          several reports, which is now every full run.
+      BENCH_RESULTS_FILE  an exact path for ONE report. Kept because it is what
+                          existing callers pass, but it now RAISES on the second
+                          distinct report instead of silently collapsing them all
+                          onto one path and leaving only the last -- which is what
+                          it used to do, and which looked like the earlier reports
+                          had never been produced.
+
+    Re-emitting the SAME basename is allowed and overwrites, because that is a
+    re-run of one report rather than two reports colliding.
     """
     report = "\n".join(lines) + "\n"
-    path = os.environ.get(
-        "BENCH_RESULTS_FILE",
-        os.path.join(tempfile.gettempdir(), default_basename),
-    )
+    explicit = os.environ.get("BENCH_RESULTS_FILE")
+    if explicit:
+        collided = [b for b in _EMITTED_BASENAMES if b != default_basename]
+        if collided:
+            raise RuntimeError(
+                f"BENCH_RESULTS_FILE={explicit!r} names a single path, but this "
+                f"run already wrote {collided} and is now emitting "
+                f"{default_basename!r}. Every report would land on that one path "
+                f"and only the last would survive. Set BENCH_RESULTS_DIR instead "
+                f"to get one file per report."
+            )
+        path = explicit
+    else:
+        path = os.path.join(
+            os.environ.get("BENCH_RESULTS_DIR", tempfile.gettempdir()),
+            default_basename,
+        )
     try:
         with open(path, "w") as f:
             f.write(report)
     except OSError:
         path = ""
+    if default_basename not in _EMITTED_BASENAMES:
+        _EMITTED_BASENAMES.append(default_basename)
     banner = "#" * 55
     header = "# BENCH RESULTS" + (f" (also written to {path})" if path else "")
     sys.stdout.write(f"\n{banner}\n{header}\n{banner}\n{report}{banner}\n")
     sys.stdout.flush()
+    return path
 
 
 def _format_sweep_table(
@@ -3031,6 +3067,78 @@ def _print_single_group_msg_sweep_report(results_dict: Any, dtype: torch.dtype) 
 # TestCase — works with both "buck2 test" and "buck2 run" (same as the old
 # test_sharded_relay_2d_integration.py pattern).
 # ---------------------------------------------------------------------------
+
+
+class EmitReportTest(unittest.TestCase):
+    """CPU-only cover for the report writer.
+
+    Deliberately its own TestCase: BenchShardedRelayPerfTest skips without 8 GPUs,
+    and this is the one part of the bench that is pure Python and can go wrong
+    without any GPU at all -- which is exactly what happened. With three reports
+    per run BENCH_RESULTS_FILE silently kept only the last, and nothing failed.
+    """
+
+    def setUp(self) -> None:
+        _EMITTED_BASENAMES.clear()
+
+    def tearDown(self) -> None:
+        _EMITTED_BASENAMES.clear()
+
+    def test_results_dir_gives_one_file_per_report(self) -> None:
+        """The case the run actually needs: six reports, six files."""
+        basenames = [
+            "bench_sharded_relay_fused_sweep_results.txt",
+            "bench_sharded_relay_parallel_sweep_results.txt",
+            "bench_sharded_relay_single_group_sweep_results.txt",
+            "bench_sharded_relay_fused_lp_sweep_results.txt",
+            "bench_sharded_relay_parallel_lp_sweep_results.txt",
+            "bench_sharded_relay_single_group_lp_sweep_results.txt",
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"BENCH_RESULTS_DIR": d}, clear=False):
+                os.environ.pop("BENCH_RESULTS_FILE", None)
+                written = [_emit_report([f"body {b}"], b) for b in basenames]
+        self.assertEqual(len(set(written)), len(basenames))
+        for path, basename in zip(written, basenames):
+            self.assertEqual(os.path.basename(path), basename)
+
+    def test_results_file_accepts_a_single_report(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "only.txt")
+            with mock.patch.dict(
+                os.environ, {"BENCH_RESULTS_FILE": target}, clear=False
+            ):
+                path = _emit_report(["body"], "whatever.txt")
+                self.assertEqual(path, target)
+                with open(target) as f:
+                    self.assertIn("body", f.read())
+
+    def test_results_file_rejects_a_second_distinct_report(self) -> None:
+        """The regression. It used to overwrite and report success."""
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "only.txt")
+            with mock.patch.dict(
+                os.environ, {"BENCH_RESULTS_FILE": target}, clear=False
+            ):
+                _emit_report(["first"], "first.txt")
+                with self.assertRaises(RuntimeError) as cm:
+                    _emit_report(["second"], "second.txt")
+        msg = str(cm.exception)
+        self.assertIn("BENCH_RESULTS_DIR", msg)  # names the fix
+        self.assertIn("first.txt", msg)  # names what would have been lost
+        self.assertIn("second.txt", msg)
+
+    def test_results_file_allows_re_emitting_the_same_report(self) -> None:
+        """A re-run of one report is not two reports colliding."""
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "only.txt")
+            with mock.patch.dict(
+                os.environ, {"BENCH_RESULTS_FILE": target}, clear=False
+            ):
+                _emit_report(["first"], "same.txt")
+                _emit_report(["second"], "same.txt")
+                with open(target) as f:
+                    self.assertIn("second", f.read())
 
 
 class BenchShardedRelayPerfTest(unittest.TestCase):

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -341,6 +341,63 @@ def _apply_lp_min_kb_env() -> None:
         os.environ["NCCL_SHARDED_RELAY_LP_MIN_KB"] = min_kb
 
 
+# Data type for the message-size sweep comparison. See _sweep_dtype().
+_MSG_SWEEP_DTYPE_DEFAULT: torch.dtype = torch.bfloat16
+_MSG_SWEEP_DTYPES: dict[str, torch.dtype] = {
+    "bf16": torch.bfloat16,
+    "bfloat16": torch.bfloat16,
+    "fp32": torch.float32,
+    "float32": torch.float32,
+}
+
+
+def _sweep_dtype() -> torch.dtype:
+    """Element type the sweeps run in.
+
+    BENCH_SWEEP_DTYPE picks bf16 (default) or fp32. It exists because the two
+    are different tuning problems for low precision, not one problem measured
+    twice: fp32 sends twice the wire bytes per element, so quantizing to fp8
+    saves twice as much, and its crossover lands at a smaller message. A
+    threshold read off a bf16 sweep is therefore conservative for fp32, and the
+    only way to know by how much is to sweep fp32 with the same harness.
+    """
+    want = _env_str("BENCH_SWEEP_DTYPE", "")
+    if not want:
+        return _MSG_SWEEP_DTYPE_DEFAULT
+    dtype = _MSG_SWEEP_DTYPES.get(want.strip().lower())
+    if dtype is None:
+        raise ValueError(
+            f"BENCH_SWEEP_DTYPE={want!r} is not one of {sorted(_MSG_SWEEP_DTYPES)}"
+        )
+    return dtype
+
+
+def _dtype_tag(dtype: torch.dtype) -> str:
+    """Short filename token for a sweep dtype ("bf16" / "fp32")."""
+    for tag, candidate in (("bf16", torch.bfloat16), ("fp32", torch.float32)):
+        if dtype == candidate:
+            return tag
+    return str(dtype).replace("torch.", "")
+
+
+def _report_basename(scope: str, lp: bool) -> str:
+    """Snapshot filename for one report, with the sweep dtype in it.
+
+    The dtype is in the NAME and not only in the table header because the
+    element type is a tuning axis, not a formatting detail: bf16 and fp32 have
+    different low-precision crossovers, so their snapshots are different
+    results. Without the tag an fp32 run writes over the bf16 snapshot it was
+    supposed to be compared against, and the file still looks plausible --
+    exactly the stale-data failure that has already invalidated conclusions on
+    this workstream once.
+    """
+    lp_part = "lp_" if lp else ""
+    return (
+        f"bench_sharded_relay_{scope}_{_dtype_tag(_sweep_dtype())}_"
+        f"{lp_part}sweep_results.txt"
+    )
+
+
 def _sweep_sizes() -> list[tuple[str, int]]:
     """Message sizes the sweeps cover.
 
@@ -1778,15 +1835,12 @@ def _benchmark_worker(
 #           sub-group.
 # The single-group scenario is benchmarked separately (see the parallel
 # independent-comm sweep, test_parallel_collectives_msg_size_sweep).
-# Fixed at bf16. NCCL allreduce/reduce-scatter baselines use SUM + manual divide
+# bf16 by default, fp32 via BENCH_SWEEP_DTYPE.
+# NCCL allreduce/reduce-scatter baselines use SUM + manual divide
 # (RCCL on MI350X lacks the AVG kernel); the relay path uses AVG in the kernel.
 # all-to-all / all-gather do no reduction. The swept nbytes is the per-active-rank
 # input tensor byte size, so sizes stay comparable across collectives.
 # ---------------------------------------------------------------------------
-
-# Data type for the message-size sweep comparison.
-_MSG_SWEEP_DTYPE: torch.dtype = torch.bfloat16
-
 
 # ----- Per-collective buffer/shape helpers (shared by NCCL + relay) ---------
 
@@ -2085,7 +2139,7 @@ def _msg_sweep_nccl_worker(
     torch.cuda.set_device(local_rank)
     device = torch.device(f"cuda:{local_rank}")
 
-    dtype = _MSG_SWEEP_DTYPE
+    dtype = _sweep_dtype()
     warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
 
@@ -2309,7 +2363,7 @@ def _msg_sweep_relay_worker(
     torch.cuda.set_device(local_rank)
     device = torch.device(f"cuda:{local_rank}")
 
-    dtype = _MSG_SWEEP_DTYPE
+    dtype = _sweep_dtype()
     warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
 
@@ -2485,7 +2539,7 @@ def _print_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
             lines.extend(
                 _format_sweep_table(results_dict, dtype, collective, active_ranks)
             )
-    _emit_report(lines, "bench_sharded_relay_fused_sweep_results.txt")
+    _emit_report(lines, _report_basename("fused", lp=False))
 
 
 # ---------------------------------------------------------------------------
@@ -2506,7 +2560,8 @@ def _print_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
 #   comm 1: active [2,3], helpers [0,1,4,5,6,7]  ... (N=4 comms)
 # Each rank is active in exactly one comm and a helper in the others.
 #
-# Fixed at bf16. NCCL baseline: N disjoint A-rank NCCL collectives running
+# bf16 by default, fp32 via BENCH_SWEEP_DTYPE.
+# NCCL baseline: N disjoint A-rank NCCL collectives running
 # concurrently (identical to the FUSED sweep's baseline; reuses _nccl_baseline_op).
 # NCCL allreduce/reduce-scatter use SUM + manual divide (RCCL on MI350X lacks the
 # AVG kernel); the relay path uses AVG in the RCCLX kernel.
@@ -2606,7 +2661,7 @@ def _parallel_msg_sweep_nccl_worker(
     )
     job_device_group = _build_per_job_nccl_group(total_procs, job)
 
-    dtype = _MSG_SWEEP_DTYPE
+    dtype = _sweep_dtype()
     warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
 
@@ -2907,7 +2962,7 @@ def _parallel_msg_sweep_relay_worker(
     )
     job_device_group = _build_per_job_nccl_group(total_procs, job)
 
-    dtype = _MSG_SWEEP_DTYPE
+    dtype = _sweep_dtype()
     warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
 
@@ -3071,7 +3126,7 @@ def _print_parallel_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> N
                     results_dict, dtype, collective, active_ranks
                 )
             )
-    _emit_report(lines, "bench_sharded_relay_parallel_sweep_results.txt")
+    _emit_report(lines, _report_basename("parallel", lp=False))
 
 
 def _format_single_group_sweep_table(
@@ -3132,7 +3187,7 @@ def _print_single_group_msg_sweep_report(results_dict: Any, dtype: torch.dtype) 
                     results_dict, dtype, collective, active_ranks
                 )
             )
-    _emit_report(lines, "bench_sharded_relay_single_group_sweep_results.txt")
+    _emit_report(lines, _report_basename("single_group", lp=False))
 
 
 # ---------------------------------------------------------------------------
@@ -3232,7 +3287,7 @@ def _print_msg_sweep_lp_report(results_dict: Any, dtype: torch.dtype) -> None:
                     f"relay_lp_{key}_fused_{{i}}",
                 )
             )
-    _emit_report(lines, "bench_sharded_relay_fused_lp_sweep_results.txt")
+    _emit_report(lines, _report_basename("fused", lp=True))
 
 
 def _print_parallel_msg_sweep_lp_report(results_dict: Any, dtype: torch.dtype) -> None:
@@ -3263,7 +3318,7 @@ def _print_parallel_msg_sweep_lp_report(results_dict: Any, dtype: torch.dtype) -
                     f"relay_parallel_lp_{key}_{{i}}",
                 )
             )
-    _emit_report(lines, "bench_sharded_relay_parallel_lp_sweep_results.txt")
+    _emit_report(lines, _report_basename("parallel", lp=True))
 
 
 def _print_single_group_msg_sweep_lp_report(
@@ -3299,7 +3354,7 @@ def _print_single_group_msg_sweep_lp_report(
                     f"relay_parallel_lp_{key}_{{i}}",
                 )
             )
-    _emit_report(lines, "bench_sharded_relay_single_group_lp_sweep_results.txt")
+    _emit_report(lines, _report_basename("single_group", lp=True))
 
 
 class EmitReportTest(unittest.TestCase):
@@ -3334,6 +3389,24 @@ class EmitReportTest(unittest.TestCase):
         self.assertEqual(len(set(written)), len(basenames))
         for path, basename in zip(written, basenames):
             self.assertEqual(os.path.basename(path), basename)
+
+    def test_report_basenames_separate_the_dtypes(self) -> None:
+        """The two dtypes are different results, so they must not share a path.
+
+        This is the case that motivated putting the dtype in the name: an fp32
+        run used to write over the bf16 snapshot it was meant to be compared
+        against, and the file still looked plausible afterwards.
+        """
+        scopes = ("fused", "parallel", "single_group")
+        names = set()
+        for dtype in ("bf16", "fp32"):
+            with mock.patch.dict(os.environ, {"BENCH_SWEEP_DTYPE": dtype}, clear=False):
+                for scope in scopes:
+                    for lp in (False, True):
+                        name = _report_basename(scope, lp=lp)
+                        self.assertIn(dtype, name)
+                        names.add(name)
+        self.assertEqual(len(names), len(scopes) * 2 * 2)
 
     def test_results_file_accepts_a_single_report(self) -> None:
         with tempfile.TemporaryDirectory() as d:
@@ -3479,8 +3552,8 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
             join=True,
         )
 
-        _print_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
-        _print_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
+        _print_msg_sweep_report(results, _sweep_dtype())
+        _print_msg_sweep_lp_report(results, _sweep_dtype())
 
         manager.shutdown()
 
@@ -3556,8 +3629,8 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
 
         # Reduce per-job entries to max-across-jobs, then print the tables.
         _reduce_parallel_jobs_max(results)
-        _print_parallel_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
-        _print_parallel_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
+        _print_parallel_msg_sweep_report(results, _sweep_dtype())
+        _print_parallel_msg_sweep_lp_report(results, _sweep_dtype())
 
         manager.shutdown()
 
@@ -3611,8 +3684,8 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
 
         # Collapse the single job's per-job entries to the base keys, then print.
         _reduce_parallel_jobs_max(results)
-        _print_single_group_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
-        _print_single_group_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
+        _print_single_group_msg_sweep_report(results, _sweep_dtype())
+        _print_single_group_msg_sweep_lp_report(results, _sweep_dtype())
 
         manager.shutdown()
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -318,6 +318,29 @@ def _sweep_reps() -> int:
     return max(1, _env_int("BENCH_SWEEP_REPS", 10))
 
 
+def _apply_lp_min_kb_env() -> None:
+    """Export BENCH_LP_MIN_KB as NCCL_SHARDED_RELAY_LP_MIN_KB, if set.
+
+    OPT-IN, and the default matters. Left unset, low precision uses the crossover
+    that SHIPS, so the checked-in snapshots show what a caller actually gets --
+    including 1.00x rows below the crossover, which is an honest record of where
+    the gate declines rather than a gap in the data.
+
+    Set it (BENCH_LP_MIN_KB=1) for a TUNING run: the built-in threshold refuses
+    small messages before anything is timed, so the crossover is the one number a
+    default run cannot measure. A tuning run makes the whole size axis eligible,
+    reads the crossover off the LP-vs-Relay column, and that measured value is what
+    then goes into lpMinBytes().
+
+    Must be exported before the communicator exists: NCCL_PARAM caches on first
+    read. Called at the top of each relay worker, which is a fresh process per
+    mp.spawn, so the export is always ahead of the first relay call.
+    """
+    min_kb = os.environ.get("BENCH_LP_MIN_KB")
+    if min_kb:
+        os.environ["NCCL_SHARDED_RELAY_LP_MIN_KB"] = min_kb
+
+
 def _sweep_sizes() -> list[tuple[str, int]]:
     """Message sizes the sweeps cover.
 
@@ -1881,6 +1904,7 @@ def _run_relay_once(
     num_groups: int,
     my_sparse_group: int,
     all_active_ranks: list[list[int]],
+    low_precision: bool = False,
 ) -> None:
     """One sharded-relay collective call with PRE-BUILT per-group tensor lists.
 
@@ -1896,6 +1920,7 @@ def _run_relay_once(
             all_active_ranks=all_active_ranks,
             op=dist.ReduceOp.AVG,
             skip_validation=True,
+            low_precision=low_precision,
         )
     elif collective == "reduce_scatter":
         relay.reduce_scatter_multi_group(
@@ -1906,6 +1931,7 @@ def _run_relay_once(
             all_active_ranks=all_active_ranks,
             op=dist.ReduceOp.AVG,
             skip_validation=True,
+            low_precision=low_precision,
         )
     elif collective == "all_to_all":
         relay.all_to_all_multi_group(
@@ -1915,6 +1941,7 @@ def _run_relay_once(
             per_group_segment_counts=counts,
             all_active_ranks=all_active_ranks,
             skip_validation=True,
+            low_precision=low_precision,
         )
     elif collective == "all_gather":
         relay.all_gather_multi_group(
@@ -1924,6 +1951,7 @@ def _run_relay_once(
             per_group_send_counts=counts,
             all_active_ranks=all_active_ranks,
             skip_validation=True,
+            low_precision=low_precision,
         )
     else:
         raise ValueError(f"unknown collective {collective!r}")
@@ -2130,6 +2158,7 @@ def _measure_relay_for(
     world_size: int,
     warmup: int,
     bench_iters: int,
+    low_precision: bool = False,
 ) -> tuple[float, float]:
     """Time the FUSED (num_groups = world // A) relay collective for one message
     size. Returns (best_ms, std_ms)."""
@@ -2168,6 +2197,7 @@ def _measure_relay_for(
             num_groups,
             my_sparse_group,
             fused_active_ranks,
+            low_precision,
         ),
         warmup,
         bench_iters,
@@ -2218,6 +2248,13 @@ def _msg_sweep_relay_warmup(
             in_list, out_list = _build_relay_group_lists(
                 a_in, a_out, bufs, num_groups, my_sparse_group
             )
+            # FULL PRECISION ONLY, deliberately. warm_elems is 2048, which is
+            # below every relay-route crossover, so a low-precision call here
+            # DECLINES on route: it would compile none of the low-precision
+            # kernels and would only fill the log with declines. Low precision is
+            # warmed instead by _measure_ms's own untimed warmup iterations, which
+            # run at the measured size -- where it actually engages, and which is
+            # also where the one-time arena bootstrap belongs.
             for _ in range(3):
                 _run_relay_once(
                     collective,
@@ -2252,6 +2289,8 @@ def _msg_sweep_relay_worker(
     os.environ["MASTER_PORT"] = str(_NCCL_PORT + 300 + port_offset)
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
+
+    _apply_lp_min_kb_env()
 
     local_rank = rank
     is_master = rank == 0
@@ -2292,25 +2331,34 @@ def _msg_sweep_relay_worker(
     # Pre-compile every distinct HIP kernel config before timing.
     _msg_sweep_relay_warmup(fused_by_a, rank, world_size, dtype, device)
 
+    # Full precision and low precision measured BACK TO BACK in the same worker on
+    # the same communicator. That is only possible because low precision is a
+    # per-call argument, and it is what makes the LP-vs-FP ratio meaningful: a
+    # second process would carry its own placement, channel assignment and clock
+    # state, so the ratio would mix the wire format with process-to-process
+    # variance. Same buffers, same comm, adjacent in time.
     for active_ranks in _sweep_active_ranks():
         relay_fused = fused_by_a[active_ranks]
         for collective in _sweep_collectives():
             for i, (_label, nbytes) in enumerate(_sweep_sizes()):
-                best_f, std_f = _measure_relay_for(
-                    collective=collective,
-                    active_ranks=active_ranks,
-                    relay_fused=relay_fused,
-                    nbytes=nbytes,
-                    dtype=dtype,
-                    device=device,
-                    rank=rank,
-                    world_size=world_size,
-                    warmup=warmup,
-                    bench_iters=bench_iters,
-                )
-                if rank == 0:
-                    key = f"{collective}_a{active_ranks}"
-                    results_dict[f"relay_{key}_fused_{i}"] = (best_f, std_f)
+                for lp in (False, True):
+                    best_f, std_f = _measure_relay_for(
+                        collective=collective,
+                        active_ranks=active_ranks,
+                        relay_fused=relay_fused,
+                        nbytes=nbytes,
+                        dtype=dtype,
+                        device=device,
+                        rank=rank,
+                        world_size=world_size,
+                        warmup=warmup,
+                        bench_iters=bench_iters,
+                        low_precision=lp,
+                    )
+                    if rank == 0:
+                        key = f"{collective}_a{active_ranks}"
+                        prefix = "relay_lp" if lp else "relay"
+                        results_dict[f"{prefix}_{key}_fused_{i}"] = (best_f, std_f)
 
     dist.barrier()
     dist.destroy_process_group()
@@ -2627,6 +2675,7 @@ def _issue_relay_async(
     out_list: list[torch.Tensor],
     count_list: list[int],
     all_active_ranks: list[list[int]],
+    low_precision: bool = False,
 ) -> Any:
     """Issue ONE single-group (num_groups=1) sharded relay collective on a comm
     with async_op=True; returns its work handle."""
@@ -2639,6 +2688,7 @@ def _issue_relay_async(
             op=dist.ReduceOp.AVG,
             skip_validation=True,
             async_op=True,
+            low_precision=low_precision,
         )
     if collective == "reduce_scatter":
         return comm.reduce_scatter_multi_group(
@@ -2650,6 +2700,7 @@ def _issue_relay_async(
             op=dist.ReduceOp.AVG,
             skip_validation=True,
             async_op=True,
+            low_precision=low_precision,
         )
     if collective == "all_to_all":
         return comm.all_to_all_multi_group(
@@ -2660,6 +2711,7 @@ def _issue_relay_async(
             all_active_ranks=all_active_ranks,
             skip_validation=True,
             async_op=True,
+            low_precision=low_precision,
         )
     if collective == "all_gather":
         return comm.all_gather_multi_group(
@@ -2670,6 +2722,7 @@ def _issue_relay_async(
             all_active_ranks=all_active_ranks,
             skip_validation=True,
             async_op=True,
+            low_precision=low_precision,
         )
     raise ValueError(f"unknown collective {collective!r}")
 
@@ -2682,6 +2735,7 @@ def _run_parallel_relay_once(
     count_list: list[int],
     active_ranks_per_comm: list[list[list[int]]],
     num_parallel: int,
+    low_precision: bool = False,
 ) -> None:
     """Issue N single-group relay collectives (one per comm) in parallel.
 
@@ -2702,6 +2756,7 @@ def _run_parallel_relay_once(
                 out_tensors[k],
                 count_list,
                 active_ranks_per_comm[k],
+                low_precision,
             )
         )
     for work in works:
@@ -2718,6 +2773,7 @@ def _parallel_relay_single_call(
     elements: int,
     dtype: torch.dtype,
     device: torch.device,
+    low_precision: bool = False,
 ) -> Any:
     """Zero-arg closure that issues this process's ONE single-group relay call.
 
@@ -2747,6 +2803,7 @@ def _parallel_relay_single_call(
         count_list,
         [[active_group]],
         1,
+        low_precision,
     )
 
 
@@ -2765,6 +2822,10 @@ def _parallel_relay_warmup_single(
     dist.barrier()
     warm_elems = 2048
     for collective in _sweep_collectives():
+        # FULL PRECISION ONLY: 2048 elements is below every relay-route crossover,
+        # so a low-precision call here declines on route and compiles nothing. Low
+        # precision is warmed by _measure_ms's untimed iterations at the measured
+        # size instead, which is also where the one-time arena bootstrap belongs.
         fn = _parallel_relay_single_call(
             collective,
             comm,
@@ -2817,6 +2878,8 @@ def _parallel_msg_sweep_relay_worker(
     os.environ["MASTER_PORT"] = str(store_port)
     os.environ["RANK"] = str(p)
     os.environ["WORLD_SIZE"] = str(total_procs)
+
+    _apply_lp_min_kb_env()
 
     store = dist.TCPStore(
         host_name="localhost",
@@ -2883,30 +2946,35 @@ def _parallel_msg_sweep_relay_worker(
             elements = nbytes // dtype.itemsize
             if elements % active_ranks != 0:
                 continue
-            fn = _parallel_relay_single_call(
-                collective,
-                comm,
-                active_group,
-                rank_in_job,
-                active_ranks,
-                elements,
-                dtype,
-                device,
-            )
-            best, std = _measure_ms(
-                fn,
-                warmup,
-                bench_iters,
-                device_barrier_group=job_device_group,
-                reps=_sweep_reps(),
-            )
-            del fn
-            torch.cuda.empty_cache()
-            if is_job_rank0:
-                results_dict[f"relay_parallel_{collective}_{key}_{i}_job{job}"] = (
-                    best,
-                    std,
+            # FP then LP back to back on the same comm; see the fused worker for
+            # why the ratio is only meaningful measured this way.
+            for lp in (False, True):
+                fn = _parallel_relay_single_call(
+                    collective,
+                    comm,
+                    active_group,
+                    rank_in_job,
+                    active_ranks,
+                    elements,
+                    dtype,
+                    device,
+                    lp,
                 )
+                best, std = _measure_ms(
+                    fn,
+                    warmup,
+                    bench_iters,
+                    device_barrier_group=job_device_group,
+                    reps=_sweep_reps(),
+                )
+                del fn
+                torch.cuda.empty_cache()
+                if is_job_rank0:
+                    prefix = "relay_parallel_lp" if lp else "relay_parallel"
+                    results_dict[f"{prefix}_{collective}_{key}_{i}_job{job}"] = (
+                        best,
+                        std,
+                    )
 
     dist.barrier()
     dist.destroy_process_group()
@@ -2932,7 +3000,11 @@ def _reduce_parallel_jobs_max(results_dict: Any) -> None:
         for collective in _sweep_collectives():
             key = f"{collective}_a{active_ranks}"
             for i, (label, _nbytes) in enumerate(_sweep_sizes()):
-                for prefix in ("relay_parallel", "nccl_parallel"):
+                for prefix in (
+                    "relay_parallel",
+                    "relay_parallel_lp",
+                    "nccl_parallel",
+                ):
                     vals = [
                         results_dict.get(f"{prefix}_{key}_{i}_job{j}")
                         for j in range(num_jobs)
@@ -3067,6 +3139,167 @@ def _print_single_group_msg_sweep_report(results_dict: Any, dtype: torch.dtype) 
 # TestCase — works with both "buck2 test" and "buck2 run" (same as the old
 # test_sharded_relay_2d_integration.py pattern).
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Low-precision comparison reports
+#
+# Three more files rather than three more columns in the existing ones. The
+# full-precision reports are checked-in snapshots that get diffed across
+# revisions, so widening them would churn every row of every snapshot for a
+# column most readers of those files are not asking about. The LP tables carry
+# the full-precision numbers alongside instead, so each file still stands alone.
+# ---------------------------------------------------------------------------
+
+
+def _format_lp_sweep_table(
+    results_dict: Any,
+    dtype: torch.dtype,
+    collective: str,
+    active_ranks: int,
+    heading: str,
+    subheadings: list[str],
+    band: str,
+    nccl_key: str,
+    relay_key: str,
+    relay_lp_key: str,
+) -> list[str]:
+    """One (collective, A) low-precision comparison table.
+
+    Five data columns rather than three: NCCL, Relay, Relay-LP and BOTH ratios.
+    LP-vs-NCCL is what a caller choosing between NCCL and the relay-with-LP cares
+    about; LP-vs-Relay is the one this table exists for, because it isolates the
+    wire format from everything else the relay does.
+
+    WHERE LP-vs-Relay READS 1.00x, LOW PRECISION DECLINED. The gate is size-only
+    and silent, so below the crossover Relay-LP runs the identical code path as
+    Relay and the ratio is 1 by construction rather than by measurement. That is
+    the signal these tables are for: the size at which the ratio leaves 1.00x IS
+    the crossover. It is also why NCCL_SHARDED_RELAY_LP_MIN_KB exists -- with the
+    built-in threshold the small end of the axis is refused before it is timed, so
+    the crossover is the one number the sweep could not otherwise see.
+    """
+    width = 78
+    line = "=" * width
+    out: list[str] = ["", line, heading, *subheadings, line]
+    out.append(f"{'':>10} | {band:^65}")
+    out.append(
+        f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} "
+        f"{'RelayLP(ms)':>12} {'LP vs NCCL':>11} {'LP vs Relay':>12}"
+    )
+    out.append("-" * width)
+    for i, (label, nbytes) in enumerate(_sweep_sizes()):
+        elements = nbytes // dtype.itemsize
+        if elements % active_ranks != 0:
+            continue
+        n = _sweep_get_ms(results_dict, nccl_key.format(i=i))
+        r = _sweep_get_ms(results_dict, relay_key.format(i=i))
+        rl = _sweep_get_ms(results_dict, relay_lp_key.format(i=i))
+        out.append(
+            f"{label:>10} | {_sweep_fmt_ms(n):>10} {_sweep_fmt_ms(r):>10} "
+            f"{_sweep_fmt_ms(rl):>12} {_sweep_fmt_speedup(n, rl):>11} "
+            f"{_sweep_fmt_speedup(r, rl):>12}"
+        )
+    out.append(line)
+    return out
+
+
+def _print_msg_sweep_lp_report(results_dict: Any, dtype: torch.dtype) -> None:
+    """FUSED sweep, full precision vs low precision."""
+    lines: list[str] = []
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
+            num_groups = NUM_GPUS // active_ranks
+            key = f"{collective}_a{active_ranks}"
+            title = collective.replace("_", "-").upper()
+            lines.extend(
+                _format_lp_sweep_table(
+                    results_dict,
+                    dtype,
+                    collective,
+                    active_ranks,
+                    f"Sharded Relay {title} — Low-Precision Message-Size Sweep "
+                    f"(MI350X, {NUM_GPUS} GPUs, {dtype})",
+                    [
+                        f"  {active_ranks} active ranks/group; times = "
+                        "best-of-N (min), barrier-aligned + hipEvent-timed",
+                        f"  FUSED = {num_groups}-group sharded relay; "
+                        "Relay and Relay-LP measured back to back on the SAME comm",
+                    ],
+                    f"FUSED ({num_groups} groups)",
+                    f"nccl_{key}_fused_{{i}}",
+                    f"relay_{key}_fused_{{i}}",
+                    f"relay_lp_{key}_fused_{{i}}",
+                )
+            )
+    _emit_report(lines, "bench_sharded_relay_fused_lp_sweep_results.txt")
+
+
+def _print_parallel_msg_sweep_lp_report(results_dict: Any, dtype: torch.dtype) -> None:
+    """Parallel separate-job sweep, full precision vs low precision."""
+    lines: list[str] = []
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
+            num_parallel = NUM_GPUS // active_ranks
+            key = f"{collective}_a{active_ranks}"
+            title = collective.replace("_", "-").upper()
+            lines.extend(
+                _format_lp_sweep_table(
+                    results_dict,
+                    dtype,
+                    collective,
+                    active_ranks,
+                    f"Sharded Relay {title} — Low-Precision {num_parallel}x "
+                    f"Parallel Sweep (MI350X, {NUM_GPUS} GPUs, {dtype})",
+                    [
+                        f"  {active_ranks} active ranks/group; times = "
+                        "best-of-N (min), max across jobs",
+                        f"  PARALLEL = {num_parallel} co-resident jobs; Relay and "
+                        "Relay-LP measured back to back on the SAME comm",
+                    ],
+                    f"PARALLEL ({num_parallel} jobs)",
+                    f"nccl_parallel_{key}_{{i}}",
+                    f"relay_parallel_{key}_{{i}}",
+                    f"relay_parallel_lp_{key}_{{i}}",
+                )
+            )
+    _emit_report(lines, "bench_sharded_relay_parallel_lp_sweep_results.txt")
+
+
+def _print_single_group_msg_sweep_lp_report(
+    results_dict: Any, dtype: torch.dtype
+) -> None:
+    """Single-group best case, full precision vs low precision.
+
+    Reads the same reduced base keys the parallel LP report reads -- this sweep is
+    the parallel sweep's num_jobs == 1 point.
+    """
+    lines: list[str] = []
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
+            key = f"{collective}_a{active_ranks}"
+            title = collective.replace("_", "-").upper()
+            lines.extend(
+                _format_lp_sweep_table(
+                    results_dict,
+                    dtype,
+                    collective,
+                    active_ranks,
+                    f"Sharded Relay {title} — Low-Precision Single-Group "
+                    f"Best-Case Sweep (MI350X, {NUM_GPUS} GPUs, {dtype})",
+                    [
+                        f"  {active_ranks} active ranks/group; times = "
+                        "best-of-N (min), no co-resident jobs",
+                        "  Relay and Relay-LP measured back to back on the SAME "
+                        "comm",
+                    ],
+                    "SINGLE GROUP (1 job)",
+                    f"nccl_parallel_{key}_{{i}}",
+                    f"relay_parallel_{key}_{{i}}",
+                    f"relay_parallel_lp_{key}_{{i}}",
+                )
+            )
+    _emit_report(lines, "bench_sharded_relay_single_group_lp_sweep_results.txt")
 
 
 class EmitReportTest(unittest.TestCase):
@@ -3247,6 +3480,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         )
 
         _print_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
+        _print_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
 
         manager.shutdown()
 
@@ -3323,6 +3557,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         # Reduce per-job entries to max-across-jobs, then print the tables.
         _reduce_parallel_jobs_max(results)
         _print_parallel_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
+        _print_parallel_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
 
         manager.shutdown()
 
@@ -3377,6 +3612,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         # Collapse the single job's per-job entries to the base keys, then print.
         _reduce_parallel_jobs_max(results)
         _print_single_group_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
+        _print_single_group_msg_sweep_lp_report(results, _MSG_SWEEP_DTYPE)
 
         manager.shutdown()
 

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -2310,5 +2310,74 @@ class FusedAllGather4ActiveValidationTest(unittest.TestCase):
         self.assertNotIsInstance(cm.exception, ValueError)
 
 
+# ---------------------------------------------------------------------------
+# Tests for the low_precision kwarg
+# ---------------------------------------------------------------------------
+
+
+class LowPrecisionForwardingTest(unittest.TestCase):
+    """
+    That `low_precision` reaches the backend, and defaults to False.
+
+    This suite is CPU-only and fully mocked, so low precision never actually
+    executes here -- forwarding is the only thing it can meaningfully cover, and
+    it is worth covering: the kwarg is threaded through four independent wrappers
+    and a dropped one would be invisible, because the backend silently declines
+    to full precision anyway and the numbers would still be correct.
+    """
+
+    def test_allreduce_defaults_to_full_precision(self) -> None:
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100)]}, "test"
+        )
+        kwargs = state.fused.allreduce_multi_group.call_args_list[0].kwargs
+        self.assertFalse(kwargs["low_precision"])
+
+    def test_allreduce_forwards_low_precision(self) -> None:
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100)]}, "test", low_precision=True
+        )
+        kwargs = state.fused.allreduce_multi_group.call_args_list[0].kwargs
+        self.assertTrue(kwargs["low_precision"])
+
+    def test_reduce_scatter_forwards_low_precision(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+            low_precision=True,
+        )
+        kwargs = state.fused.reduce_scatter_multi_group.call_args_list[0].kwargs
+        self.assertTrue(kwargs["low_precision"])
+
+    def test_all_to_all_forwards_low_precision(self) -> None:
+        state = _make_state(rank=0)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+            low_precision=True,
+        )
+        kwargs = state.fused.all_to_all_multi_group.call_args_list[0].kwargs
+        self.assertTrue(kwargs["low_precision"])
+
+    def test_all_gather_forwards_low_precision(self) -> None:
+        state = _make_state(rank=0)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+            low_precision=True,
+        )
+        kwargs = state.fused.all_gather_multi_group.call_args_list[0].kwargs
+        self.assertTrue(kwargs["low_precision"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:

The relay perf bench could only sweep bf16, and its snapshot basenames said
nothing about the element type. Both had to change together to measure fp32.

BENCH_SWEEP_DTYPE=fp32 (or bf16, the default) now selects the element type for
all three sweeps, joining BENCH_SWEEP_ACTIVE / BENCH_SWEEP_ONLY / BENCH_SWEEP_
MIN_MB as a sweep-axis override. It exists because bf16 and fp32 are different
tuning problems rather than one problem measured twice: fp32 sends twice the
wire bytes per element, so quantizing to fp8 saves 3.88x against bf16's 1.94x,
and the low-precision crossover lands at a smaller message.

The snapshots are now named ..._<scope>_<bf16|fp32>_[lp_]sweep_results.txt, and
that is the part that is not cosmetic. Without the dtype in the name an fp32 run
writes over the bf16 snapshot it was meant to be compared against, and the file
still looks entirely plausible afterwards -- the same stale-data failure that has
already invalidated conclusions on this workstream once. A self-test pins the
contract: six scopes x two dtypes must produce twelve distinct basenames.

Renaming the six existing files is deliberate churn. The alternative was to
suffix only the non-default dtype, which keeps bf16 paths stable but leaves the
axis invisible in `ls` and readable only by opening the file -- and the whole
point of this change is that the dtype is now a first-class tuning axis.

No behavioural change to any collective. The dtype default is unchanged, so a
bench run with no new env vars measures exactly what it measured before.

Reviewed By: JinghanHuang

Differential Revision: D118652814


