### PR TITLE
TWRW multi-node: resolve the placement at runtime

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -31,6 +31,8 @@ from torchrec.distributed.planner.types import (
     Enumerator,
     ParameterConstraints,
     PartitionByType,
+    PlannerError,
+    PlannerErrorType,
     Shard,
     SharderDataMap,
     ShardEstimator,
@@ -227,6 +229,7 @@ class EmbeddingEnumerator(Enumerator):
                 for sharding_type in self._filter_sharding_types(
                     name, sharder.sharding_types(self._compute_device), sharder_key
                 ):
+                    num_nodes = self._extract_num_nodes(name, sharding_type)
                     for compute_kernel in self._filter_compute_kernels(
                         name,
                         sharder.compute_kernels(sharding_type, self._compute_device),
@@ -244,6 +247,7 @@ class EmbeddingEnumerator(Enumerator):
                                 col_wise_shard_dim=col_wise_shard_dim,
                                 device_memory_sizes=self._device_memory_sizes,
                                 num_buckets=num_buckets,
+                                num_nodes=num_nodes,
                             )
                         except ZeroDivisionError as e:
                             # Re-raise with additional context about the table and module
@@ -273,7 +277,9 @@ class EmbeddingEnumerator(Enumerator):
                                 batch_size=self._batch_size,
                                 compute_kernel=compute_kernel,
                                 sharding_type=sharding_type,
-                                partition_by=get_partition_by_type(sharding_type),
+                                partition_by=get_partition_by_type(
+                                    sharding_type, num_nodes
+                                ),
                                 shards=[
                                     Shard(size=size, offset=offset)
                                     for size, offset in zip(shard_sizes, shard_offsets)
@@ -290,6 +296,7 @@ class EmbeddingEnumerator(Enumerator):
                                 stash_weights=self._get_stash_weights(
                                     name, child_module
                                 ),
+                                num_nodes=num_nodes,
                             )
                         )
                 if not sharding_options_per_table:
@@ -310,6 +317,50 @@ class EmbeddingEnumerator(Enumerator):
         # Caching the search space with a copy of sharding options, to avoid unexpected modifications to list
         self._last_stored_search_space = copy.deepcopy(sharding_options)
         return sharding_options
+
+    def _extract_num_nodes(self, parameter: str, sharding_type: str) -> Optional[int]:
+        """
+        The validated `num_nodes` constraint, or `None` where it does not apply.
+
+        TABLE_ROW_WISE only. A single node returns `None` so a stored plan stays
+        byte-identical to one planned before the constraint existed.
+
+        Unusable values are rejected here at plan time: `_multi_hosts_partition`
+        wraps host selection circularly, so an oversized value otherwise yields
+        a plan that puts two row blocks of a table on one rank.
+
+        The value is validated for every sharding type, not just the one it
+        applies to: a table whose enumeration drops TABLE_ROW_WISE still
+        fingerprints `num_nodes` into the planner context, so accepting an
+        unusable value there would invalidate a stored plan and then ignore
+        the constraint it was set for.
+        """
+        num_nodes = (
+            self._constraints[parameter].num_nodes
+            if self._constraints and self._constraints.get(parameter)
+            else None
+        )
+        if num_nodes is None:
+            return None
+        if num_nodes < 1:
+            raise PlannerError(
+                error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                message=(f"'{parameter}': num_nodes must be >= 1, got {num_nodes}."),
+            )
+        max_nodes = self._world_size // self._local_world_size
+        if num_nodes > max_nodes:
+            raise PlannerError(
+                error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                message=(
+                    f"'{parameter}': num_nodes={num_nodes} exceeds the {max_nodes} "
+                    f"node(s) available (world_size={self._world_size}, "
+                    f"intra_group_size={self._local_world_size}). Each node can hold "
+                    "at most one row block of a table."
+                ),
+            )
+        if sharding_type != ShardingType.TABLE_ROW_WISE.value:
+            return None
+        return num_nodes if num_nodes > 1 else None
 
     def _get_num_buckets(self, parameter: str, module: nn.Module) -> Optional[int]:
         """
@@ -582,12 +633,14 @@ def _extract_constraints_for_param(
     )
 
 
-def get_partition_by_type(sharding_type: str) -> str:
+def get_partition_by_type(sharding_type: str, num_nodes: Optional[int] = None) -> str:
     """
     Gets corresponding partition by type for provided sharding type.
 
     Args:
         sharding_type (str): sharding type string.
+        num_nodes (Optional[int]): TABLE_ROW_WISE row split; > 1 selects
+            MULTI_HOST.
 
     Returns:
         str: the corresponding `PartitionByType` value.
@@ -610,6 +663,15 @@ def get_partition_by_type(sharding_type: str) -> str:
     if sharding_type in device_sharding_types:
         return PartitionByType.DEVICE.value
     elif sharding_type in host_sharding_types:
+        # A TABLE_ROW_WISE table spanning several nodes is no longer a
+        # single-host placement, and MULTI_HOST's uniform partition over
+        # `num_shards / local_world_size` hosts is already the row cut it needs.
+        if (
+            sharding_type == ShardingType.TABLE_ROW_WISE.value
+            and num_nodes is not None
+            and num_nodes > 1
+        ):
+            return PartitionByType.MULTI_HOST.value
         return PartitionByType.HOST.value
     elif sharding_type in uniform_sharding_types:
         return PartitionByType.UNIFORM.value

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1321,12 +1321,13 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     Evaluator for TABLE_ROW_WISE sharding.
 
     Differences from base (TABLE_WISE):
-    - batch_inputs divided by intra_group_size (TWRW group size)
+    - batch_inputs divided by `get_batch_inputs_divisor`: the ranks the rows
+      are cut over, `intra_group_size * num_twrw_nodes`
     - Uses SR comm data type (always, unlike ROW_WISE which checks is_pooled)
     - No block_usage_penalty
     - Forward: Reduce-scatter (intra, within TWRW group) + All-to-all (inter, across groups)
     - Backward: All-to-all (inter) + All-gather (intra) + batched_copy
-    - Prefetch divided by intra_group_size
+    - Prefetch divided by the same
 
     Note: intra_group_size = pod_size * local_world_size. For pod_size=1,
     this equals local_world_size. For pod_size>1 (e.g. GB200_HP), the TWRW
@@ -1334,13 +1335,13 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     """
 
     def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
-        return ctx.intra_group_size
+        return ctx.intra_group_size * ctx.num_twrw_nodes
 
     def _get_input_read_size(
         self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
     ) -> float:
         """
-        TABLE_ROW_WISE: input_read_size = (raw / intra_group_size) * world_size * input_data_type_size.
+        TABLE_ROW_WISE: input_read_size = (raw / batch_inputs_divisor) * world_size * input_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1356,7 +1357,7 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         self, ctx: ShardPerfContext, use_min_dim: bool = False
     ) -> float:
         """
-        TABLE_ROW_WISE: embedding_lookup_size = (raw / intra_group_size) * world_size * emb_dim * table_data_type_size.
+        TABLE_ROW_WISE: embedding_lookup_size = (raw / batch_inputs_divisor) * world_size * emb_dim * table_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1400,11 +1401,12 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         """
         TABLE_ROW_WISE: expected_lookups for prefetch.
 
-        Uses intra_group_size as the divisor (matching the TWRW group size).
         Returns PRE-DIVISOR value since _default_prefetch_comp divides by
