### PR TITLE
Require a record before regenerating a golden that changes shape (#4680)

### DIFF
--- a/torchrec/checkpoint/__init__.py
+++ b/torchrec/checkpoint/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/checkpoint/schema.py
+++ b/torchrec/checkpoint/schema.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Marks a module's state_dict key set as a compatibility surface.
+
+Adding, removing, or renaming persistent state changes the keys a module writes
+to a checkpoint. Old checkpoints then fail to load. Decorating a class with
+``@checkpoint_schema_stable("some_id")`` enrolls it in the golden-snapshot test,
+so the next key-set change on it has to be acknowledged at diff submission time.
+
+The decorator has no effect at load time. It records the class so tests can
+find it.
+"""
+
+from typing import Callable, Dict, Type, TypeVar
+
+_C = TypeVar("_C", bound=type)
+
+
+def _qualname(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+# Stable id -> the class that claimed it.
+_SCHEMA_STABLE_CLASSES: Dict[str, Type[object]] = {}
+
+
+def checkpoint_schema_stable(stable_id: str) -> Callable[[_C], _C]:
+    """Enroll a class in the golden-snapshot test under ``stable_id``.
+
+    The id is written by hand rather than derived from the class, so moving a
+    file or renaming a module does not silently change the golden key and
+    abandon the entry it used to match. Two classes sharing a bare name pick
+    different ids, e.g. ``embedding_bag_collection.float`` and
+    ``embedding_bag_collection.quantized``.
+
+    Two different classes claiming one id raises: the second would otherwise
+    shadow the first and quietly take over its snapshot. Re-registering the same
+    class is allowed, so a module reload does not become an import failure.
+
+    Registration happens at import, so the registry only holds classes the
+    importing target depends on. A decorated class in a module nothing imports
+    stays invisible. The paired coverage test cross-checks the registry against
+    its own case list, which catches divergence between those two, but neither
+    can see a module that was never imported.
+    """
+    if not stable_id or stable_id != stable_id.strip():
+        raise ValueError(f"stable_id must be non-empty and unpadded, got {stable_id!r}")
+
+    def decorate(cls: _C) -> _C:
+        existing = _SCHEMA_STABLE_CLASSES.get(stable_id)
+        if existing is not None and _qualname(existing) != _qualname(cls):
+            raise ValueError(
+                f"{stable_id!r} is already registered to "
+                f"{_qualname(existing)}; {_qualname(cls)} cannot reuse it."
+            )
+        _SCHEMA_STABLE_CLASSES[stable_id] = cls
+        return cls
+
+    return decorate
+
+
+def registered_schema_stable_classes() -> Dict[str, Type[object]]:
+    """Every registered class, keyed by stable id."""
+    return dict(_SCHEMA_STABLE_CLASSES)

--- a/torchrec/checkpoint/tests/test_schema.py
+++ b/torchrec/checkpoint/tests/test_schema.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""The registry's contracts, none of which importing a decorated class exercises.
+
+A stable id is the name a golden entry is filed under. If one can be blank, or
+carry stray whitespace, or be claimed by a second class, the entry it points at
+stops describing the class that wrote it.
+"""
+
+import unittest
+from typing import Type
+
+from torchrec.checkpoint import schema
+from torchrec.checkpoint.schema import (
+    checkpoint_schema_stable,
+    registered_schema_stable_classes,
+)
+
+
+def _make_class(qualname: str, module: str = "torchrec.fake") -> Type[object]:
+    """A class with a controlled identity.
+
+    Two calls with the same name give two distinct objects that look identical
+    to the registry, which is what a module reload produces.
+    """
+    cls = type(qualname, (), {})
+    cls.__module__ = module
+    cls.__qualname__ = qualname
+    return cls
+
+
+class CheckpointSchemaStableTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # The registry is module-level, so a test that registers anything would
+        # otherwise leak into the next one and into the real entries.
+        previous = dict(schema._SCHEMA_STABLE_CLASSES)
+        self.addCleanup(schema._SCHEMA_STABLE_CLASSES.update, previous)
+        self.addCleanup(schema._SCHEMA_STABLE_CLASSES.clear)
+
+    def test_rejects_an_empty_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-empty and unpadded"):
+            checkpoint_schema_stable("")
+
+    def test_rejects_a_padded_id(self) -> None:
+        for stable_id in (" widget", "widget ", "\twidget", "widget\n"):
+            with self.subTest(stable_id=stable_id):
+                with self.assertRaisesRegex(ValueError, "non-empty and unpadded"):
+                    checkpoint_schema_stable(stable_id)
+
+    def test_rejects_a_second_class_under_one_id(self) -> None:
+        checkpoint_schema_stable("widget")(_make_class("Widget"))
+        with self.assertRaisesRegex(ValueError, "cannot reuse it"):
+            checkpoint_schema_stable("widget")(_make_class("Gadget"))
+
+    def test_a_reloaded_class_may_reclaim_its_id(self) -> None:
+        # Same module and qualname, different object — what reimporting a module
+        # produces. Raising here would turn a reload into an import failure.
+        first = _make_class("Widget")
+        second = _make_class("Widget")
+        self.assertIsNot(first, second)
+
+        checkpoint_schema_stable("widget")(first)
+        checkpoint_schema_stable("widget")(second)
+
+        # The later registration wins, so the registry tracks the live class.
+        self.assertIs(registered_schema_stable_classes()["widget"], second)
+
+    def test_returns_the_class_unchanged(self) -> None:
+        cls = _make_class("Widget")
+        self.assertIs(checkpoint_schema_stable("widget")(cls), cls)
+
+    def test_the_registry_view_is_a_copy(self) -> None:
+        checkpoint_schema_stable("widget")(_make_class("Widget"))
+        view = registered_schema_stable_classes()
+        view.clear()
+        self.assertIn("widget", registered_schema_stable_classes())

--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -13,6 +13,7 @@ import torch.distributed as dist
 from torch import nn
 from torch.distributed.tensor import DeviceMesh
 from torch.profiler import record_function
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.metric_module import PreComputeStates, RecMetricModule
 from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
 from torchrec.metrics.rec_metric import (
@@ -25,6 +26,7 @@ from torchrec.metrics.rec_metric import (
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@checkpoint_schema_stable("cpu_comms_rec_metric_module")
 class CPUCommsRecMetricModule(RecMetricModule):
     """
     A submodule of CPUOffloadedRecMetricModule.

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -61,6 +61,7 @@ except Exception:
                 pass
 
 
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.distributed.logging_utils import EventType
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.deferrable_metrics import (
@@ -297,6 +298,7 @@ def _foreach_clone_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
     return out
 
 
+@checkpoint_schema_stable("cpu_offloaded_rec_metric_module")
 class CPUOffloadedRecMetricModule(RecMetricModule):
     """
     RecMetricModule that offloads metric update() and compute() to CPU using background threads.

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -62,6 +62,7 @@ except Exception:
                 pass
 
 
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.accuracy import AccuracyMetric
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.auprc import AUPRCMetric
@@ -196,6 +197,7 @@ class StateMetric(abc.ABC):
         pass
 
 
+@checkpoint_schema_stable("RecMetricModule")
 class RecMetricModule(nn.Module):
     r"""
     For the current recommendation models, we assume there will be three

--- a/torchrec/metrics/noop_metric_module.py
+++ b/torchrec/metrics/noop_metric_module.py
@@ -13,10 +13,12 @@ from typing import Any, Dict, List, Optional, Union
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DeviceMesh
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.deferrable_metrics import DeferrableMetrics
 from torchrec.metrics.metric_module import MetricValue, RecMetricModule
 
 
+@checkpoint_schema_stable("noop_metric_module")
 class NoOpMetricModule(RecMetricModule):
     """
     A no-op implementation of RecMetricModule for when metrics

--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -529,5 +529,36 @@
       "_metrics_computations.0.weighted_num_pairs"
     ],
     "variant": ""
+  },
+  "cpu_comms_rec_metric_module": {
+    "metric_class": "CPUCommsRecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "cpu_offloaded_rec_metric_module": {
+    "metric_class": "CPUOffloadedRecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "noop_metric_module": {
+    "metric_class": "NoOpMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [],
+    "variant": ""
   }
 }

--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -143,17 +143,6 @@
     ],
     "variant": "with_r_squared"
   },
-  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
-    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
-    "metric_class": "MulticlassRecallMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "_metrics_computations.0.total_weights",
-      "_metrics_computations.0.tp_at_k"
-    ],
-    "variant": ""
-  },
   "MultiLabelPrecisionMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "MultiLabelPrecisionMetric",
@@ -162,6 +151,17 @@
     "state_dict_keys": [
       "_metrics_computations.0.false_pos_sum_label_0",
       "_metrics_computations.0.true_pos_sum_label_0"
+    ],
+    "variant": ""
+  },
+  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
+    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
+    "metric_class": "MulticlassRecallMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "_metrics_computations.0.total_weights",
+      "_metrics_computations.0.tp_at_k"
     ],
     "variant": ""
   },
@@ -201,19 +201,6 @@
       "_metrics_computations.0.weighted_num_samples"
     ],
     "variant": ""
-  },
-  "NEMetric_UNFUSED_TASKS_COMPUTATION_with_logloss": {
-    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
-    "metric_class": "NEMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "_metrics_computations.0.cross_entropy_sum",
-      "_metrics_computations.0.neg_labels",
-      "_metrics_computations.0.pos_labels",
-      "_metrics_computations.0.weighted_num_samples"
-    ],
-    "variant": "with_logloss"
   },
   "NEPositiveMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -1089,7 +1089,9 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         state_dict["_trained_batches"] = torch.tensor(100)
 
         fresh_module = self._create_rec_metric_module()
