### PR TITLE
Skip Dynamo tests when unsupported

### DIFF
--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -109,6 +109,11 @@ class MultiProcessContext:
             world_size=self.world_size,
             backend=self.backend,
             local_size=self.local_size,
+            device_id=(
+                self.device
+                if self.device.type == "cuda" and "nccl" in self.backend
+                else None
+            ),
         )
         return self
 
@@ -160,6 +165,7 @@ class MultiProcessTestBase(unittest.TestCase):
         os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+        os.environ["NCCL_NET"] = "Socket"
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
         os.environ["NCCL_DEBUG"] = "WARN"
 
@@ -172,6 +178,7 @@ class MultiProcessTestBase(unittest.TestCase):
     def tearDown(self) -> None:
         torch.use_deterministic_algorithms(False)
         del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_NET"]
         del os.environ["NCCL_SOCKET_IFNAME"]
         if torch.cuda.is_available():
             os.unsetenv("CUBLAS_WORKSPACE_CONFIG")
@@ -280,6 +287,7 @@ def run_multi_process_func(
     os.environ["MASTER_ADDR"] = str("localhost")
     os.environ["MASTER_PORT"] = str(get_free_port())
     os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+    os.environ["NCCL_NET"] = "Socket"
     os.environ["NCCL_SOCKET_IFNAME"] = "lo"
 
     torch.use_deterministic_algorithms(use_deterministic_algorithms)

--- a/torchrec/distributed/test_utils/process_runner.py
+++ b/torchrec/distributed/test_utils/process_runner.py
@@ -149,7 +149,15 @@ class SingleProcessContext:
         # Start from a clean slate in case a prior group was left initialized.
         if dist.is_initialized():
             dist.destroy_process_group()
-        dist.init_process_group(backend=self.backend, timeout=self.pg_timeout)
+        dist.init_process_group(
+            backend=self.backend,
+            timeout=self.pg_timeout,
+            device_id=(
+                self.device
+                if self.device.type == "cuda" and "nccl" in self.backend
+                else None
+            ),
+        )
         self.pg = dist.group.WORLD
 
         # Handshake: make sure every rank has joined the group before the runner

--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -26,6 +26,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
 from hypothesis import given, settings, strategies as st
+from torch._dynamo import is_dynamo_supported
 from torch._dynamo.testing import reduce_to_scalar_loss
 from torchrec.distributed.test_utils.infer_utils import (
     KJTInputExportDynamicShapeWrapper,
@@ -272,6 +273,7 @@ def _test_compile_fwd_bwd(
             _assert_close(compile_bwd_out, eager_bwd_out)
 
 
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 @unittest.skipIf(
     _is_free_threaded(),
     "torch.compile/torch.export segfaults on free-threaded Python, "

--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -25,6 +25,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
 )
 from hypothesis import given, settings, strategies as st, Verbosity
 from torch import distributed as dist
+from torch._dynamo import is_dynamo_supported
 from torch._dynamo.testing import reduce_to_scalar_loss
 from torch.distributed import ProcessGroup
 from torch.testing._internal.distributed.fake_pg import FakeStore
@@ -708,6 +709,7 @@ def _test_compile_fake_pg_fn(
     ##### COMPILE END #####
 
 
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 class TestPt2Train(MultiProcessTestBase):
     def disable_cuda_tf32(self) -> bool:
         return True

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -14,6 +14,7 @@ from typing import cast, List, NamedTuple, Optional, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import torch
+from torch._dynamo import is_dynamo_supported
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.test_utils.test_model import (
     ModelInput,
@@ -148,6 +149,7 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         self.assertEqual(missing_keys, [])
         self.assertEqual(unexpected_keys, [])
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     @unittest.skipIf(
         not torch.cuda.is_available(),
         "Not enough GPUs, this test requires at least one GPU",

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import torch
 from torch import no_grad
+from torch._dynamo import is_dynamo_supported
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import (
@@ -99,6 +100,7 @@ def generate_compile_model_output() -> Dict[str, torch.Tensor]:
     }
 
 
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 class AUCMetricCompileTest(unittest.TestCase):
     def test_auc_compile(self) -> None:
         # AUCMetricComputation.update windows the raw inputs as a growing list of

--- a/torchrec/metrics/tests/test_xauc.py
+++ b/torchrec/metrics/tests/test_xauc.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import torch
 import torch._dynamo
+from torch._dynamo import is_dynamo_supported
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.xauc import XAUCMetric
 
@@ -65,6 +66,7 @@ class XAUCMetricTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     @unittest.skipIf(
         _is_free_threaded(),
         "torch.compile segfaults on free-threaded Python, "

--- a/torchrec/models/tests/test_cuda_graph.py
+++ b/torchrec/models/tests/test_cuda_graph.py
@@ -26,6 +26,7 @@ import time
 import unittest
 
 import torch
+from torch._dynamo import is_dynamo_supported
 from torchrec.models.cuda_graph_utils import build_dlrm, collect_outputs, generate_batch
 from torchrec.models.dlrm import DLRM
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -63,6 +64,7 @@ def _gen_batch(device: torch.device) -> tuple[torch.Tensor, KeyedJaggedTensor]:
     )
 
 
+@unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA Graphs require a GPU")
 class DLRMCudaGraphTest(unittest.TestCase):
     @torch.inference_mode()

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -14,6 +14,7 @@ from typing import List
 import torch
 from parameterized import parameterized
 from torch import nn
+from torch._dynamo import is_dynamo_supported
 from torch.testing import FileCheck  # @manual
 from torchrec.datasets.utils import Batch
 from torchrec.distributed.test_utils.model_input import ModelInput
@@ -415,6 +416,7 @@ class DLRMTest(unittest.TestCase):
             )
         )
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_compile_dense_path(self) -> None:
         # compile_dense_path() wraps the dense compute path (dense_arch,
         # inter_arch, over_arch) with torch.compile. Wrapping is lazy -- no graph

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -14,6 +14,7 @@ from typing import Callable, Dict, List, Tuple
 import torch
 import torch.utils._pytree as pytree
 from hypothesis import assume, given, settings, strategies as st, Verbosity
+from torch._dynamo import is_dynamo_supported
 from torch.fx._pytree import tree_flatten_spec
 from torchrec.sparse.jagged_tensor import (
     _fbgemm_permute_pooled_embs,
@@ -1203,6 +1204,7 @@ class TritonPermuteMultiEmbeddingTest(unittest.TestCase):
             torch.testing.assert_close(output, reference, rtol=0, atol=0)
         self._assert_gradients_close(actual_grads, expected_grads, torch.float32)
 
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
     def test_compile_forward_and_backward(self) -> None:
         values, references, permutes, in_shapes, out_shapes, out_lengths = self._inputs(

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -149,13 +149,22 @@ def cuda_device_count() -> int:
 
 
 def init_distributed_single_host(
-    rank: int, world_size: int, backend: str, local_size: Optional[int] = None
+    rank: int,
+    world_size: int,
+    backend: str,
+    local_size: Optional[int] = None,
+    device_id: Optional[torch.device] = None,
 ) -> dist.ProcessGroup:
     os.environ["LOCAL_WORLD_SIZE"] = str(local_size if local_size else world_size)
     os.environ["LOCAL_RANK"] = str(rank % local_size if local_size else rank)
     if dist.is_initialized():
         dist.destroy_process_group()
-    dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+    dist.init_process_group(
+        rank=rank,
+        world_size=world_size,
+        backend=backend,
+        device_id=device_id,
+    )
     #  `Optional[_distributed_c10d.ProcessGroup]`.
     # pyrefly: ignore[bad-return]
     return dist.group.WORLD

--- a/torchrec/test_utils/tests/test_init_process_group.py
+++ b/torchrec/test_utils/tests/test_init_process_group.py
@@ -11,10 +11,14 @@ import os
 import unittest
 from contextlib import contextmanager
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import torch
 import torch.distributed as dist
-from torchrec.test_utils import init_process_group_single_rank
+from torchrec.test_utils import (
+    init_distributed_single_host,
+    init_process_group_single_rank,
+)
 
 
 @contextmanager
@@ -73,3 +77,29 @@ class InitProcessGroupSingleRankTest(unittest.TestCase):
                 init_process_group_single_rank("gloo")
 
         self.assertIn("already_initialized=True", logs.output[0])
+
+
+class InitDistributedSingleHostTest(unittest.TestCase):
+    @patch("torchrec.test_utils.dist.init_process_group")
+    @patch("torchrec.test_utils.dist.is_initialized", return_value=False)
+    def test_forwards_bound_device_to_process_group(
+        self,
+        _is_initialized: Mock,
+        init_process_group: Mock,
+    ) -> None:
+        device = torch.device("cuda:3")
+
+        init_distributed_single_host(
+            rank=3,
+            world_size=4,
+            backend="nccl",
+            local_size=2,
+            device_id=device,
+        )
+
+        init_process_group.assert_called_once_with(
+            rank=3,
+            world_size=4,
+            backend="nccl",
+            device_id=device,
+        )


### PR DESCRIPTION
Summary:
- Skip TorchRec compile and Dynamo-backed export tests when PyTorch reports Dynamo is unsupported.
- Cover PT2, distributed pipeline, metrics, DLRM, CUDA Graph, and keyed-tensor compiler tests.
- Preserve eager-only coverage on Python 3.15 and Python 3.15 free-threaded.
- Automatically restore compiler coverage when upstream PyTorch enables Dynamo support.

Differential Revision: D118840402


