### PR TITLE
Restore Python 3.15 wheel matrix entries

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -63,9 +63,9 @@ def main():
         if entry["desired_cuda"] in ("cu132", "cu134"):
             # Keep TorchRec's matrix within FBGEMM wheel support.
             continue
-        if entry["python_version"] in ("3.15", "3.15t"):
-            # fbgemm-gpu does not support python3.15 yet
-            # Re-enable once fbgemm-gpu releases python3.15 nightly builds
+        if entry["python_version"] in ("3.16", "3.16t"):
+            # fbgemm-gpu does not support python3.16 yet
+            # Re-enable once fbgemm-gpu releases python3.16 nightly builds
             continue
         new_matrix_entries.append(entry)
 


### PR DESCRIPTION
Summary:
- Restore Python 3.15 and Python 3.15 free-threaded entries in the nightly wheel matrix.
- Filter Python 3.16 and Python 3.16 free-threaded until FBGEMM publishes compatible nightly wheels.
- Continue filtering cu132 and cu134 entries to match FBGEMM wheel support.

Differential Revision: D118968077