-        prefetch_divisor (intra_group_size) afterwards.
+        prefetch_divisor afterwards.
         """
-        effective_batch_inputs = ctx.batch_inputs / ctx.intra_group_size
+        effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
+            ctx=ctx
+        )
         expected_lookups = float(
             math.ceil(
                 effective_batch_inputs * ctx.world_size * ctx.input_data_type_size
@@ -1439,13 +1441,17 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             local_world_size=intra_local_world_size,
         )
 
-        # Inter-group: all-to-all across TWRW groups
+        # Inter-group: all-to-all across TWRW groups. Each of the
+        # `num_twrw_nodes` nodes produces one partial pooled result, so the
+        # all-to-all carries that many slots per feature for the consumer to
+        # sum.
         num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
         if num_groups > 1:
             inter_group_fwd_output_write_size = (
                 ctx.batch_outputs
                 * num_groups
+                * ctx.num_twrw_nodes
                 * ctx.emb_dim
                 * ctx.fwd_a2a_comm_data_type_size
             )
@@ -1467,13 +1473,15 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
         )
 
-        # Inter-group: all-to-all across TWRW groups
+        # Inter-group: all-to-all across TWRW groups, carrying the same
+        # `num_twrw_nodes` partials per feature as the forward pass.
         num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
         if num_groups > 1:
             inter_group_bwd_output_write_size = (
                 ctx.batch_outputs
                 * num_groups
+                * ctx.num_twrw_nodes
                 * ctx.emb_dim
                 * ctx.bwd_a2a_comm_data_type_size
             )
@@ -1505,8 +1513,8 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         return inter_comms + intra_comms + bwd_batched_copy
 
     def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
-        """TABLE_ROW_WISE divides prefetch by intra_group_size."""
-        return ctx.intra_group_size
+        """TABLE_ROW_WISE divides prefetch by the ranks it is cut over."""
+        return self.get_batch_inputs_divisor(ctx)
 
 
 class DataParallelEvaluator(EmbeddingShardingPerfEvaluator):

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -516,6 +516,10 @@ class ShardPerfContext:
     local_world_size: int = 1
     intra_group_size: int = 1  # pod_size * local_world_size; TWRW group size
 
+    # Per-table, not topology: for TABLE_ROW_WISE, how many of the topology's
+    # TWRW groups this table's rows span.
+    num_twrw_nodes: int = 1
+
     # Data type sizes
     input_data_type_size: float = BIGINT_DTYPE
     table_data_type_size: float = 4.0
@@ -747,6 +751,17 @@ class ShardPerfContext:
                 f"compute kernel: {sharding_option.compute_kernel}"
             )
 
+        num_twrw_nodes = 1
+        if sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value:
+            num_twrw_nodes = sharding_option.num_nodes or 1
+            expected_shards = num_twrw_nodes * topology.intra_group_size
+            if len(shard_sizes) != expected_shards:
+                raise ValueError(
+                    f"'{sharding_option.name}': num_nodes={num_twrw_nodes} needs "
+                    f"{expected_shards} shards at an intra_group_size of "
+                    f"{topology.intra_group_size}, got {len(shard_sizes)}."
+                )
+
         # Build contexts
         contexts: List["ShardPerfContext"] = []
         for hash_size, emb_dim in shard_sizes:
@@ -761,6 +776,7 @@ class ShardPerfContext:
                 world_size=topology.world_size,
                 local_world_size=topology.local_world_size,
                 intra_group_size=topology.intra_group_size,
+                num_twrw_nodes=num_twrw_nodes,
                 input_data_type_size=input_data_type_size,
                 table_data_type_size=table_data_type_size,
                 output_data_type_size=output_data_type_size,

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -513,9 +513,13 @@ class GreedyPerfPartitioner(Partitioner):
         """
         # TODO: for now assume just one option for multi_hosts.
         if len(sharding_option_group.sharding_options) != 1:
+            names = [so.name for so in sharding_option_group.sharding_options]
             raise PlannerError(
                 error_type=PlannerErrorType.PARTITION,
-                message=f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}. Length needs to be 1",
+                message=(
+                    f"multi-host placement of {len(names)} co-located tables "
+                    f"{sorted(names)} is not supported."
+                ),
             )
         num_shards = sharding_option_group.sharding_options[0].num_shards
 
@@ -531,7 +535,7 @@ class GreedyPerfPartitioner(Partitioner):
         if remainder > 0:
             raise PlannerError(
                 error_type=PlannerErrorType.PARTITION,
-                message=f"Grid Sharding is unable to place shards equally over hosts without overlapping. {num_shards=} % {local_world_size=} != 0",
+                message=f"multi-host sharding is unable to place shards equally over hosts without overlapping. {num_shards=} % {local_world_size=} != 0",
             )
 
         sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
@@ -556,11 +560,41 @@ class GreedyPerfPartitioner(Partitioner):
                     )
                 )
             host_index += 1  # shift to next host
+            sharding_option = sharding_option_group.sharding_options[0]
+
+            # `_uniform_partition` pairs shards to `devices` positionally, so
+            # this order becomes `ParameterSharding.ranks`. The runtime keys a
+            # feature's bucket off a rank's index there and stored plans persist
+            # rank-sorted, so perf order would reload as a different placement.
+            if sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value:
+                devices = sorted(devices, key=lambda d: d.rank)
+
             host_devices = copy.deepcopy(devices)
             success = True
-            sharding_option = sharding_option_group.sharding_options[0]
+
+            # Circular reuse above can list one host twice, which GRID_SHARD
+            # supports but TABLE_ROW_WISE cannot: two row blocks on one rank means a
+            # duplicate bucket destination. Raised before the `try` because that
+            # swallows a PlannerError to retry the next offset, and no offset
+            # fixes a reuse.
+            if (
+                sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value
+                and len({d.rank for d in host_devices}) != len(host_devices)
+            ):
+                raise PlannerError(
+                    error_type=PlannerErrorType.PARTITION,
+                    message=(
+                        f"'{sharding_option.name}': TABLE_ROW_WISE placement over "
+                        f"{num_host_to_allocate} nodes reused a node "
+                        f"(only {len(sorted_host_level_devices)} available)."
+                    ),
+                )
             try:
