### PR TITLE
Rebalance unit test CI matrices

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -58,11 +58,13 @@ jobs:
             tag: "py313"
           - version: "3.14"
             tag: "py314"
+            free_threaded: false
           - version: "3.14"
             tag: "py314"
             free_threaded: true
           - version: "3.15"
             tag: "py315"
+            free_threaded: false
           - version: "3.15"
             tag: "py315"
             free_threaded: true
@@ -73,6 +75,40 @@ jobs:
         exclude:
           - is_pr: true
             cuda-tag: "cu126"
+            python:
+              version: "3.11"
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.12"
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.13"
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.14"
+              free_threaded: false
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.14"
+              free_threaded: true
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.15"
+              free_threaded: false
+          - is_pr: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.15"
+              free_threaded: true
+          - is_pr: true
+            cuda-tag: "cu130"
+            python:
+              version: "3.10"
           - is_pr: true
             cuda-tag: "cu130"
             python:
@@ -89,15 +125,12 @@ jobs:
             cuda-tag: "cu130"
             python:
               version: "3.15"
+              free_threaded: false
           - is_pr: true
             cuda-tag: "cu130"
             python:
-              version: "3.15"
+              version: "3.14"
               free_threaded: true
-          - is_main_push: true
-            cuda-tag: "cu126"
-            python:
-              version: "3.12"
           - is_main_push: true
             cuda-tag: "cu126"
             python:
@@ -105,7 +138,13 @@ jobs:
           - is_main_push: true
             cuda-tag: "cu126"
             python:
+              version: "3.14"
+              free_threaded: false
+          - is_main_push: true
+            cuda-tag: "cu126"
+            python:
               version: "3.15"
+              free_threaded: false
           - is_main_push: true
             cuda-tag: "cu126"
             python:
@@ -119,6 +158,15 @@ jobs:
             cuda-tag: "cu130"
             python:
               version: "3.11"
+          - is_main_push: true
+            cuda-tag: "cu130"
+            python:
+              version: "3.12"
+          - is_main_push: true
+            cuda-tag: "cu130"
+            python:
+              version: "3.14"
+              free_threaded: true
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -57,20 +57,21 @@ jobs:
             tag: "py313"
           - version: "3.14"
             tag: "py314"
+            free_threaded: false
           - version: "3.14"
             tag: "py314"
             free_threaded: true
           - version: "3.15"
             tag: "py315"
+            free_threaded: false
           - version: "3.15"
             tag: "py315"
             free_threaded: true
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
+        is_main_push:  # for main branch
+          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         exclude:
-          - is_pr: true
-            python:
-              version: "3.10"
           - is_pr: true
             python:
               version: "3.11"
@@ -82,7 +83,17 @@ jobs:
               version: "3.13"
           - is_pr: true
             python:
-              version: "3.14"
+              version: "3.15"
+              free_threaded: false
+          - is_main_push: true
+            python:
+              version: "3.11"
+          - is_main_push: true
+            python:
+              version: "3.13"
+          - is_main_push: true
+            python:
+              version: "3.15"
               free_threaded: true
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 
+import sys
 import unittest
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -513,6 +514,10 @@ class DedupIndicesWeightAccumulationTest(unittest.TestCase):
         self.assertAlmostEqual(acc_weights[idx_2_pos, 0].item(), 4.0, places=5)
 
 
+@unittest.skipIf(
+    sys.version_info >= (3, 15),
+    "TensorDict sequence model parallel tests do not support Python 3.15+",
+)
 @skip_if_asan_class
 class TDSequenceModelParallelTest(SequenceModelParallelTest):
 

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 
+import sys
 import unittest
 from typing import Callable, Dict, List, Tuple
 
@@ -27,7 +28,7 @@ from torchrec.sparse.jagged_tensor import (
 from torchrec.sparse.tests.utils import build_groups, build_kts
 from torchrec.test_utils import skip_if_asan_class
 
-if torch.cuda.is_available():
+if sys.version_info < (3, 15) and torch.cuda.is_available():
     from torchrec.sparse.triton_permute_multi_embedding import (
         triton_permute_multi_embedding,
     )
@@ -1078,6 +1079,10 @@ class TestKeyedTensorGPU(unittest.TestCase):
         torch.allclose(actual_kt_1_grad, expected_kt_1_grad)
 
 
+@unittest.skipIf(
+    sys.version_info >= (3, 15),
+    "Triton is not available on Python 3.15+",
+)
 class TritonPermuteMultiEmbeddingTest(unittest.TestCase):
     def _inputs(
         self,


### PR DESCRIPTION
Summary:
Reduce routine CI capacity usage while preserving broad compatibility coverage.

Capacity impact:

| Trigger | Previous jobs | New jobs | Change |
| --- | --- | --- | --- |
| PR | 6 | 7 | +1 |
| Main | 18 | 13 | -5 |
| Nightly | 24 | 24 | No change |

- Save five jobs on every main push by removing three CPU jobs and two duplicate GPU jobs.
- Keep pull-request GPU usage unchanged at three jobs.
- Limit the pull-request increase to one CPU job.
- Preserve the complete CPU and GPU matrices in nightly CI.
- Mark regular Python 3.14 and 3.15 entries as non-free-threaded so exclusions cannot also match their free-threaded variants.
- Skip TDSequenceModelParallelTest on Python 3.15 and newer, where the TensorDict sequence model parallel tests are unsupported.
- Avoid importing unavailable Triton test dependencies on Python 3.15 and newer, and skip TritonPermuteMultiEmbeddingTest to prevent collection failures.

Resulting allocation:

| Trigger | Runner | CUDA | Python versions | Jobs |
| --- | --- | --- | --- | --- |
| PR | CPU | — | 3.10, 3.14, 3.14 free-threaded, 3.15 free-threaded | 4 |
| PR | GPU | cu126 | 3.10 | 1 |
| PR | GPU | cu130 | 3.14, 3.15 free-threaded | 2 |
| PR total | | | | 7 |
| Main | CPU | — | 3.10, 3.12, 3.14, 3.14 free-threaded, 3.15 | 5 |
| Main | GPU | cu126 | 3.10, 3.11, 3.12, 3.14 free-threaded | 4 |
| Main | GPU | cu130 | 3.13, 3.14, 3.15, 3.15 free-threaded | 4 |
| Main total | | | | 13 |
| Nightly | CPU | — | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14 free-threaded, 3.15, 3.15 free-threaded | 8 |
| Nightly | GPU | cu126 | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14 free-threaded, 3.15, 3.15 free-threaded | 8 |
| Nightly | GPU | cu130 | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14 free-threaded, 3.15, 3.15 free-threaded | 8 |
| Nightly total | | | | 24 |

Differential Revision: D118925983