-        fresh_module.load_state_dict(state_dict, strict=False)
+        # strict=True matches production. Under strict=False this test passes
+        # even without the pop hook.
+        fresh_module.load_state_dict(state_dict, strict=True)
 
 
 class MetricCoverageTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -27,11 +27,15 @@ To update the golden snapshot after intentional changes:
 """
 
 import contextlib
+import copy
+import datetime
 import inspect
 import json
 import os
 import sys
+import tempfile
 import unittest
+import unittest.mock
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -42,6 +46,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -369,18 +374,22 @@ def load_golden_snapshot() -> Dict[str, Dict[str, Any]]:
 
 
 def load_required_golden_snapshot() -> Dict[str, Dict[str, Any]]:
-    """The snapshot, for tests that say nothing useful without one.
+    """The snapshot, for callers that say nothing useful without one.
 
-    An empty file makes a set-difference check pass by having nothing to
+    A test comparing against an empty file passes by having nothing to
     compare, which reads as coverage.
+
+    Regeneration against an empty baseline is worse: every generated entry
+    looks brand new, so the addition and removal gates find nothing to object
+    to and the result becomes the baseline. Emptying this file is the cheapest
+    way to defeat them.
     """
     snapshot = load_golden_snapshot()
     if not snapshot:
         raise RuntimeError(
-            f"{GOLDEN_SNAPSHOT_PATH} is missing or empty. Run with "
-            "--update-golden to generate it.\n"
-            "Regenerating from a test would write whatever the code currently "
-            "produces, and each class knows only its own part of the file."
+            f"{GOLDEN_SNAPSHOT_PATH} is missing or empty. It is checked in, so "
+            "restore it from source control rather than writing a new one. A "
+            "regenerated baseline authorizes whatever the code produces today."
         )
     return snapshot
 
@@ -1057,6 +1066,214 @@ class SchemaStableCoverageTest(unittest.TestCase):
                 f"{first.__name__} and {case.expected_class.__name__}.",
             )
         self.assertEqual(registered_schema_stable_classes(), declared)
+
+
+class SchemaChangeTest(unittest.TestCase):
+    """Regenerating must not quietly bless a changed key set.
+
+    The comparison already fails on an added or removed key. The hole was the
+    escape hatch: --update-golden rewrote the file unconditionally, and the
+    failing test names that command, so silencing a real break took one step.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.golden_snapshot = load_golden_snapshot()
+
+    def test_unauthorized_addition_is_reported(self) -> None:
+        old = {"Thing": {"state_dict_keys": ["a"]}}
+        new = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        self.assertEqual(unauthorized_additions(old, new), {"Thing": ["b"]})
+
+    def test_authorized_addition_is_allowed(self) -> None:
+        old = {"Thing": {"state_dict_keys": ["a"]}}
+        new = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        self.assertEqual(
+            unauthorized_additions(old, new, (_make_record("Thing", "b"),)), {}
+        )
+
+    def test_a_brand_new_entry_needs_no_authorization(self) -> None:
+        old: Dict[str, Dict[str, Any]] = {}
+        new = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        self.assertEqual(unauthorized_additions(old, new), {})
+
+    def test_a_dropped_entry_is_reported(self) -> None:
+        old = {"Thing": {"state_dict_keys": ["a"]}}
+        new: Dict[str, Dict[str, Any]] = {}
+        self.assertEqual(removed_entries(old, new), ["Thing"])
+
+    def test_a_rename_that_adds_a_key_cannot_hide(self) -> None:
+        """The gap the addition check alone leaves open.
+
+        Renaming the class moves the entry to a new key, so the added state key
+        rides in under the brand-new exemption. Only the dropped old entry
+        gives it away.
+        """
+        old = {"Thing": {"state_dict_keys": ["a"]}}
+        new = {"RenamedThing": {"state_dict_keys": ["a", "b"]}}
+        self.assertEqual(unauthorized_additions(old, new), {})
+        self.assertEqual(removed_entries(old, new), ["Thing"])
+
+    def test_unauthorized_removal_is_reported(self) -> None:
+        old = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        new = {"Thing": {"state_dict_keys": ["a"]}}
+        self.assertEqual(unauthorized_removals(old, new), {"Thing": ["b"]})
+
+    def test_authorized_removal_is_allowed(self) -> None:
+        old = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        new = {"Thing": {"state_dict_keys": ["a"]}}
+        self.assertEqual(
+            unauthorized_removals(old, new, (_make_removal("Thing", "b"),)), {}
+        )
+
+    def test_a_dropped_entry_is_left_to_removed_entries(self) -> None:
+        """Otherwise a rename reports every key twice, once per gate."""
+        old = {"Thing": {"state_dict_keys": ["a", "b"]}}
+        new: Dict[str, Dict[str, Any]] = {}
+        self.assertEqual(unauthorized_removals(old, new), {})
+        self.assertEqual(removed_entries(old, new), ["Thing"])
+
+    def test_configured_records_are_not_stale(self) -> None:
+        """Both registries checked in one place, so neither can run empty.
+
+        Looping over the registries meant zero assertions while they are empty,
+        which reads as coverage. The detectors themselves are pinned by the
+        synthetic tests below.
+        """
+        self.assertEqual(stale_records(_SCHEMA_ADDITIONS, self.golden_snapshot), [])
+        self.assertEqual(
+            stale_removal_records(_SCHEMA_REMOVALS, self.golden_snapshot), []
+        )
+
+    def test_stale_removal_records_are_detected(self) -> None:
+        # Staleness inverts: the key must be gone, not present.
+        snapshot = {"Thing": {"state_dict_keys": ["a"]}}
+        self.assertEqual(
+            stale_removal_records((_make_removal("Thing", "b"),), snapshot), []
+        )
+        self.assertEqual(
+            stale_removal_records((_make_removal("Thing", "a"),), snapshot),
+            ["Thing still has key 'a'"],
+        )
+        self.assertEqual(
+            stale_removal_records((_make_removal("Gone", "a"),), snapshot),
+            ["Gone is not in the golden"],
+        )
+
+    def test_removal_record_fields_are_required(self) -> None:
+        for blank in ("", "   "):
+            with self.subTest(repr(blank)), self.assertRaises(ValueError):
+                _make_removal("Thing", "b", hook=blank)
+
+    def test_stale_records_are_detected(self) -> None:
+        # _SCHEMA_ADDITIONS is empty, so the check above passes without running
+        # anything. These pin the detector itself.
+        snapshot = {"Thing": {"state_dict_keys": ["a"]}}
+        self.assertEqual(stale_records((_make_record("Thing", "a"),), snapshot), [])
+        self.assertEqual(
+            stale_records((_make_record("Gone", "a"),), snapshot),
+            ["Gone is not in the golden"],
+        )
+        self.assertEqual(
+            stale_records((_make_record("Thing", "b"),), snapshot),
+            ["Thing has no key 'b'"],
+        )
+
+    def test_record_fields_are_required(self) -> None:
+        for blank in ("", "   "):
+            with self.subTest(repr(blank)), self.assertRaises(ValueError):
+                _make_record("Thing", "b", reason=blank)
+
+    def test_record_added_must_be_a_date(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be a datetime.date"):
+            # pyre-ignore[6]
+            _make_record("Thing", "b", added="2026-01-01")
+
+
+class GoldenRegenerationTest(unittest.TestCase):
+    """The gates on the real generate-validate-save path.
+
+    The tests above call the comparison helpers directly, which says nothing
+    about whether `update_golden_snapshot` consults them or writes anyway. Each
+    case here doctors a baseline, runs the whole path against a temporary file,
+    and requires that file to come back untouched.
+
+    The patch redirects where the snapshot is read and written. It replaces a
+    path, not a dependency, so the file I/O under test is real.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Building every case is the slow part, so pay it once and reuse the
+        # result as the baseline each case then doctors.
+        with _single_rank_process_group():
+            cls.current: Dict[str, Dict[str, Any]] = generate_golden_snapshot()
+            cls.current.update(generate_schema_case_entries())
+
+    @contextlib.contextmanager
+    def _baseline(self, snapshot: Dict[str, Dict[str, Any]]) -> Iterator[Path]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "golden.json"
+            path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+            with unittest.mock.patch(
+                f"{__name__}.GOLDEN_SNAPSHOT_PATH", path
+            ), _single_rank_process_group():
+                yield path
+
+    def _assert_refused(self, baseline: Dict[str, Dict[str, Any]], reason: str) -> None:
+        with self._baseline(baseline) as path:
+            before = path.read_bytes()
+            with self.assertRaises((ValueError, RuntimeError)) as cm:
+                update_golden_snapshot()
+            self.assertIn(reason, str(cm.exception))
+            self.assertEqual(path.read_bytes(), before, "the golden was rewritten")
+
+    def _entry_holding_keys(self, baseline: Dict[str, Dict[str, Any]]) -> str:
+        """An entry with at least one state key.
+
+        Six entries legitimately have none, the AUC family among them, and they
+        sort first. Doctoring one of those changes nothing and the gate has
+        nothing to catch.
+        """
+        for key in sorted(baseline):
+            if baseline[key]["state_dict_keys"]:
+                return key
+        self.fail("no golden entry holds a state key")
+
+    def test_an_empty_baseline_is_refused(self) -> None:
+        self._assert_refused({}, "restore it from source control")
+
+    def test_an_unauthorized_addition_is_refused(self) -> None:
+        # Drop one key from one entry, so the live code looks like it added it.
+        baseline = copy.deepcopy(type(self).current)
+        key = self._entry_holding_keys(baseline)
+        baseline[key]["state_dict_keys"] = baseline[key]["state_dict_keys"][1:]
+        self._assert_refused(baseline, "add state_dict keys that nothing authorizes")
+
+    def test_an_unauthorized_removal_is_refused(self) -> None:
+        baseline = copy.deepcopy(type(self).current)
+        key = self._entry_holding_keys(baseline)
+        baseline[key]["state_dict_keys"] = baseline[key]["state_dict_keys"] + [
+            "a_key_the_code_no_longer_produces"
+        ]
+        self._assert_refused(baseline, "drop state_dict keys that nothing authorizes")
+
+    def test_a_dropped_entry_is_refused(self) -> None:
+        baseline = copy.deepcopy(type(self).current)
+        baseline["AnEntryTheCodeNoLongerProduces"] = {
+            "metric_class": "Gone",
+            "variant": "",
+            "state_dict_keys": [],
+            "persistent_buffer_fqns": [],
+            "non_persistent_buffer_fqns": [],
+        }
+        self._assert_refused(baseline, "remove golden entries")
+
+    def test_an_unchanged_baseline_is_rewritten_identically(self) -> None:
+        with self._baseline(type(self).current) as path:
+            before = path.read_bytes()
+            update_golden_snapshot()
+            self.assertEqual(path.read_bytes(), before)
 
 
 class MetricCoverageTest(unittest.TestCase):
