### PR TITLE
fix(quant_state): admit sharded FeatureProcessedEBC in the weights spec

### DIFF
--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -469,7 +469,7 @@ def sharded_tbes_weights_spec(
             "ShardedQuantManagedCollisionEmbeddingBagCollection" in type_name
         )
 
-        if is_sqebc or is_sqec or is_sqmcec or is_sqebc or is_sqmcebc:
+        if is_sqebc or is_sqec or is_sqmcec or is_sfpebc or is_sqmcebc:
             assert (
                 is_sqec + is_sqebc + is_sqmcec + is_sfpebc + is_sqmcebc == 1
             ), "Cannot have any two of ShardedQuantEmbeddingBagCollection, ShardedQuantEmbeddingCollection, ShardedQuantManagedCollisionEmbeddingCollection, ShardedQuantFeatureProcessedEmbeddingBagCollection and ShardedQuantManagedCollisionEmbeddingBagCollection are true"


### PR DESCRIPTION
### Problem

`sharded_tbes_weights_spec` in `torchrec/distributed/quant_state.py` derives five flags from the module type name and then gates on them:

```python
is_sqebc:   bool = "ShardedQuantEmbeddingBagCollection" in type_name
is_sqec:    bool = "ShardedQuantEmbeddingCollection" in type_name
is_sqmcec:  bool = "ShardedQuantManagedCollisionEmbeddingCollection" in type_name
is_sfpebc:  bool = "ShardedQuantFeatureProcessedEmbeddingBagCollection" in type_name
is_sqmcebc: bool = "ShardedQuantManagedCollisionEmbeddingBagCollection" in type_name

if is_sqebc or is_sqec or is_sqmcec or is_sqebc or is_sqmcebc:
    assert (
        is_sqec + is_sqebc + is_sqmcec + is_sfpebc + is_sqmcebc == 1
    ), "Cannot have any two of ... and ShardedQuantFeatureProcessedEmbeddingBagCollection ... are true"
```

`is_sqebc` appears twice in the gate and `is_sfpebc` is never tested, even though the assert on the next line — and the branch body — both use it.

### Impact

`"ShardedQuantFeatureProcessedEmbeddingBagCollection"` does not contain any of the other four substrings (`"ShardedQuantEmbeddingBagCollection"` is not a substring of it — `FeatureProcessed` sits in the middle), so `is_sfpebc` is the only flag true for those modules and nothing else lets them in. Sharded `ShardedQuantFeatureProcessedEmbeddingBagCollection` modules are therefore skipped entirely and contribute **no** `WeightSpec` entries to the returned mapping.

The same omission makes the `is_sfpebc` branch of `get_param_id_from_type` dead:

```python
def get_param_id_from_type(is_sqebc: bool, is_sqmcec: bool, is_sfpebc: bool) -> str:
    ...
    elif is_sfpebc:
        return "_embedding_bag_collection.embedding_bags"
```

It is called as `get_param_id_from_type(is_sqebc, is_sqmcec, is_sfpebc)` inside the branch that `is_sfpebc` can never enter.

### Fix

```python
    if is_sqebc or is_sqec or is_sqmcec or is_sfpebc or is_sqmcebc:
```

### Verification

I lifted the real gate expression out of the file before and after the patch (`git show HEAD:…` vs the working copy), recomputed the five flags from each sharded type name exactly as the source does, and evaluated both gates:

```
sharded module type                                  handled?  handled?  assert sum==1
                                                     (before)  (after)
ShardedQuantEmbeddingBagCollection                   True      True      1
ShardedQuantEmbeddingCollection                      True      True      1
ShardedQuantManagedCollisionEmbeddingCollection      True      True      1
ShardedQuantFeatureProcessedEmbeddingBagCollection   False     True      1   <== CHANGED
ShardedQuantManagedCollisionEmbeddingBagCollection   True      True      1

changed rows: 1 / 5
```

Only the previously-skipped type changes, and its flag sum is `1`, so it satisfies the assert it now reaches. The other four keep their existing behaviour.

`black` 24.2.0 (the version `.pre-commit-config.yaml` pins for `ufmt`) reports the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