-                if sharding_option.sharding_type == ShardingType.GRID_SHARD.value:
+                if sharding_option.sharding_type in (
+                    ShardingType.GRID_SHARD.value,
+                    # Same placement as grid: uniform over that many hosts.
+                    ShardingType.TABLE_ROW_WISE.value,
+                ):
                     GreedyPerfPartitioner._uniform_partition(
                         [sharding_option], host_devices
                     )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -204,6 +204,7 @@ def to_sharding_plan(
             bounds_check_mode=sharding_option.bounds_check_mode,
             output_dtype=sharding_option.output_dtype,
             key_value_params=sharding_option.key_value_params,
+            num_nodes=sharding_option.num_nodes,
         )
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]
@@ -481,6 +482,7 @@ def extract_plan(
                     feature_names=so.feature_names,
                     output_dtype=so.output_dtype,
                     key_value_params=so.key_value_params,
+                    num_nodes=so.num_nodes,
                 )
             )
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -660,6 +660,7 @@ def _calculate_shard_io_sizes(
             output_data_type_size=output_data_type_size,
             num_poolings=num_poolings,
             is_pooled=is_pooled,
+            sharding_type=sharding_type,
         )
     else:
         raise ValueError(
@@ -824,10 +825,23 @@ def _calculate_twrw_shard_io_sizes(
     output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
+    # Required: this helper serves TABLE_ROW_WISE and GRID_SHARD, and the two
+    # want different divisors below. A default would silently cost a grid
+    # table as row-wise for any caller that forgot to pass it.
+    sharding_type: str,
 ) -> Tuple[List[int], List[int]]:
+    # Ranks the table is bucketized over, matching the perf estimator's
+    # divisor. GRID_SHARD shares this helper, but its extra shards are column
+    # blocks that replicate ids rather than splitting them, so its width stays
+    # `local_world_size`.
+    batch_inputs_divisor = (
+        len(shard_sizes)
+        if sharding_type == ShardingType.TABLE_ROW_WISE.value
+        else local_world_size
+    )
     batch_inputs = (
         sum([x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)])
-        / local_world_size
+        / batch_inputs_divisor
     )
     if is_pooled:
         batch_outputs = sum(

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -19,6 +19,10 @@ from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.partitioners import (
+    GreedyPerfPartitioner,
+    ShardingOptionGroup,
+)
 from torchrec.distributed.planner.perf_models import NoopPerfModel
 from torchrec.distributed.planner.planners import (
     EmbeddingShardingPlanner,
@@ -35,7 +39,10 @@ from torchrec.distributed.planner.storage_reservations import (
     SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import (
+    DeviceHardware,
     ParameterConstraints,
+    PartitionByType,
+    Perf,
     PlanLoader,
     PlannerContextFingerprintError,
     PlannerError,
@@ -53,6 +60,7 @@ from torchrec.distributed.types import (
     CacheParams,
     DataType,
     EmbeddingModuleShardingPlan,
+    EnumerableShardingSpec,
     KeyValueParams,
     ModuleSharder,
     ShardingPlan,
@@ -386,6 +394,236 @@ class TestEmbeddingShardingPlannerWithConstraints(unittest.TestCase):
                 constraint.bounds_check_mode, sharding_option.bounds_check_mode
             )
             self.assertEqual(constraint.is_weighted, sharding_option.is_weighted)
+
+
+class TWRWSharder(EmbeddingBagCollectionSharder):
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [ShardingType.TABLE_ROW_WISE.value]
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        return [EmbeddingComputeKernel.FUSED.value]
+
+
+def _multi_host_devices(
+    num_hosts: int, host_load: Optional[List[float]] = None
+) -> List[List[DeviceHardware]]:
+    """`num_hosts` hosts of 2 ranks, optionally pre-loaded to set perf order."""
+    return [
+        [
+            DeviceHardware(
+                rank=host * 2 + local,
+                storage=Storage(hbm=1024 * 1024, ddr=0),
+                perf=Perf(
+                    fwd_compute=host_load[host] if host_load else 0.0,
+                    fwd_comms=0,
+                    bwd_compute=0,
+                    bwd_comms=0,
+                ),
+            )
+            for local in range(2)
+        ]
+        for host in range(num_hosts)
+    ]
+
+
+def _multi_host_group(
+    sharding_type: str, num_nodes: int, rows: int
+) -> ShardingOptionGroup:
+    """One table cut into `num_nodes` nodes' worth of shards at a node width of 2."""
+    num_shards = num_nodes * 2
+    block = rows // num_shards
+    return ShardingOptionGroup(
+        sharding_options=[
+            ShardingOption(
+                name="table_0",
+                tensor=torch.empty((rows, 64), device="meta"),
+                module=("sparse.ebc", nn.Module()),
+                input_lengths=[1.0],
+                batch_size=BATCH_SIZE,
+                sharding_type=sharding_type,
+                partition_by=PartitionByType.MULTI_HOST.value,
+                compute_kernel=EmbeddingComputeKernel.FUSED.value,
+                # Explicit so the bare module above is never walked for a
+                # pooling type it cannot have.
+                is_pooled=True,
+                shards=[
+                    Shard(
+                        size=[block, 64],
+                        offset=[block * i, 0],
+                        storage=Storage(hbm=1024, ddr=0),
+                        perf=Perf(
+                            fwd_compute=0, fwd_comms=0, bwd_compute=0, bwd_comms=0
+                        ),
+                    )
+                    for i in range(num_shards)
+                ],
+                num_nodes=num_nodes,
+            )
+        ],
+        storage_sum=Storage(hbm=num_shards * 1024, ddr=0),
+        perf_sum=0.0,
+        param_count=1,
+    )
+
+
+class TestTableRowWiseNumNodes(unittest.TestCase):
+    """`num_nodes` reaches the plan both as a declared field and as a placement."""
+
+    def setUp(self) -> None:
+        # 2 nodes of 2 ranks: enough for a table to span both.
+        self.topology = Topology(
+            world_size=4,
+            local_world_size=2,
+            hbm_cap=1024 * 1024 * 8,
+            compute_device="cuda",
+        )
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=1000,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+
+    def _plan(
+        self, constraints: Dict[str, ParameterConstraints]
+    ) -> EmbeddingModuleShardingPlan:
+        planner = EmbeddingShardingPlanner(
+            topology=self.topology, constraints=constraints
+        )
+        model = TestSparseNN(tables=self.tables, sparse_device=torch.device("meta"))
+        plan = planner.plan(
+            module=model,
+            sharders=[cast(ModuleSharder[nn.Module], TWRWSharder())],
+        )
+        return cast(EmbeddingModuleShardingPlan, plan.plan["sparse.ebc"])
+
+    def test_num_nodes_reaches_parameter_sharding(self) -> None:
+        """The constraint reaches `ParameterSharding` and cuts the rows over the
+        span; a table that does not opt in is untouched."""
+        ebc_plan = self._plan(
+            {
+                "table_0": ParameterConstraints(num_nodes=2),
+                "table_1": ParameterConstraints(),
+            }
+        )
+
+        split = ebc_plan["table_0"]
+        self.assertEqual(split.num_nodes, 2)
+        # Exact list, not a set of nodes: `{r // 2 for r in ranks} == {0, 1}`
+        # also holds for [0, 0, 2, 2], the duplicate-rank placement.
+        self.assertEqual(none_throws(split.ranks), [0, 1, 2, 3])
+        # Rows are partitioned across the 4 ranks, not replicated onto each:
+        # giving every rank `rows / num_nodes` stays numerically correct while
+        # silently doubling memory.
+        shards = none_throws(
+            cast(EnumerableShardingSpec, none_throws(split.sharding_spec)).shards
+        )
+        self.assertEqual([tuple(s.shard_sizes) for s in shards], [(250, 64)] * 4)
+        self.assertEqual(
+            [tuple(s.shard_offsets) for s in shards],
+            [(0, 0), (250, 0), (500, 0), (750, 0)],
+        )
+
+        # A table that does not opt in stays indistinguishable from stock: the
+        # field is unset rather than back-filled with 1, over one node's ranks.
+        stock = ebc_plan["table_1"]
+        self.assertIsNone(stock.num_nodes)
+        self.assertIn(none_throws(stock.ranks), ([0, 1], [2, 3]))
+        stock_shards = none_throws(
+            cast(EnumerableShardingSpec, none_throws(stock.sharding_spec)).shards
+        )
+        self.assertEqual([tuple(s.shard_sizes) for s in stock_shards], [(500, 64)] * 2)
+
+    def test_num_nodes_one_hashes_as_unset(self) -> None:
+        """A stored plan refuses to load when the constraint digest differs, so
+        a difference here strands the plan of anyone writing `num_nodes=1`."""
+        self.assertEqual(
+            hash(ParameterConstraints()), hash(ParameterConstraints(num_nodes=1))
+        )
+        self.assertNotEqual(
+            hash(ParameterConstraints()), hash(ParameterConstraints(num_nodes=2))
+        )
+
+    def test_unusable_num_nodes_is_rejected(self) -> None:
+        """0 reaches `_multi_hosts_partition` as a zero-host placement, a
+        negative slices the host list backwards, and an oversized value has no
+        node to put the last row block on."""
+        # Matched on message, not on a bare PlannerError: storage exhaustion and
+        # partition failure raise the same type, so a bare check would pass with
+        # the validation deleted.
+        for num_nodes, message in (
+            (3, "exceeds the 2 node"),
+            (0, "must be >= 1"),
+            (-1, "must be >= 1"),
+        ):
+            with self.subTest(num_nodes=num_nodes):
+                with self.assertRaisesRegex(PlannerError, message):
+                    self._plan({"table_0": ParameterConstraints(num_nodes=num_nodes)})
+
+    def test_unusable_num_nodes_is_rejected_for_another_sharding_type(self) -> None:
+        """`num_nodes` is fingerprinted into the planner context whatever the
+        sharding type, so a sharder that never offers TABLE_ROW_WISE has to
+        reject an unusable value too rather than stranding a stored plan on a
+        constraint it then drops."""
+        planner = EmbeddingShardingPlanner(
+            topology=self.topology,
+            constraints={"table_0": ParameterConstraints(num_nodes=3)},
+        )
+        model = TestSparseNN(tables=self.tables, sparse_device=torch.device("meta"))
+        with self.assertRaisesRegex(PlannerError, "exceeds the 2 node"):
+            planner.plan(
+                module=model,
+                sharders=[cast(ModuleSharder[nn.Module], TWvsRWSharder())],
+            )
+
+    def test_multi_host_partition_places_row_blocks_in_rank_order(self) -> None:
+        """`_uniform_partition` consumes the device list positionally, so perf
+        order would decide which node holds row block 0. The runtime takes a
+        feature's bucket from a rank's index there and stored plans persist
+        rank-sorted, so that would reload as a different placement."""
+        # Host 0 is loaded, making perf order the reverse of rank order.
+        row_wise = _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 2, 1000)
+        GreedyPerfPartitioner._multi_hosts_partition(
+            row_wise, _multi_host_devices(2, host_load=[100.0, 0.0])
+        )
+        self.assertEqual(
+            [shard.rank for shard in row_wise.sharding_options[0].shards], [0, 1, 2, 3]
+        )
+
+        # GRID_SHARD shares this path and keeps the perf order it has today.
+        grid = _multi_host_group(ShardingType.GRID_SHARD.value, 2, 1000)
+        GreedyPerfPartitioner._multi_hosts_partition(
+            grid, _multi_host_devices(2, host_load=[100.0, 0.0])
+        )
+        self.assertEqual(
+            [shard.rank for shard in grid.sharding_options[0].shards], [2, 3, 0, 1]
+        )
+
+    def test_multi_host_partition_rejects_a_reused_host(self) -> None:
+        """Host selection wraps circularly, which GRID_SHARD tolerates and
+        row-wise cannot: two row blocks on one rank is a duplicate bucket
+        destination."""
+        # Called directly because `_extract_num_nodes` rejects the oversized
+        # `num_nodes` first; this is the second line of that defense.
+        with self.assertRaisesRegex(PlannerError, "reused a node"):
+            GreedyPerfPartitioner._multi_hosts_partition(
+                _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 3, 1002),
+                _multi_host_devices(2),
+            )
+
+        # Three real hosts must still place, or a check that rejected every
+        # multi-node TABLE_ROW_WISE placement would pass the assertion above.
+        group = _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 3, 1002)
+        GreedyPerfPartitioner._multi_hosts_partition(group, _multi_host_devices(3))
+        self.assertEqual(
+            [shard.rank for shard in group.sharding_options[0].shards],
+            [0, 1, 2, 3, 4, 5],
+        )
 
 
 class TestEmbeddingShardingHashPlannerContextInputs(unittest.TestCase):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1342,6 +1342,9 @@ class ShardingOption:
             table's weights GPU->CPU during the dense forward/backward. Set on the
             table config before planning; the planner reflects the HBM that stashing
             frees in its storage estimates.
+        num_nodes (Optional[int]): carried from `ParameterConstraints.num_nodes`
+            so the plan states the row split rather than leaving the runtime to
+            infer it from the placement.
     """
 
     def __init__(
@@ -1366,6 +1369,7 @@ class ShardingOption:
         key_value_params: Optional[KeyValueParams] = None,
         num_poolings: Optional[List[float]] = None,
         stash_weights: bool = False,
+        num_nodes: Optional[int] = None,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -1394,6 +1398,7 @@ class ShardingOption:
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
         self.stash_weights: bool = stash_weights
+        self.num_nodes: Optional[int] = num_nodes
 
         child_module = module[1]
         self._module_type_key: str = (
@@ -1654,6 +1659,12 @@ class ParameterConstraints:
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE, either for
             SSD or PS.
         use_virtual_table (bool): is virtual table enabled for this table.
+        num_nodes (Optional[int]): TABLE_ROW_WISE only. Number of nodes the
+            table's rows are split across. `None` (the default) and 1 both mean
+            the stock single-node placement; values > 1 spread one logical
+            table over `num_nodes * topology.intra_group_size` ranks at full
+            width. A node is torchrec's topology group, which is one host only
+            when `pod_size == 1`.
     """
 
     sharding_types: Optional[List[str]] = None
@@ -1674,11 +1685,12 @@ class ParameterConstraints:
     device_group: Optional[str] = None
     key_value_params: Optional[KeyValueParams] = None
     use_virtual_table: bool = False
+    num_nodes: Optional[int] = None
 
     def _hashable_values(
         self, cache_params: object, key_value_params: object
     ) -> Tuple[Any, ...]:
-        return (
+        hashable_values = (
             tuple(self.sharding_types) if self.sharding_types else None,
             tuple(self.compute_kernels) if self.compute_kernels else None,
             self.min_partition,
@@ -1696,6 +1708,12 @@ class ParameterConstraints:
             key_value_params,
             self.use_virtual_table,
         )
+        # A stored plan is refused when this digest does not match, so extend
+        # the fingerprint only for a real opt-in. Plans cached before the field
+        # existed stay valid.
+        if self.num_nodes is not None and self.num_nodes > 1:
+            return (*hashable_values, self.num_nodes)
+        return hashable_values
 
     def _persistent_hash(
         self,

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -175,6 +175,14 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             # pyrefly: ignore[missing-attribute]
             shards = info.param_sharding.sharding_spec.shards
 
+            table_name = info.embedding_config.name
+            num_nodes: int = info.param_sharding.num_nodes or 1
+            if num_nodes > 1:
+                raise NotImplementedError(
+                    f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is "
+                    "not supported by the runtime yet."
+                )
+
             # construct the global sharded_tensor_metadata
             global_metadata = ShardedTensorMetadata(
                 shards_metadata=shards,

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -131,6 +131,79 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             if group_config.has_feature_processor:
                 self._has_feature_processor = True
 
+    def _resolve_placement_ranks(
+        self,
+        table_name: str,
+        num_nodes: int,
+        plan_ranks: List[int],
+        num_shards: int,
+        table_node: int,
+    ) -> List[int]:
+        """
+        Ranks holding a table's row blocks: `ranks[i]` holds `shards[i]`.
+
+        A single-node table derives them from `table_node`: `_shard` only
+        ever read `ranks[0]`, so a plan may list just that one. A multi-node
+        table takes them from the plan, since the nodes it spans do not follow
+        from `table_node`.
+
+        Which of the two applies is declared by `num_nodes`, never inferred
+        from `len(ranks)`: the planner and the runtime size a node from
+        `Topology.intra_group_size` and `intra_and_cross_node_pg`, so a
+        rank-count test would self-activate whenever those disagree.
+        """
+        local_size = self._local_size
+        if num_nodes < 1:
+            raise ValueError(f"'{table_name}': num_nodes={num_nodes} must be >= 1.")
+
+        if num_nodes == 1:
+            if not self._is_2D_parallel and len(plan_ranks) > local_size:
+                raise ValueError(
+                    f"'{table_name}': the plan places it on {len(plan_ranks)} "
+                    f"ranks, more than the {local_size} in a node, but does "
+                    "not set num_nodes. The planner and the runtime disagree "
+                    "on how wide a node is."
+                )
+            if num_shards < local_size:
+                raise ValueError(
+                    f"'{table_name}': a single-node table needs at least one "
+                    f"shard per rank, but the plan has {num_shards} shards for "
+                    f"a node of {local_size} ranks."
+                )
+            return list(range(table_node * local_size, (table_node + 1) * local_size))
+
+        if self._is_2D_parallel:
+            raise ValueError(
+                f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is not "
+                "supported under 2D parallelism."
+            )
+        if len(plan_ranks) != num_shards:
+            raise ValueError(
+                f"'{table_name}': a multi-node table pairs each rank with one "
+                f"row block, but the plan has {len(plan_ranks)} placement "
+                f"ranks for {num_shards} shards."
+            )
+        if len(plan_ranks) != num_nodes * local_size:
+            raise ValueError(
+                f"'{table_name}': num_nodes={num_nodes} needs "
+                f"{num_nodes * local_size} ranks at a node width of "
+                f"{local_size}, but the plan places it on {len(plan_ranks)}. "
+                "The planner and the runtime disagree on how wide a node is."
+            )
+        if len(set(plan_ranks)) != len(plan_ranks):
+            raise ValueError(
+                f"'{table_name}': placement ranks {plan_ranks} repeat a rank; "
+                "each row block needs its own."
+            )
+        nodes = {plan_rank // local_size for plan_rank in plan_ranks}
+        if len(nodes) != num_nodes:
+            raise ValueError(
+                f"'{table_name}': num_nodes={num_nodes} but its "
+                f"{len(plan_ranks)} ranks spread over {len(nodes)} nodes, so a "
+                "node holds only part of a row block."
+            )
+        return plan_ranks
+
     def _shard(
         self,
         sharding_infos: List[EmbeddingShardingInfo],
@@ -177,6 +250,14 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
 
             table_name = info.embedding_config.name
             num_nodes: int = info.param_sharding.num_nodes or 1
+            placement_ranks = self._resolve_placement_ranks(
+                table_name=table_name,
+                num_nodes=num_nodes,
+                # pyrefly: ignore[bad-argument-type]
+                plan_ranks=list(info.param_sharding.ranks),
+                num_shards=len(shards),
+                table_node=table_node,
+            )
             if num_nodes > 1:
                 raise NotImplementedError(
                     f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is "
@@ -208,11 +289,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     stride=info.param.stride(),
                 )
 
-            for rank in range(
-                table_node * local_size,
-                (table_node + 1) * local_size,
-            ):
-                rank_idx = rank - (table_node * local_size)
+            for rank_idx, rank in enumerate(placement_ranks):
                 tables_per_rank[rank].append(
                     ShardedEmbeddingTable(
                         num_embeddings=info.embedding_config.num_embeddings,

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -99,6 +99,7 @@ def calculate_shard_sizes_and_offsets(
     col_wise_shard_dim: Optional[int] = None,
     device_memory_sizes: Optional[List[int]] = None,
     num_buckets: Optional[int] = None,
+    num_nodes: Optional[int] = None,
 ) -> Tuple[List[List[int]], List[List[int]]]:
     """
     Calculates sizes and offsets for tensor sharded according to provided sharding type.
@@ -109,6 +110,9 @@ def calculate_shard_sizes_and_offsets(
         local_world_size (int): total number of devices in host group topology.
         sharding_type (str): provided ShardingType value.
         col_wise_shard_dim (Optional[int]): dimension for column wise sharding split.
+        num_nodes (Optional[int]): for TABLE_ROW_WISE, number of nodes the
+            table's rows are split across, in units of `local_world_size`.
+            Defaults to 1.
 
     Returns:
         Tuple[List[List[int]], List[List[int]]]: shard sizes, represented as a list of the dimensions of the sharded tensor on each device, and shard offsets, represented as a list of coordinates of placement on each device.
@@ -140,7 +144,9 @@ def calculate_shard_sizes_and_offsets(
             )
         )
     elif sharding_type == ShardingType.TABLE_ROW_WISE.value:
-        return _calculate_rw_shard_sizes_and_offsets(rows, local_world_size, columns)
+        return _calculate_rw_shard_sizes_and_offsets(
+            rows, (num_nodes or 1) * local_world_size, columns
+        )
     elif (
         sharding_type == ShardingType.COLUMN_WISE.value
         or sharding_type == ShardingType.TABLE_COLUMN_WISE.value
@@ -333,6 +339,7 @@ def _get_parameter_size_offsets(
     world_size: int,
     col_wise_shard_dim: Optional[int] = None,
     num_buckets: Optional[int] = None,
+    num_nodes: Optional[int] = None,
 ) -> List[Tuple[List[int], List[int]]]:
     (
         shard_sizes,
@@ -344,6 +351,7 @@ def _get_parameter_size_offsets(
         sharding_type=sharding_type.value,
         col_wise_shard_dim=col_wise_shard_dim,
         num_buckets=num_buckets,
+        num_nodes=num_nodes,
     )
     return list(zip(shard_sizes, shard_offsets))
 
@@ -396,6 +404,7 @@ def _get_parameter_sharding(
     sharder: ModuleSharder[nn.Module],
     placements: Optional[List[str]] = None,
     compute_kernel: Optional[str] = None,
+    num_nodes: Optional[int] = None,
 ) -> ParameterSharding:
     return ParameterSharding(
         sharding_spec=(
@@ -430,6 +439,7 @@ def _get_parameter_sharding(
             else _get_compute_kernel(sharder, param, sharding_type, device_type)
         ),
         ranks=[rank for (_, _, rank) in size_offset_ranks],
+        num_nodes=num_nodes,
     )
 
 
@@ -784,8 +794,11 @@ def table_row_wise(
     """
     Returns a generator of ParameterShardingPlan for `ShardingType::TABLE_ROW_WISE` for construct_module_sharding_plan.
 
+    Cuts the rows over the ranks of a single node. Use
+    `table_row_wise_multi_node` to spread them over several.
+
     Args:
-    host_index (int): index of host (node) to do row wise
+    host_index (int): index of the host (node) to do row wise
 
     Example::
 
@@ -797,6 +810,49 @@ def table_row_wise(
             },
         )
     """
+    return table_row_wise_multi_node(host_indexes=[host_index])
+
+
+def table_row_wise_multi_node(
+    host_indexes: List[int],
+) -> ParameterShardingGenerator:
+    """
+    Returns a generator of ParameterShardingPlan for `ShardingType::TABLE_ROW_WISE` for construct_module_sharding_plan.
+
+    Args:
+    host_indexes (List[int]): indexes of hosts (nodes) to split the rows across.
+        They need not be adjacent. Rows are cut over
+        `len(host_indexes) * local_size` ranks instead of one node's worth;
+        shards stay full width. The planner's equivalent
+        (`ParameterConstraints.num_nodes`) counts `Topology.intra_group_size`
+        ranks per node instead of `local_size`.
+
+    Example::
+
+        ebc = EmbeddingBagCollection(...)
+        plan = construct_module_sharding_plan(
+            ebc,
+            {
+                # rows split over hosts 0 and 3
+                "table_5": table_row_wise_multi_node(host_indexes=[0, 3]),
+            },
+        )
+    """
+    if not host_indexes:
+        raise ValueError(
+            "table_row_wise_multi_node: host_indexes must name at least one host."
+        )
+    if len(set(host_indexes)) != len(host_indexes):
+        raise ValueError(
+            f"table_row_wise_multi_node: host_indexes={host_indexes} names a host "
+            "twice. Two row blocks on one rank is a duplicate bucket destination."
+        )
+    # Sorted rather than caller order: a plan is persisted rank-ascending and
+    # reloaded with row offsets recomputed in that order, so an unsorted span
+    # would come back as a different placement. The planner's
+    # `_multi_hosts_partition` sorts for the same reason.
+    hosts: List[int] = sorted(host_indexes)
+    num_nodes: int = len(hosts)
 
     def _parameter_sharding_generator(
         param: nn.Parameter,
@@ -805,18 +861,30 @@ def table_row_wise(
         device_type: str,
         sharder: ModuleSharder[nn.Module],
     ) -> ParameterSharding:
+        total_num_hosts = world_size // local_size
+        out_of_range = [host for host in hosts if not 0 <= host < total_num_hosts]
+        if out_of_range:
+            raise ValueError(
+                f"table_row_wise_multi_node(host_indexes={hosts}) needs host(s) "
+                f"{out_of_range}, but there are only {total_num_hosts} "
+                f"(world_size={world_size}, local_size={local_size})."
+            )
+
         size_and_offsets = _get_parameter_size_offsets(
             param,
             ShardingType.TABLE_ROW_WISE,
             local_size,
             world_size,
+            num_nodes=num_nodes,
         )
 
         size_offset_ranks = []
-        assert len(size_and_offsets) <= local_size
-        for (size, offset), rank in zip(size_and_offsets, range(local_size)):
-            rank_offset = host_index * local_size
-            size_offset_ranks.append((size, offset, rank_offset + rank))
+        placement_ranks = [
+            host * local_size + rank for host in hosts for rank in range(local_size)
+        ]
+        assert len(size_and_offsets) <= len(placement_ranks)
+        for (size, offset), rank in zip(size_and_offsets, placement_ranks):
+            size_offset_ranks.append((size, offset, rank))
 
         return _get_parameter_sharding(
             param,
@@ -825,6 +893,8 @@ def table_row_wise(
             local_size,
             device_type,
             sharder,
+            # Unset for a single node: keeps pre-feature plans byte-identical.
+            num_nodes=num_nodes if num_nodes > 1 else None,
         )
 
     return _parameter_sharding_generator

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -9,7 +9,7 @@
 
 import copy
 import unittest
-from typing import Any, Dict, List, Optional
+from typing import Any, cast, Dict, List, Optional
 
 import hypothesis.strategies as st
 import torch
@@ -39,6 +39,7 @@ from torchrec.distributed.sharding_plan import (
     QuantEmbeddingCollectionSharder,
     row_wise,
     table_row_wise,
+    table_row_wise_multi_node,
     table_wise,
 )
 from torchrec.distributed.test_utils.multi_process import (
@@ -55,6 +56,7 @@ from torchrec.distributed.types import (
     ShardingType,
     ShardMetadata,
 )
+from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import data_type_to_dtype, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
@@ -1124,6 +1126,98 @@ class ConstructParameterShardingTest(unittest.TestCase):
         self.assertIn(
             "column dim of 65 cannot be evenly divided across [0, 1]",
             str(context.exception),
+        )
+
+    def _multi_node_plan(
+        self,
+        per_param_sharding: Dict[str, ParameterShardingGenerator],
+        world_size: int,
+        num_embeddings: int = 1000,
+    ) -> EmbeddingModuleShardingPlan:
+        tables = [
+            EmbeddingBagConfig(
+                name=name,
+                feature_names=["feature_" + name],
+                embedding_dim=64,
+                num_embeddings=num_embeddings,
+                data_type=DataType.FP32,
+            )
+            for name in per_param_sharding
+        ]
+        return construct_module_sharding_plan(
+            EmbeddingBagCollection(tables=tables),
+            per_param_sharding=per_param_sharding,
+            local_size=2,
+            world_size=world_size,
+            device_type="cuda",
+        )
+
+    def test_table_row_wise_multi_node_rejects_empty_span(self) -> None:
+        """An empty span leaves no ranks to place the table on."""
+        with self.assertRaisesRegex(ValueError, "at least one host"):
+            table_row_wise_multi_node(host_indexes=[])
+
+    def test_table_row_wise_multi_node_rejects_repeated_host(self) -> None:
+        """Two row blocks on one rank is a duplicate bucket destination."""
+        with self.assertRaisesRegex(ValueError, "names a host twice"):
+            table_row_wise_multi_node(host_indexes=[1, 1])
+
+    def test_table_row_wise_multi_node_rejects_host_past_the_end(self) -> None:
+        """Hosts are bounded against the world, or the plan names ranks that do
+        not exist."""
+        for host_indexes in ([1, 2], [-1, 0]):  # a 2-host world
+            with self.subTest(host_indexes=host_indexes):
+                with self.assertRaisesRegex(ValueError, r"but there are only 2"):
+                    self._multi_node_plan(
+                        {
+                            "table_0": table_row_wise_multi_node(
+                                host_indexes=host_indexes
+                            )
+                        },
+                        world_size=4,
+                    )
+
+    def test_table_row_wise_multi_node_sorts_a_scattered_span(self) -> None:
+        """Hosts need not be adjacent; the span is sorted because a plan is
+        persisted rank-ascending and reloaded with offsets in that order. The
+        span ends on the last host, so an off-by-one bound fails here."""
+        plan = self._multi_node_plan(
+            {
+                "table_0": table_row_wise_multi_node(host_indexes=[3, 0]),
+                "table_1": table_row_wise_multi_node(host_indexes=[1]),
+            },
+            world_size=8,
+        )
+        self.assertEqual(none_throws(plan["table_0"].ranks), [0, 1, 6, 7])
+        self.assertEqual(plan["table_0"].num_nodes, 2)
+        # A one-node span stays indistinguishable from a pre-feature plan.
+        self.assertEqual(none_throws(plan["table_1"].ranks), [2, 3])
+        self.assertIsNone(plan["table_1"].num_nodes)
+
+    def test_table_row_wise_multi_node_cuts_rows_across_the_span(self) -> None:
+        """Rows are partitioned over the span, not replicated per node: 10 rows
+        over 4 ranks is a `ceil` cut of 3/3/3/1."""
+        plan = self._multi_node_plan(
+            {
+                "table_0": table_row_wise_multi_node(host_indexes=[2, 0]),
+                "table_1": table_row_wise_multi_node(host_indexes=[1]),
+            },
+            world_size=8,
+            num_embeddings=10,
+        )
+
+        shards = none_throws(
+            cast(
+                EnumerableShardingSpec, none_throws(plan["table_0"].sharding_spec)
+            ).shards
+        )
+        self.assertEqual(
+            [tuple(shard.shard_sizes) for shard in shards],
+            [(3, 64), (3, 64), (3, 64), (1, 64)],
+        )
+        self.assertEqual(
+            [tuple(shard.shard_offsets) for shard in shards],
+            [(0, 0), (3, 0), (6, 0), (9, 0)],
         )
 
 

--- a/torchrec/distributed/tests/test_twrw_placement.py
+++ b/torchrec/distributed/tests/test_twrw_placement.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, List, Optional
+
+import torch
+from torch.distributed._shard.sharding_spec import EnumerableShardingSpec
+from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo
+from torchrec.distributed.sharding.twrw_sharding import BaseTwRwEmbeddingSharding
+from torchrec.distributed.types import ParameterSharding, ShardingType, ShardMetadata
+from torchrec.distributed.utils import none_throws
+from torchrec.modules.embedding_configs import EmbeddingTableConfig
+
+_LOCAL_SIZE: int = 4
+
+
+class _PlacementResolver:
+    """
+    `_resolve_placement_ranks` with only the two attributes it reads.
+
+    The real constructor needs a live `dist` world, and `object.__new__` is out
+    too: `EmbeddingSharding` is an ABC that `BaseTwRwEmbeddingSharding` does not
+    fully implement. Borrowing the function keeps these tests on shipped code.
+    """
+
+    _resolve_placement_ranks = BaseTwRwEmbeddingSharding._resolve_placement_ranks
+
+    def __init__(self, local_size: int, is_2D_parallel: bool = False) -> None:
+        self._local_size = local_size
+        self._is_2D_parallel = is_2D_parallel
+
+
+def _resolve(
+    num_nodes: int,
+    plan_ranks: List[int],
+    num_shards: Optional[int] = None,
+    table_node: int = 0,
+    local_size: int = _LOCAL_SIZE,
+    is_2D_parallel: bool = False,
+) -> List[int]:
+    resolver = _PlacementResolver(local_size, is_2D_parallel)
+    # pyrefly: ignore[bad-argument-type]
+    return resolver._resolve_placement_ranks(
+        table_name="table_0",
+        num_nodes=num_nodes,
+        plan_ranks=plan_ranks,
+        num_shards=len(plan_ranks) if num_shards is None else num_shards,
+        table_node=table_node,
+    )
+
+
+class ResolvePlacementRanksTest(unittest.TestCase):
+    """
+    Every rejection in `_resolve_placement_ranks`, plus the two accepted shapes.
+
+    It is the last check before a collective constructor: past it, a
+    contradictory `num_nodes` becomes a duplicate bucket destination or an
+    out-of-range rank inside an all-to-all, which hangs rather than raises.
+    """
+
+    def test_shard_and_rank_counts_must_match(self) -> None:
+        """Multi-node only, where `ranks[i]` pairs with `shards[i]`: a mismatch
+        reads past the end of `shards` or leaves a block unplaced."""
+        for placed, num_shards in ((8, 7), (0, 8)):
+            with self.subTest(placed=placed):
+                with self.assertRaisesRegex(
+                    ValueError, rf"{placed} placement ranks for {num_shards} shards"
+                ):
+                    _resolve(
+                        num_nodes=2,
+                        plan_ranks=list(range(placed)),
+                        num_shards=num_shards,
+                    )
+
+    def test_single_node_shard_shortfall_is_rejected(self) -> None:
+        """The single-node branch fills the node from `table_node`, so too few
+        shards is a bare IndexError in `_shard`."""
+        with self.assertRaisesRegex(ValueError, r"2 shards for a node of 4 ranks"):
+            _resolve(num_nodes=1, plan_ranks=[0, 1], num_shards=2)
+
+    def test_num_nodes_below_one_is_rejected(self) -> None:
+        """0 makes the width check `num_nodes * local_size` demand zero ranks;
+        a negative demands a negative number."""
+        for num_nodes in (0, -1):
+            with self.subTest(num_nodes=num_nodes):
+                with self.assertRaisesRegex(
+                    ValueError, rf"num_nodes={num_nodes} must be >= 1"
+                ):
+                    _resolve(num_nodes=num_nodes, plan_ranks=[0, 1, 2, 3])
+
+    def test_multi_node_under_2d_parallelism_is_rejected(self) -> None:
+        """Under 2D `plan_ranks` is global while `_shard` maps it through the
+        peer group, so a multi-node placement has no defined meaning yet."""
+        with self.assertRaisesRegex(
+            ValueError, r"num_nodes=2 is not supported under 2D parallelism"
+        ):
+            _resolve(
+                num_nodes=2,
+                plan_ranks=list(range(8)),
+                is_2D_parallel=True,
+            )
+
+    def test_single_node_placed_wider_than_a_node_is_rejected(self) -> None:
+        """The case `num_nodes` exists to disambiguate: 8 ranks at a node width
+        of 4 is either a two-node placement or a planner/runtime disagreement
+        about node width. Undeclared, it is the second, and inferring the first
+        would activate the feature on a table that never asked for it."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"the plan places it on 8 ranks, more than the 4 in a node",
+        ):
+            _resolve(num_nodes=1, plan_ranks=list(range(8)))
+
+    def test_rank_count_must_match_num_nodes_times_local_size(self) -> None:
+        """The same node-width disagreement from the opt-in side: `num_nodes=2`
+        at a runtime node width of 4 needs exactly 8 ranks, under or over."""
+        for placed in (6, 12):
+            with self.subTest(placed=placed):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    r"num_nodes=2 needs 8 ranks at a node width of 4, but the "
+                    rf"plan places it on {placed}",
+                ):
+                    _resolve(num_nodes=2, plan_ranks=list(range(placed)))
+
+    def test_repeated_rank_is_rejected(self) -> None:
+        """Two row blocks on one rank, breaking the `ranks[i]` to `shards[i]`
+        pairing. Whole-node reuse is what an oversized `num_nodes` produces:
+        `_multi_hosts_partition` selects hosts circularly."""
+        for num_nodes, plan_ranks in (
+            (2, [0, 1, 2, 2, 4, 5, 6, 7]),
+            (2, [0, 1, 2, 3, 0, 1, 2, 3]),
+            (3, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3]),
+        ):
+            with self.subTest(plan_ranks=plan_ranks):
+                with self.assertRaisesRegex(ValueError, r"repeat a rank"):
+                    _resolve(num_nodes=num_nodes, plan_ranks=plan_ranks)
+
+    def test_span_wider_than_num_nodes_is_rejected(self) -> None:
+        """The right rank count, all distinct, but spread wider than declared.
+        Distinct ranks cannot span fewer, so this is the only shape left once
+        the duplicate check above has run."""
+        with self.assertRaisesRegex(ValueError, r"8 ranks spread over 3 nodes"):
+            _resolve(num_nodes=2, plan_ranks=[0, 1, 2, 3, 4, 5, 8, 9])
+
+    def test_single_node_derives_the_whole_node(self) -> None:
+        """The stock placement: the table owns its node's ranks, derived from
+        `table_node` rather than echoed from the plan, so an unsorted plan
+        still comes back in node order."""
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[8, 9, 10, 11], table_node=2),
+            [8, 9, 10, 11],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[0, 1, 2, 3], table_node=0),
+            [0, 1, 2, 3],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[11, 10, 9, 8], table_node=2),
+            [8, 9, 10, 11],
+        )
+
+    def test_single_node_accepts_a_first_rank_only_plan(self) -> None:
+        """`_shard` only ever read `ranks[0]` for TABLE_ROW_WISE, so a plan
+        listing one rank has always been enough; requiring one per shard now
+        would reject plans that load today."""
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[8], num_shards=4, table_node=2),
+            [8, 9, 10, 11],
+        )
+
+    def test_single_node_wider_than_a_node_is_allowed_under_2d(self) -> None:
+        """2D is exempt from the width check: `plan_ranks` is a global
+        placement that `_shard` remaps, so it legitimately exceeds the sharding
+        group's node width. Dropping the guard would break every 2D
+        TABLE_ROW_WISE model, which no other case here catches."""
+        self.assertEqual(
+            _resolve(
+                num_nodes=1,
+                plan_ranks=list(range(8)),
+                table_node=1,
+                is_2D_parallel=True,
+            ),
+            [4, 5, 6, 7],
+        )
+
+    def test_multi_node_returns_plan_order_unsorted(self) -> None:
+        """`ranks[i]` pairs with `shards[i]`, so sorting would pair a rank with
+        a different row range."""
+        self.assertEqual(
+            _resolve(
+                num_nodes=2,
+                plan_ranks=[2, 3, 0, 1],
+                # Would give a different answer via the single-node branch.
+                table_node=1,
+                local_size=2,
+            ),
+            [2, 3, 0, 1],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=3, plan_ranks=[4, 5, 0, 1, 2, 3], local_size=2),
+            [4, 5, 0, 1, 2, 3],
+        )
+
+        # Ascending comes back unchanged too, so the above is order
+        # preservation and not the function reversing.
+        self.assertEqual(
+            _resolve(num_nodes=2, plan_ranks=[0, 1, 2, 3], local_size=2),
+            [0, 1, 2, 3],
+        )
+
+
+class _Sharder:
+    """`_shard` with only the attributes it reads; see `_PlacementResolver`."""
+
+    _resolve_placement_ranks = BaseTwRwEmbeddingSharding._resolve_placement_ranks
+    _shard = BaseTwRwEmbeddingSharding._shard
+
+    def __init__(self, world_size: int, local_size: int) -> None:
+        self._world_size = world_size
+        self._local_size = local_size
+        self._is_2D_parallel = False
+        self._pg = None
+        self._env: Any = type("_Env", (), {"output_dtensor": False})()
+
+
+def _sharding_info(
+    name: str,
+    rows: int,
+    dim: int,
+    ranks: List[int],
+    num_shards: int,
+    num_nodes: Optional[int] = None,
+) -> EmbeddingShardingInfo:
+    rows_per_shard = rows // num_shards
+    return EmbeddingShardingInfo(
+        embedding_config=EmbeddingTableConfig(
+            num_embeddings=rows,
+            embedding_dim=dim,
+            name=name,
+            feature_names=[f"f_{name}"],
+            embedding_names=[f"f_{name}"],
+        ),
+        param_sharding=ParameterSharding(
+            sharding_type=ShardingType.TABLE_ROW_WISE.value,
+            compute_kernel="dense",
+            ranks=ranks,
+            sharding_spec=EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_sizes=[rows_per_shard, dim],
+                        shard_offsets=[i * rows_per_shard, 0],
+                        placement=f"rank:{i}/cpu",
+                    )
+                    for i in range(num_shards)
+                ]
+            ),
+            num_nodes=num_nodes,
+        ),
+        param=torch.empty(rows, dim, device="meta"),
+    )
+
+
+class ShardPlacementTest(unittest.TestCase):
+    """
+    `_shard` itself, which `ResolvePlacementRanksTest` does not reach.
+
+    Without it, an implementation that resolved the placement and then threw it
+    away, keeping the loop `_resolve_placement_ranks` replaced, passes every
+    other test here.
+    """
+
+    def test_single_node_pairs_shards_with_the_derived_node(self) -> None:
+        """Row block `i` lands on the `i`th rank of the derived node."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        # One rank in the plan and four shards: all `_shard` ever read.
+        info = _sharding_info("t", rows=400, dim=8, ranks=[4], num_shards=4)
+        # pyrefly: ignore[bad-argument-type]
+        per_rank = sharder._shard([info])
+
+        placed = {r: t for r, t in enumerate(per_rank) if t}
+        self.assertEqual(sorted(placed), [4, 5, 6, 7])
+        self.assertEqual(
+            [
+                none_throws(placed[r][0].local_metadata).shard_offsets[0]
+                for r in sorted(placed)
+            ],
+            [0, 100, 200, 300],
+        )
+
+    def test_multi_node_is_refused_until_the_forward_path_exists(self) -> None:
+        """The placement resolves, but nothing bucketizes ids across nodes or
+        sums the per-node partials yet."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        info = _sharding_info(
+            "t", rows=800, dim=8, ranks=list(range(8)), num_shards=8, num_nodes=2
+        )
+        with self.assertRaisesRegex(NotImplementedError, r"num_nodes=2"):
+            # pyrefly: ignore[bad-argument-type]
+            sharder._shard([info])
+
+    def test_multi_node_shard_rank_mismatch_raises(self) -> None:
+        """`_shard` surfaces the resolver's rejections rather than swallowing
+        them."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        info = _sharding_info(
+            "t", rows=800, dim=8, ranks=list(range(8)), num_shards=8, num_nodes=2
+        )
+        info.param_sharding.ranks = list(range(7))
+        with self.assertRaisesRegex(ValueError, r"7 placement ranks for 8 shards"):
+            # pyrefly: ignore[bad-argument-type]
+            sharder._shard([info])

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -816,11 +816,15 @@ class ParameterSharding:
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
         output_dtype (Optional[DataType]): output dtype.
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE or PS.
+        num_nodes (Optional[int]): number of nodes this table's rows are split
+            across; see `ParameterConstraints.num_nodes`.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
       ShardingType.COLUMN_WISE - rank where the embedding shards are placed, seen as individual tables
-      ShardingType.TABLE_ROW_WISE  - first rank when this embedding is placed
+      ShardingType.TABLE_ROW_WISE  - first rank when this embedding is placed;
+        with num_nodes > 1, one rank per row block, positionally paired with
+        sharding_spec.shards
       ShardingType.ROW_WISE, ShardingType.DATA_PARALLEL - unused
 
     """