@@ -1776,6 +1993,225 @@ def generate_schema_case_entries() -> Dict[str, Dict[str, Any]]:
     return entries
 
 
+@dataclass(frozen=True)
+class _SchemaChange:
+    """What every deliberate change to a golden entry has to say.
+
+    Neither record changes behavior. Both are review gates and a paper trail,
+    and the subclass field naming the migration is the one that matters.
+    """
+
+    golden_key: str
+    state_key: str
+    reason: str
+    owner: str
+
+    def _validate(self, extra_text: Tuple[str, ...], date_field: str) -> None:
+        for name in ("golden_key", "state_key", "reason", "owner") + extra_text:
+            value = getattr(self, name)
+            if not value or not value.strip():
+                raise ValueError(
+                    f"{type(self).__name__}.{name} must be non-empty "
+                    f"({self.state_key!r} on {self.golden_key!r})"
+                )
+        # The annotation alone does not stop a string, and a string date sorts
+        # and compares wrong without ever raising.
+        when = getattr(self, date_field)
+        if not isinstance(when, datetime.date):
+            raise ValueError(
+                f"{type(self).__name__}.{date_field} must be a datetime.date, "
+                f"got {type(when).__name__}"
+            )
+
+
+@dataclass(frozen=True)
+class _SchemaAddition(_SchemaChange):
+    """An intentional new state_dict key on a class that already has a golden entry.
+
+    Additions are the direction a module hook cannot repair. DCP validates that
+    every model FQN exists in checkpoint metadata before load_state_dict runs,
+    so a checkpoint written before the key existed is rejected by the planner,
+    ahead of any hook. Adding one persistent buffer to RecMetricModule has
+    already taken down production training this way.
+
+    `rollout` names how checkpoints that predate the key are handled, usually
+    LoadOverride.allow_missing_fqns.
+    """
+
+    rollout: str
+    added: datetime.date
+
+    def __post_init__(self) -> None:
+        self._validate(("rollout",), "added")
+
+
+@dataclass(frozen=True)
+class _SchemaRemoval(_SchemaChange):
+    """A state_dict key dropped from a class that keeps its golden entry.
+
+    Removals break a narrower set of loads than additions. torchmetrics pops
+    the keys it still declares, so a key it no longer declares reaches
+    nn.Module's strict check unclaimed and raises. DCP and the legacy client
+    build the load dict from the model, so the leftover key is never requested
+    there. Only a checkpoint-derived load reads it back, which today means
+    transfer learning.
+
+    `hook` names what pops the key for checkpoints that still carry it.
+    """
+
+    hook: str
+    removed: datetime.date
+
+    def __post_init__(self) -> None:
+        self._validate(("hook",), "removed")
+
+
+# Every deliberate addition to an existing golden entry. Regenerating the
+# snapshot refuses to write an added key that is not listed here.
+_SCHEMA_ADDITIONS: Tuple[_SchemaAddition, ...] = ()
+
+# The same, for keys dropped from an entry that survives.
+_SCHEMA_REMOVALS: Tuple[_SchemaRemoval, ...] = ()
+
+
+def _make_record(golden_key: str, state_key: str, **overrides: Any) -> _SchemaAddition:
+    """A filled-in record, so tests can vary the one field they care about."""
+    fields: Dict[str, Any] = {
+        "golden_key": golden_key,
+        "state_key": state_key,
+        "reason": "test",
+        "rollout": "test",
+        "owner": "test",
+        "added": datetime.date(2026, 1, 1),
+    }
+    fields.update(overrides)
+    return _SchemaAddition(**fields)
+
+
+def _make_removal(golden_key: str, state_key: str, **overrides: Any) -> _SchemaRemoval:
+    """The removal-side twin of _make_record."""
+    fields: Dict[str, Any] = {
+        "golden_key": golden_key,
+        "state_key": state_key,
+        "reason": "test",
+        "hook": "test",
+        "owner": "test",
+        "removed": datetime.date(2026, 1, 1),
+    }
+    fields.update(overrides)
+    return _SchemaRemoval(**fields)
+
+
+def _unclaimed_delta(
+    source: Dict[str, Dict[str, Any]],
+    target: Dict[str, Dict[str, Any]],
+    records: Sequence[_SchemaChange],
+) -> Dict[str, List[str]]:
+    """For entries both snapshots hold, keys in `source` absent from `target`.
+
+    Keys a record claims are dropped from the result. Entries missing from
+    either side are skipped, so a brand-new or dropped entry is somebody else's
+    problem.
+    """
+    claimed: Dict[str, Set[str]] = {}
+    for record in records:
+        claimed.setdefault(record.golden_key, set()).add(record.state_key)
+
+    offenders: Dict[str, List[str]] = {}
+    for golden_key, entry in source.items():
+        if golden_key not in target:
+            continue
+        delta = set(entry["state_dict_keys"]) - set(
+            target[golden_key]["state_dict_keys"]
+        )
+        unclaimed = sorted(delta - claimed.get(golden_key, set()))
+        if unclaimed:
+            offenders[golden_key] = unclaimed
+    return offenders
+
+
+def unauthorized_additions(
+    old: Dict[str, Dict[str, Any]],
+    new: Dict[str, Dict[str, Any]],
+    records: Sequence[_SchemaAddition] = (),
+) -> Dict[str, List[str]]:
+    """Keys that regeneration would add without a matching _SchemaAddition.
+
+    Entries absent from `old` are skipped. A genuinely new class or case has no
+    baseline to break, so its first snapshot needs no authorization. Pair this
+    with removed_entries, which is what stops a rename from reaching that
+    exemption while also adding a key.
+    """
+    return _unclaimed_delta(source=new, target=old, records=records)
+
+
+def unauthorized_removals(
+    old: Dict[str, Dict[str, Any]],
+    new: Dict[str, Dict[str, Any]],
+    records: Sequence[_SchemaRemoval] = (),
+) -> Dict[str, List[str]]:
+    """Keys that regeneration would drop without a matching _SchemaRemoval.
+
+    Entries absent from `new` are skipped, because removed_entries already
+    refuses those outright.
+    """
+    return _unclaimed_delta(source=old, target=new, records=records)
+
+
+def removed_entries(
+    old: Dict[str, Dict[str, Any]], new: Dict[str, Dict[str, Any]]
+) -> List[str]:
+    """Golden entries that regeneration would drop.
+
+    A METRICS_TO_TEST key is built from `__name__`, so renaming a metric moves
+    its entry. The old one disappears and the replacement looks brand new, so a
+    rename that also adds a state key would walk straight through the addition
+    gate. Case-table keys are hand-written ids and do not move on a rename,
+    which is what those ids are for.
+
+    Losing an entry is rare and always worth a look, so this refuses rather
+    than asking for a record.
+    """
+    return sorted(set(old) - set(new))
+
+
+def stale_records(
+    records: Sequence[_SchemaAddition], snapshot: Dict[str, Dict[str, Any]]
+) -> List[str]:
+    """Addition records naming a key the snapshot does not hold.
+
+    A record for a key that never landed, or that was later removed, is a claim
+    nobody can check.
+    """
+    stale: List[str] = []
+    for record in records:
+        entry = snapshot.get(record.golden_key)
+        if entry is None:
+            stale.append(f"{record.golden_key} is not in the golden")
+        elif record.state_key not in entry["state_dict_keys"]:
+            stale.append(f"{record.golden_key} has no key {record.state_key!r}")
+    return stale
+
+
+def stale_removal_records(
+    records: Sequence[_SchemaRemoval], snapshot: Dict[str, Dict[str, Any]]
+) -> List[str]:
+    """Removal records whose key came back.
+
+    Staleness inverts here. An addition record points at a key that must now be
+    present; a removal record points at one that must now be absent. Re-adding
+    the key leaves a record excusing a removal that no longer happened.
+    """
+    stale: List[str] = []
+    for record in records:
+        entry = snapshot.get(record.golden_key)
+        if entry is None:
+            stale.append(f"{record.golden_key} is not in the golden")
+        elif record.state_key in entry["state_dict_keys"]:
+            stale.append(f"{record.golden_key} still has key {record.state_key!r}")
+    return stale
+
+
 def update_golden_snapshot() -> None:
     print("Generating golden snapshot...")
     snapshot = generate_golden_snapshot()
@@ -1787,6 +2223,52 @@ def update_golden_snapshot() -> None:
             "One generator would overwrite the other."
         )
     snapshot.update(case_entries)
