### PR TITLE
Bind TorchRec distributed test processes to NCCL2 devices

### DIFF
--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -109,6 +109,11 @@ class MultiProcessContext:
             world_size=self.world_size,
             backend=self.backend,
             local_size=self.local_size,
+            device_id=(
+                self.device
+                if self.device.type == "cuda" and "nccl" in self.backend
+                else None
+            ),
         )
         return self
 
@@ -160,6 +165,7 @@ class MultiProcessTestBase(unittest.TestCase):
         os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+        os.environ["NCCL_NET"] = "Socket"
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
         os.environ["NCCL_DEBUG"] = "WARN"
 
@@ -172,6 +178,7 @@ class MultiProcessTestBase(unittest.TestCase):
     def tearDown(self) -> None:
         torch.use_deterministic_algorithms(False)
         del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_NET"]
         del os.environ["NCCL_SOCKET_IFNAME"]
         if torch.cuda.is_available():
             os.unsetenv("CUBLAS_WORKSPACE_CONFIG")
@@ -280,6 +287,7 @@ def run_multi_process_func(
     os.environ["MASTER_ADDR"] = str("localhost")
     os.environ["MASTER_PORT"] = str(get_free_port())
     os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+    os.environ["NCCL_NET"] = "Socket"
     os.environ["NCCL_SOCKET_IFNAME"] = "lo"
 
     torch.use_deterministic_algorithms(use_deterministic_algorithms)

--- a/torchrec/distributed/test_utils/process_runner.py
+++ b/torchrec/distributed/test_utils/process_runner.py
@@ -149,7 +149,15 @@ class SingleProcessContext:
         # Start from a clean slate in case a prior group was left initialized.
         if dist.is_initialized():
             dist.destroy_process_group()
-        dist.init_process_group(backend=self.backend, timeout=self.pg_timeout)
+        dist.init_process_group(
+            backend=self.backend,
+            timeout=self.pg_timeout,
+            device_id=(
+                self.device
+                if self.device.type == "cuda" and "nccl" in self.backend
+                else None
+            ),
+        )
         self.pg = dist.group.WORLD
 
         # Handshake: make sure every rank has joined the group before the runner

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -149,13 +149,22 @@ def cuda_device_count() -> int:
 
 
 def init_distributed_single_host(
-    rank: int, world_size: int, backend: str, local_size: Optional[int] = None
+    rank: int,
+    world_size: int,
+    backend: str,
+    local_size: Optional[int] = None,
+    device_id: Optional[torch.device] = None,
 ) -> dist.ProcessGroup:
     os.environ["LOCAL_WORLD_SIZE"] = str(local_size if local_size else world_size)
     os.environ["LOCAL_RANK"] = str(rank % local_size if local_size else rank)
     if dist.is_initialized():
         dist.destroy_process_group()
-    dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+    dist.init_process_group(
+        rank=rank,
+        world_size=world_size,
+        backend=backend,
+        device_id=device_id,
+    )
     #  `Optional[_distributed_c10d.ProcessGroup]`.
     # pyrefly: ignore[bad-return]
     return dist.group.WORLD

--- a/torchrec/test_utils/tests/test_init_process_group.py
+++ b/torchrec/test_utils/tests/test_init_process_group.py
@@ -11,10 +11,14 @@ import os
 import unittest
 from contextlib import contextmanager
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import torch
 import torch.distributed as dist
-from torchrec.test_utils import init_process_group_single_rank
+from torchrec.test_utils import (
+    init_distributed_single_host,
+    init_process_group_single_rank,
+)
 
 
 @contextmanager
@@ -73,3 +77,29 @@ class InitProcessGroupSingleRankTest(unittest.TestCase):
                 init_process_group_single_rank("gloo")
 
         self.assertIn("already_initialized=True", logs.output[0])
+
+
+class InitDistributedSingleHostTest(unittest.TestCase):
+    @patch("torchrec.test_utils.dist.init_process_group")
+    @patch("torchrec.test_utils.dist.is_initialized", return_value=False)
+    def test_forwards_bound_device_to_process_group(
+        self,
+        _is_initialized: Mock,
+        init_process_group: Mock,
+    ) -> None:
+        device = torch.device("cuda:3")
+
+        init_distributed_single_host(
+            rank=3,
+            world_size=4,
+            backend="nccl",
+            local_size=2,
+            device_id=device,
+        )
+
+        init_process_group.assert_called_once_with(
+            rank=3,
+            world_size=4,
+            backend="nccl",
+            device_id=device,
+        )


### PR DESCRIPTION
Summary:
PyTorch 2.15 changes the standard nccl backend to use ProcessGroupNCCL2 by default. This default switch landed in pytorch/pytorch#192281 (internal D118216377) on September 1, 2026. An unset TORCH_DIST_USE_NCCL2 or a value of 1 now selects NCCL2; TORCH_DIST_USE_NCCL2=0 and the explicit nccl-legacy backend remain rollback paths.

The regression was reported as:

    AssertionError: 4 != 0: Detected at least one unsuccessful run
    RuntimeError: Failed to initialize NCCL communicator: invalid usage
    NCCL Last Error: Failed to initialize any NET plugin

After selecting the local Socket transport, NCCL2 exposed the device-selection issue directly:

    NCCL Last Error: Duplicate GPU detected: rank 2 and rank 0 both on CUDA device 1b000

Pass each worker's selected CUDA device to init_process_group so NCCL2 does not infer the device from LOCAL_RANK. This preserves the synthetic hierarchical test topology, where LOCAL_RANK models a two-GPU node while each of the four local workers owns a distinct physical GPU.

Apply the same explicit device binding to the torchrun-style process runner. Force local multiprocess tests to use NCCL Socket over loopback so machine-wide IB configuration does not affect single-host unit tests. Add coverage that verifies the bound device is forwarded to PyTorch.

Differential Revision: D118822771