@@ -835,6 +839,7 @@ class ParameterSharding:
     bounds_check_mode: Optional[BoundsCheckMode] = None
     output_dtype: Optional[DataType] = None
     key_value_params: Optional[KeyValueParams] = None
+    num_nodes: Optional[int] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):


### PR DESCRIPTION
Summary:
A sharding plan hands the runtime a `ParameterSharding` per table: sharding
type, a rank list, and one `ShardMetadata` (size + offset) per shard.
`BaseTwRwEmbeddingSharding._shard` turns that into the per-rank tables the
lookup kernels are built from, so it is where the plan becomes a placement.

It used to derive that placement by looping over one node's ranks, reading
`ParameterSharding.ranks` only to work out *which* node, which holds exactly as
long as a table lives on one node. It now reads the placement through a new
`_resolve_placement_ranks` and validates it against the plan's `num_nodes`.

Whether rows span several nodes is read from `num_nodes`, never inferred from
`len(ranks)`. The planner sizes a node from `Topology.intra_group_size` and the
runtime from `intra_and_cross_node_pg`; when those disagree, inferring from the
rank count would switch the feature on for a table that never asked for it.

A single-node table's ranks are still derived from the node index, so
`plan_ranks` is only validated, never used for the result. That matters for
compatibility: `_shard` only ever read `ranks[0]` for TABLE_ROW_WISE, so nothing
guaranteed the rest of the list was populated and a plan listing one rank
alongside a full node's worth of shards has always been valid. Now rejected: a
plan listing more ranks than the runtime's node width (previously every entry
past `ranks[0]` was ignored), and fewer shards than the node is wide (previously
a bare `IndexError` further down). A *surplus* of shards is left alone, since
the replaced loop dropped the extras and raising would fail a job that runs
today.

A multi-node table's ranks are taken from the plan verbatim: `ranks[i]` pairs
with `shards[i]`, and the nodes it spans need not be contiguous. Both plan
producers already emit them rank-ascending, so returning them untouched honours
the pairing the plan states rather than accepting an unsorted shape. Now
rejected: a shard/rank count mismatch; `num_nodes > 1` under 2D parallelism,
where the plan's ranks are global and get remapped so a cross-node placement has
no defined meaning yet; a rank count that is not `num_nodes * local_size`; a
rank repeated within the placement, which puts two row blocks on one rank and
breaks the pairing; and a placement spread over more nodes than declared.

Those last two are ordered repeat-then-spread so each means one thing. Distinct
ranks filling `num_nodes * local_size` slots cannot cover fewer than `num_nodes`
nodes, so once repeats are rejected the node-count check can only be reporting a
wider spread.

`_shard` still refuses `num_nodes > 1`, so the placement it now resolves only
ever reproduces the node loop it replaced.

Differential Revision: D117328944