+
+    # Not load_golden_snapshot: an absent file reads as {}, which turns every
+    # generated entry into a brand-new one and silences all three gates below.
+    previous = load_required_golden_snapshot()
+
+    dropped = removed_entries(previous, snapshot)
+    if dropped:
+        raise ValueError(
+            f"Regenerating would remove golden entries: {dropped}.\n"
+            "No record authorizes this, deliberately. If the removal is right, "
+            f"delete those entries from {GOLDEN_SNAPSHOT_PATH.name} by hand and "
+            "run again, in the same diff that renames or drops the class. The "
+            "hand edit is the acknowledgement.\n"
+            "If it is not right, a case lost its coverage and the table needs "
+            "the row back."
+        )
+
+    dropped_keys = unauthorized_removals(previous, snapshot, _SCHEMA_REMOVALS)
+    if dropped_keys:
+        detail = "\n".join(
+            f"  {key}: {sorted(keys)}" for key, keys in sorted(dropped_keys.items())
+        )
+        raise ValueError(
+            "Regenerating would drop state_dict keys that nothing authorizes:\n"
+            f"{detail}\n"
+            "A checkpoint written before the removal still carries the key. "
+            "Loads built from the model never ask for it, but a "
+            "checkpoint-derived load reads it back, finds nobody claiming it, "
+            "and raises. Add a _SchemaRemoval for each, naming the hook that "
+            "pops it."
+        )
+
+    offenders = unauthorized_additions(previous, snapshot, _SCHEMA_ADDITIONS)
+    if offenders:
+        detail = "\n".join(
+            f"  {key}: {sorted(keys)}" for key, keys in sorted(offenders.items())
+        )
+        raise ValueError(
+            "Regenerating would add state_dict keys that nothing authorizes:\n"
+            f"{detail}\n"
+            "An added key makes every older checkpoint unloadable, and no "
+            "module hook can repair that: the planner rejects the load before "
+            "any hook runs. Add a _SchemaAddition for each, naming the reason, "
+            "the rollout plan for existing checkpoints, and an owner."
+        )
+
     save_golden_snapshot(snapshot)
     print(f"Golden snapshot saved to {GOLDEN_SNAPSHOT_PATH}")
     print(f"Total metrics captured: {len(snapshot)}")

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -129,87 +129,69 @@ def create_test_task(
     )
 
 
+def build_metric(
+    metric_class: Type[RecMetric],
+    compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    task_names: Optional[List[str]] = None,
+    use_tensor_task: bool = False,
+    use_session_task: bool = False,
+    **kwargs: Any,
+) -> RecMetric:
+    """One metric under the fixed configuration every golden entry is taken at.
+
+    Callers used to build the metric once to read its state_dict keys and again
+    to read its buffers, which doubled the construction work and let the two
+    reads drift apart.
+    """
+    if task_names is None:
+        task_names = ["test_task"]
+
+    tasks = [
+        create_test_task(
+            name,
+            with_tensor_name=use_tensor_task,
+            with_session_metric_def=use_session_task,
+        )
+        for name in task_names
+    ]
+
+    return metric_class(
+        world_size=1,
+        my_rank=0,
+        batch_size=32,
+        tasks=tasks,
+        compute_mode=compute_mode,
+        window_size=100,
+        fused_update_limit=0,
+        **kwargs,
+    )
+
+
 def extract_state_dict_keys(
     metric_class: Type[RecMetric],
     compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-    task_names: Optional[List[str]] = None,
-    use_tensor_task: bool = False,
-    use_session_task: bool = False,
     **kwargs: Any,
 ) -> List[str]:
