### PR TITLE
Load strictly in the _trained_batches compat test (#4672)

### DIFF
--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -1089,7 +1089,9 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         state_dict["_trained_batches"] = torch.tensor(100)
 
         fresh_module = self._create_rec_metric_module()
-        fresh_module.load_state_dict(state_dict, strict=False)
+        # strict=True matches production. Under strict=False this test passes
+        # even without the pop hook.
+        fresh_module.load_state_dict(state_dict, strict=True)
 
 
 class MetricCoverageTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

This diff makes the `_trained_batches` compatibility test load strictly.

`RecMetricModule` pops `_trained_batches` out of the state dict when it loads. The test that covers that pop calls `load_state_dict` with `strict=False`, which ignores unexpected keys. So the test passes even when the hook is gone.

This diff switches the call to `strict=True`, which is what production does. Delete the pop hook now and the test fails.

Reviewed By: jeffkbkim

Differential Revision: D118901825


