### PR TITLE
Return zeros on inference cache miss in embedding cache mode (#4676)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -280,6 +280,7 @@ def create_sharding_infos_by_sharding_device_group(
                         stash_weights=MemoryStashingManager.resolve_stash_weights(
                             table_name, config
                         ),
+                        enable_embedding_update=config.enable_embedding_update,
                     ),
                     param_sharding=parameter_sharding,
                     param=param,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3135

### Summary
#### [KVZCH] Enable random init

This diff enables the random initialization of weights in the KV embedding inference wrapper.

The change is done in three stages:

*   In `dram_kv_embedding_inference_wrapper.cpp`, we added a new tensor to the results containing whether random initialization is disabled.
*   In `dram_kv_inference_embedding.h`, we changed the default value of `disable_random_init` to be a variable instead of `false`. This allows the user to choose whether to disable random initialization.
*   In `KVInferenceWrapperTest.cpp`, we updated the test to include the new tensor in the serialized results.

With this change, users can now choose to disable random initialization of weights in the KV embedding inference wrapper.

Reviewed By: emlin, EddyLXJ

Differential Revision: D118223145