-    if task_names is None:
-        task_names = ["test_task"]
-
-    tasks = [
-        create_test_task(
-            name,
-            with_tensor_name=use_tensor_task,
-            with_session_metric_def=use_session_task,
-        )
-        for name in task_names
-    ]
-
-    metric = metric_class(
-        world_size=1,
-        my_rank=0,
-        batch_size=32,
-        tasks=tasks,
-        compute_mode=compute_mode,
-        window_size=100,
-        fused_update_limit=0,
-        **kwargs,
+    return sorted(
+        build_metric(metric_class, compute_mode, **kwargs).state_dict().keys()
     )
 
-    state_dict = metric.state_dict()
-    return sorted(state_dict.keys())
 
+def buffer_fqns(module: torch.nn.Module) -> Tuple[List[str], List[str]]:
+    """Buffer names split by whether they reach the state_dict.
 
-def extract_named_buffer_fqns(
-    metric_class: Type[RecMetric],
-    compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-    task_names: Optional[List[str]] = None,
-    use_tensor_task: bool = False,
-    use_session_task: bool = False,
-    **kwargs: Any,
-) -> Tuple[List[str], List[str]]:
-    if task_names is None:
-        task_names = ["test_task"]
-
-    tasks = [
-        create_test_task(
-            name,
-            with_tensor_name=use_tensor_task,
-            with_session_metric_def=use_session_task,
-        )
-        for name in task_names
-    ]
-
-    metric = metric_class(
-        world_size=1,
-        my_rank=0,
-        batch_size=32,
-        tasks=tasks,
-        compute_mode=compute_mode,
-        window_size=100,
-        fused_update_limit=0,
-        **kwargs,
-    )
-
-    all_buffer_fqns = [name for name, _ in metric.named_buffers()]
-    state_dict_keys = set(metric.state_dict().keys())
-
-    persistent = []
-    non_persistent = []
-
-    for fqn in all_buffer_fqns:
-        is_persistent = any(
-            fqn == key or key.endswith(fqn) or fqn in key for key in state_dict_keys
-        )
-        if is_persistent:
-            persistent.append(fqn)
-        else:
-            non_persistent.append(fqn)
-
+    A buffer is in the state_dict exactly when it is persistent and not None,
+    so membership answers both questions. The earlier version matched a buffer
+    name against any state key containing it, which called a buffer persistent
+    on a coincidental substring.
+    """
+    saved = set(module.state_dict().keys())
+    persistent: List[str] = []
+    non_persistent: List[str] = []
+    for name, value in module.named_buffers():
+        if value is None:
+            continue
+        (persistent if name in saved else non_persistent).append(name)
     return sorted(persistent), sorted(non_persistent)
 
 
@@ -231,13 +213,9 @@ METRICS_TO_TEST: List[
     Tuple[Type[RecMetric], List[RecComputeMode], Dict[str, Any], List[str]]
 ] = [
     # Core metrics with persistent state
+    # include_logloss only gates which metrics _compute reports, so it adds no
+    # state and produced an entry identical to the default one above.
     (NEMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
-    (
-        NEMetric,
-        [RecComputeMode.UNFUSED_TASKS_COMPUTATION],
-        {"include_logloss": True},
-        ["with_logloss"],
-    ),
     (CalibrationMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
     (CTRMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
     (MSEMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
@@ -338,35 +316,47 @@ def generate_golden_snapshot() -> Dict[str, Dict[str, Any]]:
     """
     Generate a complete golden snapshot of all metrics.
 
+    Every entry must build. Skipping a metric that raises would write a file
+    missing that metric, and the write still succeeds, so a partial snapshot
+    replaces a good one.
+
     Returns:
         Dictionary mapping metric keys to their FQN information.
     """
     snapshot: Dict[str, Dict[str, Any]] = {}
+    failures: List[str] = []
 
     for metric_class, compute_modes, kwargs, variants in METRICS_TO_TEST:
         for compute_mode in compute_modes:
             for variant in variants:
+                key = get_metric_snapshot_key(metric_class, compute_mode, variant)
+                if key in snapshot:
+                    raise ValueError(
+                        f"Two METRICS_TO_TEST rows produce the key {key!r}. The "
+                        "second would overwrite the first, and both rows would "
+                        "then check against one baseline. Give the rows "
+                        "different variant names."
+                    )
                 try:
-                    key = get_metric_snapshot_key(metric_class, compute_mode, variant)
-                    state_dict_keys = extract_state_dict_keys(
-                        metric_class, compute_mode, **kwargs
-                    )
-                    persistent_fqns, non_persistent_fqns = extract_named_buffer_fqns(
-                        metric_class, compute_mode, **kwargs
-                    )
-
-                    snapshot[key] = {
-                        "metric_class": metric_class.__name__,
-                        "compute_mode": compute_mode.name,
-                        "variant": variant,
-                        "state_dict_keys": state_dict_keys,
-                        "persistent_buffer_fqns": persistent_fqns,
-                        "non_persistent_buffer_fqns": non_persistent_fqns,
-                    }
+                    metric = build_metric(metric_class, compute_mode, **kwargs)
+                    state_dict_keys = sorted(metric.state_dict().keys())
+                    persistent_fqns, non_persistent_fqns = buffer_fqns(metric)
                 except Exception as e:
-                    # pyrefly: ignore[unbound-name]
-                    print(f"Warning: Failed to generate snapshot for {key}: {e}")
+                    failures.append(f"  {key}: {type(e).__name__}: {e}")
                     continue
+
+                snapshot[key] = {
+                    "metric_class": metric_class.__name__,
+                    "compute_mode": compute_mode.name,
+                    "variant": variant,
+                    "state_dict_keys": state_dict_keys,
+                    "persistent_buffer_fqns": persistent_fqns,
+                    "non_persistent_buffer_fqns": non_persistent_fqns,
+                }
+
+    if failures:
+        detail = "\n".join(failures)
+        raise RuntimeError(f"Could not build every metric in the table:\n{detail}")
 
     return snapshot
 
@@ -376,6 +366,23 @@ def load_golden_snapshot() -> Dict[str, Dict[str, Any]]:
         return {}
     with open(GOLDEN_SNAPSHOT_PATH, "r") as f:
         return json.load(f)
+
+
+def load_required_golden_snapshot() -> Dict[str, Dict[str, Any]]:
+    """The snapshot, for tests that say nothing useful without one.
+
+    An empty file makes a set-difference check pass by having nothing to
+    compare, which reads as coverage.
+    """
+    snapshot = load_golden_snapshot()
+    if not snapshot:
+        raise RuntimeError(
+            f"{GOLDEN_SNAPSHOT_PATH} is missing or empty. Run with "
+            "--update-golden to generate it.\n"
+            "Regenerating from a test would write whatever the code currently "
+            "produces, and each class knows only its own part of the file."
+        )
+    return snapshot
 
 
 def save_golden_snapshot(snapshot: Dict[str, Dict[str, Any]]) -> None:
@@ -398,12 +405,7 @@ class MetricFQNBackwardCompatibilityTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
-        if not cls.golden_snapshot:
-            print("No golden snapshot found. Generating initial snapshot...")
-            cls.golden_snapshot = generate_golden_snapshot()
-            save_golden_snapshot(cls.golden_snapshot)
-            print(f"Golden snapshot saved to {GOLDEN_SNAPSHOT_PATH}")
+        cls.golden_snapshot = load_required_golden_snapshot()
         cls.current_snapshot = None
 
     def _check_metric_compatibility(
@@ -433,18 +435,17 @@ class MetricFQNBackwardCompatibilityTest(unittest.TestCase):
         key = get_metric_snapshot_key(metric_class, compute_mode, variant)
 
         if key not in self.golden_snapshot:
-            self.skipTest(
-                f"No golden snapshot for {key}. Run with --update-golden to create."
+            self.fail(
+                f"No golden entry for {key}. Run with --update-golden to create it. "
+                "Skipping here would silently drop this metric's regression "
+                "coverage the moment its entry goes missing."
             )
 
         baseline = self.golden_snapshot[key]
 
-        current_state_dict_keys = set(
-            extract_state_dict_keys(metric_class, compute_mode, **kwargs)
-        )
-        current_persistent_fqns, _ = extract_named_buffer_fqns(
-            metric_class, compute_mode, **kwargs
-        )
+        metric = build_metric(metric_class, compute_mode, **kwargs)
+        current_state_dict_keys = set(metric.state_dict().keys())
+        current_persistent_fqns, _ = buffer_fqns(metric)
         current_persistent_fqns_set = set(current_persistent_fqns)
 
         baseline_state_dict_keys = set(baseline["state_dict_keys"])
@@ -513,220 +514,25 @@ class MetricFQNBackwardCompatibilityTest(unittest.TestCase):
         # If there are added keys, require user to update golden snapshot
         return len(added_keys) == 0
 
-    def test_ne_metric_unfused(self) -> None:
-        self._check_metric_compatibility(
-            NEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
+    def test_every_metric_in_the_table(self) -> None:
+        """One check per METRICS_TO_TEST row, driven by the table itself.
 
-    def test_ne_metric_fused(self) -> None:
-        self._check_metric_compatibility(
-            NEMetric, RecComputeMode.FUSED_TASKS_COMPUTATION
-        )
-
-    def test_ne_metric_with_logloss(self) -> None:
-        self._check_metric_compatibility(
-            NEMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            variant="with_logloss",
-            include_logloss=True,
-        )
-
-    def test_calibration_metric_unfused(self) -> None:
-        self._check_metric_compatibility(
-            CalibrationMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_calibration_metric_fused(self) -> None:
-        self._check_metric_compatibility(
-            CalibrationMetric, RecComputeMode.FUSED_TASKS_COMPUTATION
-        )
-
-    def test_ctr_metric(self) -> None:
-        self._check_metric_compatibility(
-            CTRMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_mse_metric(self) -> None:
-        self._check_metric_compatibility(
-            MSEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_mse_metric_with_r_squared(self) -> None:
-        self._check_metric_compatibility(
-            MSEMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            variant="with_r_squared",
-            include_r_squared=True,
-        )
-
-    def test_mae_metric(self) -> None:
-        self._check_metric_compatibility(
-            MAEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_weighted_avg_metric_unfused(self) -> None:
-        self._check_metric_compatibility(
-            WeightedAvgMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_weighted_avg_metric_fused(self) -> None:
-        self._check_metric_compatibility(
-            WeightedAvgMetric, RecComputeMode.FUSED_TASKS_COMPUTATION
-        )
-
-    def test_accuracy_metric(self) -> None:
-        self._check_metric_compatibility(
-            AccuracyMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_precision_metric(self) -> None:
-        self._check_metric_compatibility(
-            PrecisionMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_recall_metric(self) -> None:
-        self._check_metric_compatibility(
-            RecallMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_tower_qps_metric(self) -> None:
-        self._check_metric_compatibility(
-            TowerQPSMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_nmse_metric(self) -> None:
-        self._check_metric_compatibility(
-            NMSEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_average_metric(self) -> None:
-        self._check_metric_compatibility(
-            AverageMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_hindsight_target_pr_metric(self) -> None:
-        self._check_metric_compatibility(
-            HindsightTargetPRMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_auc_metric(self) -> None:
-        self._check_metric_compatibility(
-            AUCMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_auprc_metric(self) -> None:
-        self._check_metric_compatibility(
-            AUPRCMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_rauc_metric(self) -> None:
-        self._check_metric_compatibility(
-            RAUCMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_gauc_metric(self) -> None:
-        self._check_metric_compatibility(
-            GAUCMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_ndcg_metric(self) -> None:
-        self._check_metric_compatibility(
-            NDCGMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_xauc_metric(self) -> None:
-        self._check_metric_compatibility(
-            XAUCMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_scalar_metric(self) -> None:
-        self._check_metric_compatibility(
-            ScalarMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_tensor_weighted_avg_metric(self) -> None:
-        self._check_metric_compatibility(
-            TensorWeightedAvgMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            variant="",
-            use_tensor_task=True,
-        )
-
-    def test_cali_free_ne_metric(self) -> None:
-        self._check_metric_compatibility(
-            CaliFreeNEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_ne_positive_metric(self) -> None:
-        self._check_metric_compatibility(
-            NEPositiveMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_serving_ne_metric(self) -> None:
-        self._check_metric_compatibility(
-            ServingNEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_unweighted_ne_metric(self) -> None:
-        self._check_metric_compatibility(
-            UnweightedNEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_recalibrated_ne_metric(self) -> None:
-        self._check_metric_compatibility(
-            RecalibratedNEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_serving_calibration_metric(self) -> None:
-        self._check_metric_compatibility(
-            ServingCalibrationMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_recalibrated_calibration_metric(self) -> None:
-        self._check_metric_compatibility(
-            RecalibratedCalibrationMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_output_metric(self) -> None:
-        self._check_metric_compatibility(
-            OutputMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
-        )
-
-    def test_multiclass_recall_metric(self) -> None:
-        self._check_metric_compatibility(
-            MulticlassRecallMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            number_of_classes=3,
-        )
-
-    def test_multi_label_precision_metric(self) -> None:
-        self._check_metric_compatibility(
-            MultiLabelPrecisionMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            num_labels=1,
-        )
-
-    def test_segmented_ne_metric(self) -> None:
-        self._check_metric_compatibility(
-            SegmentedNEMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            num_groups=2,
-            grouping_keys="test_task-grouping",
-        )
-
-    def test_precision_session_metric(self) -> None:
-        self._check_metric_compatibility(
-            PrecisionSessionMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            use_session_task=True,
-        )
-
-    def test_recall_session_metric(self) -> None:
-        self._check_metric_compatibility(
-            RecallSessionMetric,
-            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            use_session_task=True,
-        )
+        Hand-written methods used to do this, one per row. Deleting one left
+        its golden entry in place and the suite green, which is the coverage
+        loss test_no_orphaned_golden_entries is meant to catch. Generation,
+        checking, and that orphan check now read the same table.
+        """
+        for metric_class, compute_modes, kwargs, variants in METRICS_TO_TEST:
+            for compute_mode in compute_modes:
+                for variant in variants:
+                    with self.subTest(
+                        metric=metric_class.__name__,
+                        compute_mode=compute_mode.name,
+                        variant=variant,
+                    ):
+                        self._check_metric_compatibility(
+                            metric_class, compute_mode, variant=variant, **kwargs
+                        )
 
 
 class MetricStateSnapshotTest(unittest.TestCase):
@@ -979,7 +785,7 @@ class GoldenCaseTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
+        cls.golden_snapshot = load_required_golden_snapshot()
 
     def setUp(self) -> None:
         # Registered before any module is built, so under addCleanup's LIFO
@@ -1097,6 +903,29 @@ class GoldenCaseTest(unittest.TestCase):
                     self.assertIn("written by a different", str(cm.exception))
                 finally:
                     del self.golden_snapshot
+
+    def test_no_orphaned_golden_entries(self) -> None:
+        """Every golden entry must belong to something that checks it.
+
+        An entry nobody claims is dead weight that still looks like coverage.
+        That happens when a metric is dropped from METRICS_TO_TEST, or a case is
+        removed, and the entry is left behind.
+        """
+        expected = {case.key for case in _SCHEMA_CASES}
+        for metric_class, compute_modes, _kwargs, variants in METRICS_TO_TEST:
+            for compute_mode in compute_modes:
+                for variant in variants:
+                    expected.add(
+                        get_metric_snapshot_key(metric_class, compute_mode, variant)
+                    )
+
+        orphans = sorted(set(self.golden_snapshot) - expected)
+        if orphans:
+            self.fail(
+                f"Golden entries that no test claims: {orphans}.\n"
+                "Either restore whatever used to check them, or delete the "
+                "entries."
+            )
 
     def test_case_keys_are_unique(self) -> None:
         keys = [case.key for case in _SCHEMA_CASES]
@@ -1244,6 +1073,24 @@ class MetricCoverageTest(unittest.TestCase):
         # e.g., "torchrec.metrics.foo.SomeMetric": "deprecated, removed next release",
     }
 
+    def test_rows_produce_distinct_keys(self) -> None:
+        """No two rows may claim one golden entry.
+
+        The key drops kwargs, so two rows differing only in configuration
+        collide. Generation refuses to write that, but this names the offending
+        rows without making anyone run --update-golden to find out.
+        """
+        keys = [
+            get_metric_snapshot_key(metric_class, compute_mode, variant)
+            for metric_class, compute_modes, _kwargs, variants in METRICS_TO_TEST
+            for compute_mode in compute_modes
+            for variant in variants
+        ]
+        duplicates = sorted({key for key in keys if keys.count(key) > 1})
+        self.assertEqual(
+            duplicates, [], f"METRICS_TO_TEST rows collide on {duplicates}"
+        )
+
     @unittest.skipIf(
         sys.version_info < (3, 11),
         "concurrent.futures._base.Future is type but not a class",
@@ -1266,9 +1113,9 @@ class MetricCoverageTest(unittest.TestCase):
                 f"The following RecMetric subclasses are not covered by backward "
                 f"compatibility tests: {sorted(missing_metrics)}.\n\n"
                 f"To fix this:\n"
-                f"1. Add the metric to METRICS_TO_TEST in this file\n"
-                f"2. Add a corresponding test_<metric>_metric() method\n"
-                f"3. Run the tests to generate the golden snapshot\n\n"
+                f"1. Add a METRICS_TO_TEST row. The check runs from the table, "
+                f"so the row is the whole registration.\n"
+                f"2. Run with --update-golden to write its entry.\n\n"
                 f"If the metric should be excluded, add it to EXCLUDED_METRICS with a reason."
             )
 
@@ -1794,7 +1641,7 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
+        cls.golden_snapshot = load_required_golden_snapshot()
 
     def _simulate_dcp_fqn_validation(
         self,
@@ -1833,7 +1680,10 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
             NEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION
         )
         if key not in self.golden_snapshot:
-            self.skipTest(f"No golden snapshot for {key}")
+            self.fail(
+                f"No golden entry for {key}. This simulation needs one; run "
+                "with --update-golden."
+            )
 
         current_fqns = set(
             extract_state_dict_keys(NEMetric, RecComputeMode.UNFUSED_TASKS_COMPUTATION)

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -48,6 +48,8 @@ from typing import (
 )
 
 import torch
+import torch.distributed as dist
+from torchrec.checkpoint.schema import registered_schema_stable_classes
 from torchrec.metrics.accuracy import AccuracyMetric
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.auprc import AUPRCMetric
@@ -57,6 +59,8 @@ from torchrec.metrics.calibration import CalibrationMetric
 from torchrec.metrics.calibration_with_recalibration import (
     RecalibratedCalibrationMetric,
 )
+from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
+from torchrec.metrics.cpu_offloaded_metric_module import CPUOffloadedRecMetricModule
 from torchrec.metrics.ctr import CTRMetric
 from torchrec.metrics.gauc import GAUCMetric
 from torchrec.metrics.hindsight_target_pr import HindsightTargetPRMetric
@@ -71,6 +75,7 @@ from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.ne_positive import NEPositiveMetric
 from torchrec.metrics.ne_with_recalibration import RecalibratedNEMetric
 from torchrec.metrics.nmse import NMSEMetric
+from torchrec.metrics.noop_metric_module import NoOpMetricModule
 from torchrec.metrics.num_missing_labels import NumMissingLabelsMetric
 from torchrec.metrics.num_positive_samples import NumPositiveSamplesMetric
 from torchrec.metrics.output import OutputMetric
@@ -92,6 +97,7 @@ from torchrec.metrics.unweighted_ne import UnweightedNEMetric
 from torchrec.metrics.weighted_avg import WeightedAvgMetric
 from torchrec.metrics.weighted_sum_predictions import WeightedSumPredictionsMetric
 from torchrec.metrics.xauc import XAUCMetric
+from torchrec.test_utils import init_process_group_single_rank
 
 
 # Path to the golden snapshot file
@@ -877,8 +883,88 @@ _CORE_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
     ),
 )
 
-# Child diffs extend this rather than editing the tuple above.
-_SCHEMA_CASES: Tuple[_GoldenCase, ...] = _CORE_SCHEMA_CASES
+
+def _module_fixture_kwargs() -> Dict[str, Any]:
+    """Construction args carrying one real metric.
+
+    An empty RecMetricList would produce an empty state_dict, and a golden entry
+    with no keys records nothing about the module's shape.
+    """
+    tasks = [create_test_task("task1")]
+    return {
+        "batch_size": 32,
+        "world_size": 1,
+        "rec_tasks": tasks,
+        "rec_metrics": RecMetricList(
+            [
+                NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=32,
+                    tasks=tasks,
+                    compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+                    window_size=100,
+                )
+            ]
+        ),
+    }
+
+
+def _shutdown(module: torch.nn.Module) -> None:
+    """Release a CPUOffloadedRecMetricModule's worker threads.
+
+    Two threads plus an atexit hook per instance, and one case builds three.
+    shutdown() is idempotent.
+    """
+    # pyre-ignore[16]
+    module.shutdown()
+
+
+@contextlib.contextmanager
+def _single_rank_process_group() -> Iterator[None]:
+    """A process group for CPUOffloadedRecMetricModule's compute worker.
+
+    shutdown() wakes that worker, which calls dist.new_group and then re-raises
+    whatever it caught. So building a module without a group succeeds and its
+    teardown throws, which is why generation needs this as much as the tests do.
+
+    Only destroys a group it created, so a caller that brought its own keeps it.
+    """
+    created = not dist.is_initialized()
+    if created:
+        init_process_group_single_rank("gloo")
+    try:
+        yield
+    finally:
+        if created:
+            dist.destroy_process_group()
+
+
+# Enrolled with @checkpoint_schema_stable under these same ids. Not RecMetric
+# subclasses, so _discover_all_recmetric_subclasses cannot see them.
+_MODULE_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
+    _GoldenCase("noop_metric_module", NoOpMetricModule, "", NoOpMetricModule),
+    _GoldenCase(
+        "cpu_comms_rec_metric_module",
+        CPUCommsRecMetricModule,
+        "",
+        lambda: CPUCommsRecMetricModule(**_module_fixture_kwargs()),
+    ),
+    # state_dict() reads the comms tree and load_state_dict() writes the offloaded
+    # one, but both carry the same keys, so this pins the shape and not which tree
+    # a load reached. test_cpu_offloaded_metric_module covers the load direction.
+    _GoldenCase(
+        "cpu_offloaded_rec_metric_module",
+        CPUOffloadedRecMetricModule,
+        "",
+        lambda: CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"), **_module_fixture_kwargs()
+        ),
+        cleanup=_shutdown,
+    ),
+)
+
+_SCHEMA_CASES: Tuple[_GoldenCase, ...] = _CORE_SCHEMA_CASES + _MODULE_SCHEMA_CASES
 
 
 class GoldenCaseTest(unittest.TestCase):
@@ -894,6 +980,14 @@ class GoldenCaseTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.golden_snapshot = load_golden_snapshot()
+
+    def setUp(self) -> None:
+        # Registered before any module is built, so under addCleanup's LIFO
+        # order the group is torn down last. Destroying it ahead of a module
+        # would make that module's shutdown throw.
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(_single_rank_process_group())
 
     @contextlib.contextmanager
     def _built(self, case: _GoldenCase) -> Iterator[torch.nn.Module]:
@@ -1105,6 +1199,35 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         # strict=True matches production. Under strict=False this test passes
         # even without the pop hook.
         fresh_module.load_state_dict(state_dict, strict=True)
+
+
+class SchemaStableCoverageTest(unittest.TestCase):
+    """The decorator registry and the case table must list the same ids.
+
+    A class decorated but absent from the table has no fixture and no golden
+    entry. An id in the table that nothing registers is covered by accident
+    rather than by declaration.
+
+    Neither can see a decorated class in a module that was never imported;
+    registration is import-bound. Adding a case forces the Buck dep, which is
+    what makes the class visible in the first place.
+    """
+
+    def test_registry_matches_case_table(self) -> None:
+        # Comparing the id sets alone would pass if two ids were swapped between
+        # classes, so compare the id-to-class mapping. Built by hand because a
+        # comprehension lets a second case under one id overwrite the first, and
+        # the duplicate-key check in the generator only sees id plus variant.
+        declared: Dict[str, Type[torch.nn.Module]] = {}
+        for case in _SCHEMA_CASES:
+            first = declared.setdefault(case.stable_id, case.expected_class)
+            self.assertIs(
+                first,
+                case.expected_class,
+                f"stable_id {case.stable_id!r} is claimed by two classes: "
+                f"{first.__name__} and {case.expected_class.__name__}.",
+            )
+        self.assertEqual(registered_schema_stable_classes(), declared)
 
 
 class MetricCoverageTest(unittest.TestCase):
@@ -1776,26 +1899,30 @@ def generate_schema_case_entries() -> Dict[str, Dict[str, Any]]:
 
     The comparison path fails rather than writing a missing entry, so this is
     the only way a new case gets one.
+
+    Owns the process group rather than leaving it to the caller: the tests get
+    one from setUp, and --update-golden runs outside unittest entirely.
     """
     entries: Dict[str, Dict[str, Any]] = {}
-    for case in _SCHEMA_CASES:
-        if case.key in entries:
-            raise ValueError(
-                f"Two cases share the key {case.key!r}. One would overwrite the "
-                "other's golden entry."
-            )
-        module = case.build()
-        try:
-            entries[case.key] = {
-                "metric_class": case.expected_class.__name__,
-                "variant": case.variant,
-                "state_dict_keys": sorted(module.state_dict().keys()),
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-        finally:
-            if case.cleanup is not None:
-                case.cleanup(module)
+    with _single_rank_process_group():
+        for case in _SCHEMA_CASES:
+            if case.key in entries:
+                raise ValueError(
+                    f"Two cases share the key {case.key!r}. One would overwrite "
+                    "the other's golden entry."
+                )
+            module = case.build()
+            try:
+                entries[case.key] = {
+                    "metric_class": case.expected_class.__name__,
+                    "variant": case.variant,
+                    "state_dict_keys": sorted(module.state_dict().keys()),
+                    "persistent_buffer_fqns": [],
+                    "non_persistent_buffer_fqns": [],
+                }
+            finally:
+                if case.cleanup is not None:
+                    case.cleanup(module)
     return entries
 
 

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -26,13 +26,26 @@ To update the golden snapshot after intentional changes:
     python -m torchrec.metrics.tests.test_metric_fqn_backward_compatibility --update-golden
 """
 
+import contextlib
 import inspect
 import json
 import os
 import sys
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
 
 import torch
 from torchrec.metrics.accuracy import AccuracyMetric
@@ -777,139 +790,278 @@ class MetricStateSnapshotTest(unittest.TestCase):
         self._test_metric_state_roundtrip(WeightedAvgMetric)
 
 
-# Golden snapshot keys for ThroughputMetric and RecMetricModule
-THROUGHPUT_SNAPSHOT_KEY = "ThroughputMetric"
-THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY = "ThroughputMetric_with_batch_size_stages"
-REC_METRIC_MODULE_SNAPSHOT_KEY = "RecMetricModule"
-REC_METRIC_MODULE_WITH_THROUGHPUT_KEY = "RecMetricModule_with_throughput"
+# Fixture values for the golden cases.
+_THROUGHPUT_BATCH_SIZE_STAGES: List[BatchSizeStage] = [
+    BatchSizeStage(batch_size=32, max_iters=100),
+    BatchSizeStage(batch_size=64, max_iters=None),
+]
 
 
-class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
+def _make_throughput_metric(
+    batch_size_stages: Optional[List[BatchSizeStage]] = None,
+) -> ThroughputMetric:
+    return ThroughputMetric(
+        batch_size=32,
+        world_size=1,
+        window_seconds=100,
+        warmup_steps=10,
+        batch_size_stages=batch_size_stages,
+    )
+
+
+def _make_rec_metric_module(
+    throughput_metric: Optional[ThroughputMetric] = None,
+) -> RecMetricModule:
+    tasks = [create_test_task("task1")]
+    return RecMetricModule(
+        batch_size=32,
+        world_size=1,
+        rec_tasks=tasks,
+        rec_metrics=RecMetricList(
+            [
+                NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=32,
+                    tasks=tasks,
+                    compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+                    window_size=100,
+                )
+            ]
+        ),
+        throughput_metric=throughput_metric,
+    )
+
+
+@dataclass(frozen=True)
+class _GoldenCase:
+    """One golden snapshot: which entry it is, and how to build it.
+
+    The builder is self-contained, so a case cannot be paired with another
+    case's configuration. `stable_id` is written by hand rather than derived
+    from the class, so moving a file does not silently change the key and
+    abandon the entry it used to match.
     """
-    Test suite for ThroughputMetric FQN backward compatibility.
 
-    ThroughputMetric is an nn.Module (not RecMetric) with its own state_dict structure.
+    stable_id: str
+    expected_class: Type[torch.nn.Module]
+    variant: str
+    build: Callable[[], torch.nn.Module]
+    # Called on every module this case builds. A case whose module owns threads
+    # or other process state declares how to release it.
+    cleanup: Optional[Callable[[torch.nn.Module], None]] = None
+
+    @property
+    def key(self) -> str:
+        return f"{self.stable_id}_{self.variant}" if self.variant else self.stable_id
+
+
+_REC_METRIC_MODULE_DEFAULT = _GoldenCase(
+    "RecMetricModule", RecMetricModule, "", _make_rec_metric_module
+)
+
+_CORE_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
+    _GoldenCase("ThroughputMetric", ThroughputMetric, "", _make_throughput_metric),
+    _GoldenCase(
+        "ThroughputMetric",
+        ThroughputMetric,
+        "with_batch_size_stages",
+        lambda: _make_throughput_metric(_THROUGHPUT_BATCH_SIZE_STAGES),
+    ),
+    _REC_METRIC_MODULE_DEFAULT,
+    _GoldenCase(
+        "RecMetricModule",
+        RecMetricModule,
+        "with_throughput",
+        lambda: _make_rec_metric_module(_make_throughput_metric()),
+    ),
+)
+
+# Child diffs extend this rather than editing the tuple above.
+_SCHEMA_CASES: Tuple[_GoldenCase, ...] = _CORE_SCHEMA_CASES
+
+
+class GoldenCaseTest(unittest.TestCase):
+    """Compares each golden case against the entry it wrote.
+
+    Checking the stored metadata matters as much as the keys. Comparing one
+    case against another's baseline can otherwise pass: the extra keys look
+    like an addition, and the addition check loads them away.
     """
+
+    golden_snapshot: Dict[str, Dict[str, Any]]
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.golden_snapshot = load_golden_snapshot()
 
-    def _create_throughput_metric(
-        self, with_batch_size_stages: bool = False
-    ) -> ThroughputMetric:
-        from torchrec.metrics.metrics_config import BatchSizeStage
+    @contextlib.contextmanager
+    def _built(self, case: _GoldenCase) -> Iterator[torch.nn.Module]:
+        module = case.build()
+        try:
+            yield module
+        finally:
+            if case.cleanup is not None:
+                case.cleanup(module)
 
-        batch_size_stages = None
-        if with_batch_size_stages:
-            batch_size_stages = [
-                BatchSizeStage(batch_size=32, max_iters=100),
-                BatchSizeStage(batch_size=64, max_iters=None),
-            ]
+    def _check_case(self, case: _GoldenCase) -> None:
+        with self._built(case) as module:
+            self.assertIs(type(module), case.expected_class)
 
-        return ThroughputMetric(
-            batch_size=32,
-            world_size=1,
-            window_seconds=100,
-            warmup_steps=10,
-            batch_size_stages=batch_size_stages,
+            if case.key not in self.golden_snapshot:
+                self.fail(
+                    f"No golden entry for {case.key}. Run with --update-golden "
+                    "to create it. Writing one here would bless whatever the "
+                    "code currently produces, and concurrent tests writing the "
+                    "whole file at once corrupt it."
+                )
+
+            entry = self.golden_snapshot[case.key]
+            self.assertEqual(
+                entry["metric_class"],
+                case.expected_class.__name__,
+                f"Golden entry {case.key} was written by a different class.",
+            )
+            self.assertEqual(
+                entry["variant"],
+                case.variant,
+                f"Golden entry {case.key} was written by a different variant.",
+            )
+
+            current_keys = set(module.state_dict().keys())
+
+        baseline_keys = set(entry["state_dict_keys"])
+
+        removed = baseline_keys - current_keys
+        if removed:
+            self.fail(
+                f"BREAKING CHANGE in {case.key}: state_dict keys removed: "
+                f"{sorted(removed)}."
+            )
+
+        added = current_keys - baseline_keys
+        if not added:
+            return
+
+        self.fail(
+            f"BREAKING CHANGE in {case.key}: state_dict keys added: "
+            f"{sorted(added)}. {self._why_an_older_checkpoint_breaks(case, added)}"
         )
 
-    def _get_state_dict_keys(self, with_batch_size_stages: bool = False) -> List[str]:
-        metric = self._create_throughput_metric(with_batch_size_stages)
-        return sorted(metric.state_dict().keys())
+    def _why_an_older_checkpoint_breaks(
+        self, case: _GoldenCase, added: Set[str]
+    ) -> str:
+        """The best available explanation for an added key, not a verdict.
 
-    def test_throughput_metric_compatibility(self) -> None:
-        key = THROUGHPUT_SNAPSHOT_KEY
+        A strict load that raises names the exact key. One that succeeds proves
+        nothing: DCP validates every model FQN against checkpoint metadata
+        before load_state_dict runs, and state a strict load cannot see, such
+        as anything torchmetrics holds by setattr, is state the planner still
+        demands. So an addition always fails and this only picks the wording.
 
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_batch_size_stages=False)
-            self.golden_snapshot[key] = {
-                "metric_class": "ThroughputMetric",
-                "variant": "",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
+        Build a separate source and destination so neither is a module already
+        inspected.
+        """
+        with self._built(case) as source, self._built(case) as destination:
+            older = {k: v for k, v in source.state_dict().items() if k not in added}
+            try:
+                destination.load_state_dict(older, strict=True)
+            except Exception as e:
+                return f"A checkpoint without them no longer loads: {e}"
+        return (
+            "An in-process load still succeeds, so the key is invisible to the "
+            "strict check, but DCP rejects the checkpoint before that runs."
+        )
 
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_batch_size_stages=False))
-        baseline_keys = set(baseline["state_dict_keys"])
+    def test_golden_cases(self) -> None:
+        for case in _SCHEMA_CASES:
+            with self.subTest(case.key):
+                self._check_case(case)
 
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}. "
-                "This will cause old checkpoints to fail loading."
-            )
+    def test_metadata_mismatch_is_rejected(self) -> None:
+        """The stored metric_class and variant must match the case asking.
 
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(added_keys):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
+        Without this, a case can compare against an entry another case wrote:
+        the extra keys read as an addition and the addition check loads them
+        away. Injecting each mismatch pins both guards, which are otherwise
+        only exercised when the golden is already wrong.
+        """
+        case = _CORE_SCHEMA_CASES[0]
+        for field_name, wrong_value in (
+            ("metric_class", "SomeOtherClass"),
+            ("variant", "some_other_variant"),
+        ):
+            with self.subTest(field_name):
+                entry = dict(type(self).golden_snapshot[case.key])
+                entry[field_name] = wrong_value
+                # Shadows the class attribute for this instance only; the real
+                # snapshot is untouched and no restore is needed.
+                self.golden_snapshot = {case.key: entry}
+                try:
+                    with self.assertRaises(AssertionError) as cm:
+                        self._check_case(case)
+                    self.assertIn("written by a different", str(cm.exception))
+                finally:
+                    del self.golden_snapshot
+
+    def test_case_keys_are_unique(self) -> None:
+        keys = [case.key for case in _SCHEMA_CASES]
+        self.assertEqual(sorted(keys), sorted(set(keys)))
+
+    def test_one_class_per_stable_id(self) -> None:
+        """A stable id names one class, however many variants it has.
+
+        The key carries the variant, so two classes could share an id and still
+        keep distinct keys. Anything that maps id to class would then silently
+        keep whichever row it read last.
+        """
+        classes_by_id: Dict[str, Set[Type[torch.nn.Module]]] = {}
+        for case in _SCHEMA_CASES:
+            classes_by_id.setdefault(case.stable_id, set()).add(case.expected_class)
+
+        for stable_id, classes in classes_by_id.items():
+            with self.subTest(stable_id):
+                self.assertEqual(
+                    len(classes),
+                    1,
+                    f"{stable_id} is claimed by "
+                    f"{sorted(c.__name__ for c in classes)}.",
                 )
 
-    def test_throughput_metric_with_stages_compatibility(self) -> None:
-        key = THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY
+    def test_cases_for_same_id_have_distinct_key_sets(self) -> None:
+        """Every case under one id must snapshot a different key set.
 
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_batch_size_stages=True)
-            self.golden_snapshot[key] = {
-                "metric_class": "ThroughputMetric",
-                "variant": "with_batch_size_stages",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_batch_size_stages=True))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}. "
-                "This will cause old checkpoints to fail loading."
-            )
-
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(added_keys, with_stages=True):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
+        The unnamed case counts too, so this catches a named variant whose
+        builder forgot the argument that distinguishes it. The key and the
+        stored metadata both agree with themselves in that case; only the
+        resulting shape disagrees.
+        """
+        by_id: Dict[str, List[FrozenSet[str]]] = {}
+        for case in _SCHEMA_CASES:
+            with self._built(case) as module:
+                by_id.setdefault(case.stable_id, []).append(
+                    frozenset(module.state_dict().keys())
                 )
 
-    def _verify_backward_compatibility(
-        self, added_keys: Set[str], with_stages: bool = False
-    ) -> bool:
-        try:
-            metric = self._create_throughput_metric(with_batch_size_stages=with_stages)
-            state_dict = metric.state_dict()
-            old_checkpoint = {
-                k: v for k, v in state_dict.items() if k not in added_keys
-            }
+        for stable_id, entries in by_id.items():
+            with self.subTest(stable_id):
+                self.assertEqual(
+                    len(set(entries)),
+                    len(entries),
+                    f"{stable_id} has {len(entries)} cases but "
+                    f"{len(set(entries))} distinct key sets. One builder is carrying "
+                    "another's configuration.",
+                )
 
-            fresh_metric = self._create_throughput_metric(
-                with_batch_size_stages=with_stages
-            )
-            fresh_metric.load_state_dict(old_checkpoint, strict=True)
-            return True
-        except Exception:
-            return False
+
+class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
+    """Round-trip checks for ThroughputMetric that are not golden comparisons."""
 
     def test_throughput_metric_state_roundtrip(self) -> None:
-        metric = self._create_throughput_metric()
+        metric = _make_throughput_metric()
         initial_state = metric.state_dict()
 
-        fresh_metric = self._create_throughput_metric()
+        fresh_metric = _make_throughput_metric()
         fresh_metric.load_state_dict(initial_state, strict=True)
 
         restored_state = fresh_metric.state_dict()
@@ -924,152 +1076,13 @@ class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
 
 
 class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
-    """
-    Test suite for RecMetricModule FQN backward compatibility.
-
-    RecMetricModule is a container that holds RecMetrics, ThroughputMetric, and StateMetrics.
-    """
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Load the golden snapshot."""
-        cls.golden_snapshot = load_golden_snapshot()
-
-    def _create_rec_metric_module(
-        self, with_throughput: bool = False, with_metrics: bool = True
-    ) -> RecMetricModule:
-        tasks = [create_test_task("task1")]
-
-        rec_metrics = None
-        if with_metrics:
-            ne_metric = NEMetric(
-                world_size=1,
-                my_rank=0,
-                batch_size=32,
-                tasks=tasks,
-                compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-                window_size=100,
-            )
-            rec_metrics = RecMetricList([ne_metric])
-
-        throughput_metric = None
-        if with_throughput:
-            throughput_metric = ThroughputMetric(
-                batch_size=32,
-                world_size=1,
-                window_seconds=100,
-                warmup_steps=10,
-            )
-
-        return RecMetricModule(
-            batch_size=32,
-            world_size=1,
-            rec_tasks=tasks,
-            rec_metrics=rec_metrics,
-            throughput_metric=throughput_metric,
-        )
-
-    def _get_state_dict_keys(
-        self, with_throughput: bool = False, with_metrics: bool = True
-    ) -> List[str]:
-        module = self._create_rec_metric_module(
-            with_throughput=with_throughput, with_metrics=with_metrics
-        )
-        return sorted(module.state_dict().keys())
-
-    def test_rec_metric_module_compatibility(self) -> None:
-        key = REC_METRIC_MODULE_SNAPSHOT_KEY
-
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_throughput=False)
-            self.golden_snapshot[key] = {
-                "metric_class": "RecMetricModule",
-                "variant": "",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_throughput=False))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}."
-            )
-
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(
-                added_keys, with_throughput=False
-            ):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
-                )
-
-    def test_rec_metric_module_with_throughput_compatibility(self) -> None:
-        key = REC_METRIC_MODULE_WITH_THROUGHPUT_KEY
-
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_throughput=True)
-            self.golden_snapshot[key] = {
-                "metric_class": "RecMetricModule",
-                "variant": "with_throughput",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_throughput=True))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}."
-            )
-
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(
-                added_keys, with_throughput=True
-            ):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
-                )
-
-    def _verify_backward_compatibility(
-        self, added_keys: Set[str], with_throughput: bool = False
-    ) -> bool:
-        try:
-            module = self._create_rec_metric_module(with_throughput=with_throughput)
-            state_dict = module.state_dict()
-            old_checkpoint = {
-                k: v for k, v in state_dict.items() if k not in added_keys
-            }
-
-            fresh_module = self._create_rec_metric_module(
-                with_throughput=with_throughput
-            )
-            fresh_module.load_state_dict(old_checkpoint, strict=True)
-            return True
-        except Exception:
-            return False
+    """Round-trip checks for RecMetricModule that are not golden comparisons."""
 
     def test_rec_metric_module_state_roundtrip(self) -> None:
-        module = self._create_rec_metric_module(with_throughput=True)
+        module = _make_rec_metric_module(_make_throughput_metric())
         initial_state = module.state_dict()
 
-        fresh_module = self._create_rec_metric_module(with_throughput=True)
+        fresh_module = _make_rec_metric_module(_make_throughput_metric())
         fresh_module.load_state_dict(initial_state, strict=True)
 
         restored_state = fresh_module.state_dict()
@@ -1083,12 +1096,12 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
             )
 
     def test_rec_metric_module_backward_compat_trained_batches(self) -> None:
-        module = self._create_rec_metric_module()
+        module = _make_rec_metric_module()
         state_dict = module.state_dict()
 
         state_dict["_trained_batches"] = torch.tensor(100)
 
-        fresh_module = self._create_rec_metric_module()
+        fresh_module = _make_rec_metric_module()
         # strict=True matches production. Under strict=False this test passes
         # even without the pop hook.
         fresh_module.load_state_dict(state_dict, strict=True)
@@ -1105,7 +1118,7 @@ class MetricCoverageTest(unittest.TestCase):
     # Metrics that are intentionally excluded from testing (with reason)
     EXCLUDED_METRICS: Dict[str, str] = {
         # Add metrics here that should be excluded, with a reason
-        # e.g., "SomeMetric": "deprecated, will be removed in next release",
+        # e.g., "torchrec.metrics.foo.SomeMetric": "deprecated, removed next release",
     }
 
     @unittest.skipIf(
@@ -1716,9 +1729,12 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
             )
 
     def test_rec_metric_module_dcp_validation(self) -> None:
-        key = REC_METRIC_MODULE_SNAPSHOT_KEY
+        key = _REC_METRIC_MODULE_DEFAULT.key
         if key not in self.golden_snapshot:
-            self.skipTest(f"No golden snapshot for {key}")
+            self.fail(
+                f"No golden entry for {key}. This simulation needs one; run "
+                "with --update-golden."
+            )
 
         tasks = [create_test_task("task1")]
         ne_metric = NEMetric(
@@ -1755,9 +1771,45 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
             )
 
 
+def generate_schema_case_entries() -> Dict[str, Dict[str, Any]]:
+    """Golden entries for the _SCHEMA_CASES table.
+
+    The comparison path fails rather than writing a missing entry, so this is
+    the only way a new case gets one.
+    """
+    entries: Dict[str, Dict[str, Any]] = {}
+    for case in _SCHEMA_CASES:
+        if case.key in entries:
+            raise ValueError(
+                f"Two cases share the key {case.key!r}. One would overwrite the "
+                "other's golden entry."
+            )
+        module = case.build()
+        try:
+            entries[case.key] = {
+                "metric_class": case.expected_class.__name__,
+                "variant": case.variant,
+                "state_dict_keys": sorted(module.state_dict().keys()),
+                "persistent_buffer_fqns": [],
+                "non_persistent_buffer_fqns": [],
+            }
+        finally:
+            if case.cleanup is not None:
+                case.cleanup(module)
+    return entries
+
+
 def update_golden_snapshot() -> None:
     print("Generating golden snapshot...")
     snapshot = generate_golden_snapshot()
+    case_entries = generate_schema_case_entries()
+    collisions = sorted(set(snapshot) & set(case_entries))
+    if collisions:
+        raise ValueError(
+            f"Case keys collide with metric snapshot keys: {collisions}. "
+            "One generator would overwrite the other."
+        )
+    snapshot.update(case_entries)
     save_golden_snapshot(snapshot)
     print(f"Golden snapshot saved to {GOLDEN_SNAPSHOT_PATH}")
     print(f"Total metrics captured: {len(snapshot)}")

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -18,6 +18,7 @@ from typing import Any, Deque, Dict, List, Optional
 
 import torch
 import torch.nn as nn
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.distributed.utils import none_throws
 from torchrec.metrics.metrics_config import BatchSizeStage
 from torchrec.metrics.metrics_namespace import (
@@ -32,6 +33,7 @@ MAX_WINDOW_TS: int = 2 * 60 * 60  # 2 hours
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@checkpoint_schema_stable("ThroughputMetric")
 class ThroughputMetric(nn.Module):
     """
     The module to calculate throughput. Throughput is defined as the trained examples


### PR DESCRIPTION
Summary:

This diff makes regeneration refuse to bless a schema change.

Changing a golden entry's key set breaks checkpoints. The comparison already failed on it, but `--update-golden` rewrote the file unconditionally. The failing test even names that command, so silencing a real break took one step.

Regeneration now needs a record for each change, naming the reason, the migration, and an owner. An added key needs a `_SchemaAddition`, because DCP validates model FQNs before `load_state_dict` and no hook can repair it. A dropped key needs a `_SchemaRemoval` naming the hook that pops it. Dropping a whole entry is refused outright, which stops a rename from re-entering as brand new.

Regeneration also refuses an empty baseline. An absent file reads as no entries, which makes every generated entry brand new and silences all three gates at once.

A hand-edited golden still bypasses the records. That is the design for a whole-entry removal, and for the rest the golden diff is the trace and code review is the backstop.

Differential Revision: D118982267


