### PR TITLE
TWRW multi-node: runtime

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -31,6 +31,8 @@ from torchrec.distributed.planner.types import (
     Enumerator,
     ParameterConstraints,
     PartitionByType,
+    PlannerError,
+    PlannerErrorType,
     Shard,
     SharderDataMap,
     ShardEstimator,
@@ -227,6 +229,7 @@ class EmbeddingEnumerator(Enumerator):
                 for sharding_type in self._filter_sharding_types(
                     name, sharder.sharding_types(self._compute_device), sharder_key
                 ):
+                    num_nodes = self._extract_num_nodes(name, sharding_type)
                     for compute_kernel in self._filter_compute_kernels(
                         name,
                         sharder.compute_kernels(sharding_type, self._compute_device),
@@ -244,6 +247,7 @@ class EmbeddingEnumerator(Enumerator):
                                 col_wise_shard_dim=col_wise_shard_dim,
                                 device_memory_sizes=self._device_memory_sizes,
                                 num_buckets=num_buckets,
+                                num_nodes=num_nodes,
                             )
                         except ZeroDivisionError as e:
                             # Re-raise with additional context about the table and module
@@ -273,7 +277,9 @@ class EmbeddingEnumerator(Enumerator):
                                 batch_size=self._batch_size,
                                 compute_kernel=compute_kernel,
                                 sharding_type=sharding_type,
-                                partition_by=get_partition_by_type(sharding_type),
+                                partition_by=get_partition_by_type(
+                                    sharding_type, num_nodes
+                                ),
                                 shards=[
                                     Shard(size=size, offset=offset)
                                     for size, offset in zip(shard_sizes, shard_offsets)
@@ -290,6 +296,7 @@ class EmbeddingEnumerator(Enumerator):
                                 stash_weights=self._get_stash_weights(
                                     name, child_module
                                 ),
+                                num_nodes=num_nodes,
                             )
                         )
                 if not sharding_options_per_table:
@@ -310,6 +317,50 @@ class EmbeddingEnumerator(Enumerator):
         # Caching the search space with a copy of sharding options, to avoid unexpected modifications to list
         self._last_stored_search_space = copy.deepcopy(sharding_options)
         return sharding_options
+
+    def _extract_num_nodes(self, parameter: str, sharding_type: str) -> Optional[int]:
+        """
+        The validated `num_nodes` constraint, or `None` where it does not apply.
+
+        TABLE_ROW_WISE only. A single node returns `None` so a stored plan stays
+        byte-identical to one planned before the constraint existed.
+
+        Unusable values are rejected here at plan time: `_multi_hosts_partition`
+        wraps host selection circularly, so an oversized value otherwise yields
+        a plan that puts two row blocks of a table on one rank.
+
+        The value is validated for every sharding type, not just the one it
+        applies to: a table whose enumeration drops TABLE_ROW_WISE still
+        fingerprints `num_nodes` into the planner context, so accepting an
+        unusable value there would invalidate a stored plan and then ignore
+        the constraint it was set for.
+        """
+        num_nodes = (
+            self._constraints[parameter].num_nodes
+            if self._constraints and self._constraints.get(parameter)
+            else None
+        )
+        if num_nodes is None:
+            return None
+        if num_nodes < 1:
+            raise PlannerError(
+                error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                message=(f"'{parameter}': num_nodes must be >= 1, got {num_nodes}."),
+            )
+        max_nodes = self._world_size // self._local_world_size
+        if num_nodes > max_nodes:
+            raise PlannerError(
+                error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                message=(
+                    f"'{parameter}': num_nodes={num_nodes} exceeds the {max_nodes} "
+                    f"node(s) available (world_size={self._world_size}, "
+                    f"intra_group_size={self._local_world_size}). Each node can hold "
+                    "at most one row block of a table."
+                ),
+            )
+        if sharding_type != ShardingType.TABLE_ROW_WISE.value:
+            return None
+        return num_nodes if num_nodes > 1 else None
 
     def _get_num_buckets(self, parameter: str, module: nn.Module) -> Optional[int]:
         """
@@ -582,12 +633,14 @@ def _extract_constraints_for_param(
     )
 
 
-def get_partition_by_type(sharding_type: str) -> str:
+def get_partition_by_type(sharding_type: str, num_nodes: Optional[int] = None) -> str:
     """
     Gets corresponding partition by type for provided sharding type.
 
     Args:
         sharding_type (str): sharding type string.
+        num_nodes (Optional[int]): TABLE_ROW_WISE row split; > 1 selects
+            MULTI_HOST.
 
     Returns:
         str: the corresponding `PartitionByType` value.
@@ -610,6 +663,15 @@ def get_partition_by_type(sharding_type: str) -> str:
     if sharding_type in device_sharding_types:
         return PartitionByType.DEVICE.value
     elif sharding_type in host_sharding_types:
+        # A TABLE_ROW_WISE table spanning several nodes is no longer a
+        # single-host placement, and MULTI_HOST's uniform partition over
+        # `num_shards / local_world_size` hosts is already the row cut it needs.
+        if (
+            sharding_type == ShardingType.TABLE_ROW_WISE.value
+            and num_nodes is not None
+            and num_nodes > 1
+        ):
+            return PartitionByType.MULTI_HOST.value
         return PartitionByType.HOST.value
     elif sharding_type in uniform_sharding_types:
         return PartitionByType.UNIFORM.value

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1321,12 +1321,13 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     Evaluator for TABLE_ROW_WISE sharding.
 
     Differences from base (TABLE_WISE):
-    - batch_inputs divided by intra_group_size (TWRW group size)
+    - batch_inputs divided by `get_batch_inputs_divisor`: the ranks the rows
+      are cut over, `intra_group_size * num_twrw_nodes`
     - Uses SR comm data type (always, unlike ROW_WISE which checks is_pooled)
     - No block_usage_penalty
     - Forward: Reduce-scatter (intra, within TWRW group) + All-to-all (inter, across groups)
     - Backward: All-to-all (inter) + All-gather (intra) + batched_copy
-    - Prefetch divided by intra_group_size
+    - Prefetch divided by the same
 
     Note: intra_group_size = pod_size * local_world_size. For pod_size=1,
     this equals local_world_size. For pod_size>1 (e.g. GB200_HP), the TWRW
@@ -1334,13 +1335,13 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     """
 
     def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
-        return ctx.intra_group_size
+        return ctx.intra_group_size * ctx.num_twrw_nodes
 
     def _get_input_read_size(
         self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
     ) -> float:
         """
-        TABLE_ROW_WISE: input_read_size = (raw / intra_group_size) * world_size * input_data_type_size.
+        TABLE_ROW_WISE: input_read_size = (raw / batch_inputs_divisor) * world_size * input_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1356,7 +1357,7 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         self, ctx: ShardPerfContext, use_min_dim: bool = False
     ) -> float:
         """
-        TABLE_ROW_WISE: embedding_lookup_size = (raw / intra_group_size) * world_size * emb_dim * table_data_type_size.
+        TABLE_ROW_WISE: embedding_lookup_size = (raw / batch_inputs_divisor) * world_size * emb_dim * table_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1400,11 +1401,12 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         """
         TABLE_ROW_WISE: expected_lookups for prefetch.
 
-        Uses intra_group_size as the divisor (matching the TWRW group size).
         Returns PRE-DIVISOR value since _default_prefetch_comp divides by
-        prefetch_divisor (intra_group_size) afterwards.
+        prefetch_divisor afterwards.
         """
-        effective_batch_inputs = ctx.batch_inputs / ctx.intra_group_size
+        effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
+            ctx=ctx
+        )
         expected_lookups = float(
             math.ceil(
                 effective_batch_inputs * ctx.world_size * ctx.input_data_type_size
@@ -1439,13 +1441,17 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             local_world_size=intra_local_world_size,
         )
 
-        # Inter-group: all-to-all across TWRW groups
+        # Inter-group: all-to-all across TWRW groups. Each of the
+        # `num_twrw_nodes` nodes produces one partial pooled result, so the
+        # all-to-all carries that many slots per feature for the consumer to
+        # sum.
         num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
         if num_groups > 1:
             inter_group_fwd_output_write_size = (
                 ctx.batch_outputs
                 * num_groups
+                * ctx.num_twrw_nodes
                 * ctx.emb_dim
                 * ctx.fwd_a2a_comm_data_type_size
             )
@@ -1467,13 +1473,15 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
         )
 
-        # Inter-group: all-to-all across TWRW groups
+        # Inter-group: all-to-all across TWRW groups, carrying the same
+        # `num_twrw_nodes` partials per feature as the forward pass.
         num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
         if num_groups > 1:
             inter_group_bwd_output_write_size = (
                 ctx.batch_outputs
                 * num_groups
+                * ctx.num_twrw_nodes
                 * ctx.emb_dim
                 * ctx.bwd_a2a_comm_data_type_size
             )
@@ -1505,8 +1513,8 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         return inter_comms + intra_comms + bwd_batched_copy
 
     def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
-        """TABLE_ROW_WISE divides prefetch by intra_group_size."""
-        return ctx.intra_group_size
+        """TABLE_ROW_WISE divides prefetch by the ranks it is cut over."""
+        return self.get_batch_inputs_divisor(ctx)
 
 
 class DataParallelEvaluator(EmbeddingShardingPerfEvaluator):

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -516,6 +516,10 @@ class ShardPerfContext:
     local_world_size: int = 1
     intra_group_size: int = 1  # pod_size * local_world_size; TWRW group size
 
+    # Per-table, not topology: for TABLE_ROW_WISE, how many of the topology's
+    # TWRW groups this table's rows span.
+    num_twrw_nodes: int = 1
+
     # Data type sizes
     input_data_type_size: float = BIGINT_DTYPE
     table_data_type_size: float = 4.0
@@ -747,6 +751,17 @@ class ShardPerfContext:
                 f"compute kernel: {sharding_option.compute_kernel}"
             )
 
+        num_twrw_nodes = 1
+        if sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value:
+            num_twrw_nodes = sharding_option.num_nodes or 1
+            expected_shards = num_twrw_nodes * topology.intra_group_size
+            if len(shard_sizes) != expected_shards:
+                raise ValueError(
+                    f"'{sharding_option.name}': num_nodes={num_twrw_nodes} needs "
+                    f"{expected_shards} shards at an intra_group_size of "
+                    f"{topology.intra_group_size}, got {len(shard_sizes)}."
+                )
+
         # Build contexts
         contexts: List["ShardPerfContext"] = []
         for hash_size, emb_dim in shard_sizes:
@@ -761,6 +776,7 @@ class ShardPerfContext:
                 world_size=topology.world_size,
                 local_world_size=topology.local_world_size,
                 intra_group_size=topology.intra_group_size,
+                num_twrw_nodes=num_twrw_nodes,
                 input_data_type_size=input_data_type_size,
                 table_data_type_size=table_data_type_size,
                 output_data_type_size=output_data_type_size,

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -513,9 +513,13 @@ class GreedyPerfPartitioner(Partitioner):
         """
         # TODO: for now assume just one option for multi_hosts.
         if len(sharding_option_group.sharding_options) != 1:
+            names = [so.name for so in sharding_option_group.sharding_options]
             raise PlannerError(
                 error_type=PlannerErrorType.PARTITION,
-                message=f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}. Length needs to be 1",
+                message=(
+                    f"multi-host placement of {len(names)} co-located tables "
+                    f"{sorted(names)} is not supported."
+                ),
             )
         num_shards = sharding_option_group.sharding_options[0].num_shards
 
@@ -531,7 +535,7 @@ class GreedyPerfPartitioner(Partitioner):
         if remainder > 0:
             raise PlannerError(
                 error_type=PlannerErrorType.PARTITION,
-                message=f"Grid Sharding is unable to place shards equally over hosts without overlapping. {num_shards=} % {local_world_size=} != 0",
+                message=f"multi-host sharding is unable to place shards equally over hosts without overlapping. {num_shards=} % {local_world_size=} != 0",
             )
 
         sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
@@ -556,11 +560,41 @@ class GreedyPerfPartitioner(Partitioner):
                     )
                 )
             host_index += 1  # shift to next host
+            sharding_option = sharding_option_group.sharding_options[0]
+
+            # `_uniform_partition` pairs shards to `devices` positionally, so
+            # this order becomes `ParameterSharding.ranks`. The runtime keys a
+            # feature's bucket off a rank's index there and stored plans persist
+            # rank-sorted, so perf order would reload as a different placement.
+            if sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value:
+                devices = sorted(devices, key=lambda d: d.rank)
+
             host_devices = copy.deepcopy(devices)
             success = True
-            sharding_option = sharding_option_group.sharding_options[0]
+
+            # Circular reuse above can list one host twice, which GRID_SHARD
+            # supports but TABLE_ROW_WISE cannot: two row blocks on one rank means a
+            # duplicate bucket destination. Raised before the `try` because that
+            # swallows a PlannerError to retry the next offset, and no offset
+            # fixes a reuse.
+            if (
+                sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value
+                and len({d.rank for d in host_devices}) != len(host_devices)
+            ):
+                raise PlannerError(
+                    error_type=PlannerErrorType.PARTITION,
+                    message=(
+                        f"'{sharding_option.name}': TABLE_ROW_WISE placement over "
+                        f"{num_host_to_allocate} nodes reused a node "
+                        f"(only {len(sorted_host_level_devices)} available)."
+                    ),
+                )
             try:
-                if sharding_option.sharding_type == ShardingType.GRID_SHARD.value:
+                if sharding_option.sharding_type in (
+                    ShardingType.GRID_SHARD.value,
+                    # Same placement as grid: uniform over that many hosts.
+                    ShardingType.TABLE_ROW_WISE.value,
+                ):
                     GreedyPerfPartitioner._uniform_partition(
                         [sharding_option], host_devices
                     )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -204,6 +204,7 @@ def to_sharding_plan(
             bounds_check_mode=sharding_option.bounds_check_mode,
             output_dtype=sharding_option.output_dtype,
             key_value_params=sharding_option.key_value_params,
+            num_nodes=sharding_option.num_nodes,
         )
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]
@@ -481,6 +482,7 @@ def extract_plan(
                     feature_names=so.feature_names,
                     output_dtype=so.output_dtype,
                     key_value_params=so.key_value_params,
+                    num_nodes=so.num_nodes,
                 )
             )
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -660,6 +660,7 @@ def _calculate_shard_io_sizes(
             output_data_type_size=output_data_type_size,
             num_poolings=num_poolings,
             is_pooled=is_pooled,
+            sharding_type=sharding_type,
         )
     else:
         raise ValueError(
@@ -824,10 +825,23 @@ def _calculate_twrw_shard_io_sizes(
     output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
+    # Required: this helper serves TABLE_ROW_WISE and GRID_SHARD, and the two
+    # want different divisors below. A default would silently cost a grid
+    # table as row-wise for any caller that forgot to pass it.
+    sharding_type: str,
 ) -> Tuple[List[int], List[int]]:
+    # Ranks the table is bucketized over, matching the perf estimator's
+    # divisor. GRID_SHARD shares this helper, but its extra shards are column
+    # blocks that replicate ids rather than splitting them, so its width stays
+    # `local_world_size`.
+    batch_inputs_divisor = (
+        len(shard_sizes)
+        if sharding_type == ShardingType.TABLE_ROW_WISE.value
+        else local_world_size
+    )
     batch_inputs = (
         sum([x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)])
-        / local_world_size
+        / batch_inputs_divisor
     )
     if is_pooled:
         batch_outputs = sum(

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -19,6 +19,10 @@ from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.partitioners import (
+    GreedyPerfPartitioner,
+    ShardingOptionGroup,
+)
 from torchrec.distributed.planner.perf_models import NoopPerfModel
 from torchrec.distributed.planner.planners import (
     EmbeddingShardingPlanner,
@@ -35,7 +39,10 @@ from torchrec.distributed.planner.storage_reservations import (
     SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import (
+    DeviceHardware,
     ParameterConstraints,
+    PartitionByType,
+    Perf,
     PlanLoader,
     PlannerContextFingerprintError,
     PlannerError,
@@ -53,6 +60,7 @@ from torchrec.distributed.types import (
     CacheParams,
     DataType,
     EmbeddingModuleShardingPlan,
+    EnumerableShardingSpec,
     KeyValueParams,
     ModuleSharder,
     ShardingPlan,
@@ -386,6 +394,236 @@ class TestEmbeddingShardingPlannerWithConstraints(unittest.TestCase):
                 constraint.bounds_check_mode, sharding_option.bounds_check_mode
             )
             self.assertEqual(constraint.is_weighted, sharding_option.is_weighted)
+
+
+class TWRWSharder(EmbeddingBagCollectionSharder):
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [ShardingType.TABLE_ROW_WISE.value]
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        return [EmbeddingComputeKernel.FUSED.value]
+
+
+def _multi_host_devices(
+    num_hosts: int, host_load: Optional[List[float]] = None
+) -> List[List[DeviceHardware]]:
+    """`num_hosts` hosts of 2 ranks, optionally pre-loaded to set perf order."""
+    return [
+        [
+            DeviceHardware(
+                rank=host * 2 + local,
+                storage=Storage(hbm=1024 * 1024, ddr=0),
+                perf=Perf(
+                    fwd_compute=host_load[host] if host_load else 0.0,
+                    fwd_comms=0,
+                    bwd_compute=0,
+                    bwd_comms=0,
+                ),
+            )
+            for local in range(2)
+        ]
+        for host in range(num_hosts)
+    ]
+
+
+def _multi_host_group(
+    sharding_type: str, num_nodes: int, rows: int
+) -> ShardingOptionGroup:
+    """One table cut into `num_nodes` nodes' worth of shards at a node width of 2."""
+    num_shards = num_nodes * 2
+    block = rows // num_shards
+    return ShardingOptionGroup(
+        sharding_options=[
+            ShardingOption(
+                name="table_0",
+                tensor=torch.empty((rows, 64), device="meta"),
+                module=("sparse.ebc", nn.Module()),
+                input_lengths=[1.0],
+                batch_size=BATCH_SIZE,
+                sharding_type=sharding_type,
+                partition_by=PartitionByType.MULTI_HOST.value,
+                compute_kernel=EmbeddingComputeKernel.FUSED.value,
+                # Explicit so the bare module above is never walked for a
+                # pooling type it cannot have.
+                is_pooled=True,
+                shards=[
+                    Shard(
+                        size=[block, 64],
+                        offset=[block * i, 0],
+                        storage=Storage(hbm=1024, ddr=0),
+                        perf=Perf(
+                            fwd_compute=0, fwd_comms=0, bwd_compute=0, bwd_comms=0
+                        ),
+                    )
+                    for i in range(num_shards)
+                ],
+                num_nodes=num_nodes,
+            )
+        ],
+        storage_sum=Storage(hbm=num_shards * 1024, ddr=0),
+        perf_sum=0.0,
+        param_count=1,
+    )
+
+
+class TestTableRowWiseNumNodes(unittest.TestCase):
+    """`num_nodes` reaches the plan both as a declared field and as a placement."""
+
+    def setUp(self) -> None:
+        # 2 nodes of 2 ranks: enough for a table to span both.
+        self.topology = Topology(
+            world_size=4,
+            local_world_size=2,
+            hbm_cap=1024 * 1024 * 8,
+            compute_device="cuda",
+        )
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=1000,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+
+    def _plan(
+        self, constraints: Dict[str, ParameterConstraints]
+    ) -> EmbeddingModuleShardingPlan:
+        planner = EmbeddingShardingPlanner(
+            topology=self.topology, constraints=constraints
+        )
+        model = TestSparseNN(tables=self.tables, sparse_device=torch.device("meta"))
+        plan = planner.plan(
+            module=model,
+            sharders=[cast(ModuleSharder[nn.Module], TWRWSharder())],
+        )
+        return cast(EmbeddingModuleShardingPlan, plan.plan["sparse.ebc"])
+
+    def test_num_nodes_reaches_parameter_sharding(self) -> None:
+        """The constraint reaches `ParameterSharding` and cuts the rows over the
+        span; a table that does not opt in is untouched."""
+        ebc_plan = self._plan(
+            {
+                "table_0": ParameterConstraints(num_nodes=2),
+                "table_1": ParameterConstraints(),
+            }
+        )
+
+        split = ebc_plan["table_0"]
+        self.assertEqual(split.num_nodes, 2)
+        # Exact list, not a set of nodes: `{r // 2 for r in ranks} == {0, 1}`
+        # also holds for [0, 0, 2, 2], the duplicate-rank placement.
+        self.assertEqual(none_throws(split.ranks), [0, 1, 2, 3])
+        # Rows are partitioned across the 4 ranks, not replicated onto each:
+        # giving every rank `rows / num_nodes` stays numerically correct while
+        # silently doubling memory.
+        shards = none_throws(
+            cast(EnumerableShardingSpec, none_throws(split.sharding_spec)).shards
+        )
+        self.assertEqual([tuple(s.shard_sizes) for s in shards], [(250, 64)] * 4)
+        self.assertEqual(
+            [tuple(s.shard_offsets) for s in shards],
+            [(0, 0), (250, 0), (500, 0), (750, 0)],
+        )
+
+        # A table that does not opt in stays indistinguishable from stock: the
+        # field is unset rather than back-filled with 1, over one node's ranks.
+        stock = ebc_plan["table_1"]
+        self.assertIsNone(stock.num_nodes)
+        self.assertIn(none_throws(stock.ranks), ([0, 1], [2, 3]))
+        stock_shards = none_throws(
+            cast(EnumerableShardingSpec, none_throws(stock.sharding_spec)).shards
+        )
+        self.assertEqual([tuple(s.shard_sizes) for s in stock_shards], [(500, 64)] * 2)
+
+    def test_num_nodes_one_hashes_as_unset(self) -> None:
+        """A stored plan refuses to load when the constraint digest differs, so
+        a difference here strands the plan of anyone writing `num_nodes=1`."""
+        self.assertEqual(
+            hash(ParameterConstraints()), hash(ParameterConstraints(num_nodes=1))
+        )
+        self.assertNotEqual(
+            hash(ParameterConstraints()), hash(ParameterConstraints(num_nodes=2))
+        )
+
+    def test_unusable_num_nodes_is_rejected(self) -> None:
+        """0 reaches `_multi_hosts_partition` as a zero-host placement, a
+        negative slices the host list backwards, and an oversized value has no
+        node to put the last row block on."""
+        # Matched on message, not on a bare PlannerError: storage exhaustion and
+        # partition failure raise the same type, so a bare check would pass with
+        # the validation deleted.
+        for num_nodes, message in (
+            (3, "exceeds the 2 node"),
+            (0, "must be >= 1"),
+            (-1, "must be >= 1"),
+        ):
+            with self.subTest(num_nodes=num_nodes):
+                with self.assertRaisesRegex(PlannerError, message):
+                    self._plan({"table_0": ParameterConstraints(num_nodes=num_nodes)})
+
+    def test_unusable_num_nodes_is_rejected_for_another_sharding_type(self) -> None:
+        """`num_nodes` is fingerprinted into the planner context whatever the
+        sharding type, so a sharder that never offers TABLE_ROW_WISE has to
+        reject an unusable value too rather than stranding a stored plan on a
+        constraint it then drops."""
+        planner = EmbeddingShardingPlanner(
+            topology=self.topology,
+            constraints={"table_0": ParameterConstraints(num_nodes=3)},
+        )
+        model = TestSparseNN(tables=self.tables, sparse_device=torch.device("meta"))
+        with self.assertRaisesRegex(PlannerError, "exceeds the 2 node"):
+            planner.plan(
+                module=model,
+                sharders=[cast(ModuleSharder[nn.Module], TWvsRWSharder())],
+            )
+
+    def test_multi_host_partition_places_row_blocks_in_rank_order(self) -> None:
+        """`_uniform_partition` consumes the device list positionally, so perf
+        order would decide which node holds row block 0. The runtime takes a
+        feature's bucket from a rank's index there and stored plans persist
+        rank-sorted, so that would reload as a different placement."""
+        # Host 0 is loaded, making perf order the reverse of rank order.
+        row_wise = _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 2, 1000)
+        GreedyPerfPartitioner._multi_hosts_partition(
+            row_wise, _multi_host_devices(2, host_load=[100.0, 0.0])
+        )
+        self.assertEqual(
+            [shard.rank for shard in row_wise.sharding_options[0].shards], [0, 1, 2, 3]
+        )
+
+        # GRID_SHARD shares this path and keeps the perf order it has today.
+        grid = _multi_host_group(ShardingType.GRID_SHARD.value, 2, 1000)
+        GreedyPerfPartitioner._multi_hosts_partition(
+            grid, _multi_host_devices(2, host_load=[100.0, 0.0])
+        )
+        self.assertEqual(
+            [shard.rank for shard in grid.sharding_options[0].shards], [2, 3, 0, 1]
+        )
+
+    def test_multi_host_partition_rejects_a_reused_host(self) -> None:
+        """Host selection wraps circularly, which GRID_SHARD tolerates and
+        row-wise cannot: two row blocks on one rank is a duplicate bucket
+        destination."""
+        # Called directly because `_extract_num_nodes` rejects the oversized
+        # `num_nodes` first; this is the second line of that defense.
+        with self.assertRaisesRegex(PlannerError, "reused a node"):
+            GreedyPerfPartitioner._multi_hosts_partition(
+                _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 3, 1002),
+                _multi_host_devices(2),
+            )
+
+        # Three real hosts must still place, or a check that rejected every
+        # multi-node TABLE_ROW_WISE placement would pass the assertion above.
+        group = _multi_host_group(ShardingType.TABLE_ROW_WISE.value, 3, 1002)
+        GreedyPerfPartitioner._multi_hosts_partition(group, _multi_host_devices(3))
+        self.assertEqual(
+            [shard.rank for shard in group.sharding_options[0].shards],
+            [0, 1, 2, 3, 4, 5],
+        )
 
 
 class TestEmbeddingShardingHashPlannerContextInputs(unittest.TestCase):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1342,6 +1342,9 @@ class ShardingOption:
             table's weights GPU->CPU during the dense forward/backward. Set on the
             table config before planning; the planner reflects the HBM that stashing
             frees in its storage estimates.
+        num_nodes (Optional[int]): carried from `ParameterConstraints.num_nodes`
+            so the plan states the row split rather than leaving the runtime to
+            infer it from the placement.
     """
 
     def __init__(
@@ -1366,6 +1369,7 @@ class ShardingOption:
         key_value_params: Optional[KeyValueParams] = None,
         num_poolings: Optional[List[float]] = None,
         stash_weights: bool = False,
+        num_nodes: Optional[int] = None,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -1394,6 +1398,7 @@ class ShardingOption:
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
         self.stash_weights: bool = stash_weights
+        self.num_nodes: Optional[int] = num_nodes
 
         child_module = module[1]
         self._module_type_key: str = (
@@ -1654,6 +1659,12 @@ class ParameterConstraints:
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE, either for
             SSD or PS.
         use_virtual_table (bool): is virtual table enabled for this table.
+        num_nodes (Optional[int]): TABLE_ROW_WISE only. Number of nodes the
+            table's rows are split across. `None` (the default) and 1 both mean
+            the stock single-node placement; values > 1 spread one logical
+            table over `num_nodes * topology.intra_group_size` ranks at full
+            width. A node is torchrec's topology group, which is one host only
+            when `pod_size == 1`.
     """
 
     sharding_types: Optional[List[str]] = None
@@ -1674,11 +1685,12 @@ class ParameterConstraints:
     device_group: Optional[str] = None
     key_value_params: Optional[KeyValueParams] = None
     use_virtual_table: bool = False
+    num_nodes: Optional[int] = None
 
     def _hashable_values(
         self, cache_params: object, key_value_params: object
     ) -> Tuple[Any, ...]:
-        return (
+        hashable_values = (
             tuple(self.sharding_types) if self.sharding_types else None,
             tuple(self.compute_kernels) if self.compute_kernels else None,
             self.min_partition,
@@ -1696,6 +1708,12 @@ class ParameterConstraints:
             key_value_params,
             self.use_virtual_table,
         )
+        # A stored plan is refused when this digest does not match, so extend
+        # the fingerprint only for a real opt-in. Plans cached before the field
+        # existed stay valid.
+        if self.num_nodes is not None and self.num_nodes > 1:
+            return (*hashable_values, self.num_nodes)
+        return hashable_values
 
     def _persistent_hash(
         self,

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -175,6 +175,14 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             # pyrefly: ignore[missing-attribute]
             shards = info.param_sharding.sharding_spec.shards
 
+            table_name = info.embedding_config.name
+            num_nodes: int = info.param_sharding.num_nodes or 1
+            if num_nodes > 1:
+                raise NotImplementedError(
+                    f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is "
+                    "not supported by the runtime yet."
+                )
+
             # construct the global sharded_tensor_metadata
             global_metadata = ShardedTensorMetadata(
                 shards_metadata=shards,

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -131,6 +131,79 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             if group_config.has_feature_processor:
                 self._has_feature_processor = True
 
+    def _resolve_placement_ranks(
+        self,
+        table_name: str,
+        num_nodes: int,
+        plan_ranks: List[int],
+        num_shards: int,
+        table_node: int,
+    ) -> List[int]:
+        """
+        Ranks holding a table's row blocks: `ranks[i]` holds `shards[i]`.
+
+        A single-node table derives them from `table_node`: `_shard` only
+        ever read `ranks[0]`, so a plan may list just that one. A multi-node
+        table takes them from the plan, since the nodes it spans do not follow
+        from `table_node`.
+
+        Which of the two applies is declared by `num_nodes`, never inferred
+        from `len(ranks)`: the planner and the runtime size a node from
+        `Topology.intra_group_size` and `intra_and_cross_node_pg`, so a
+        rank-count test would self-activate whenever those disagree.
+        """
+        local_size = self._local_size
+        if num_nodes < 1:
+            raise ValueError(f"'{table_name}': num_nodes={num_nodes} must be >= 1.")
+
+        if num_nodes == 1:
+            if not self._is_2D_parallel and len(plan_ranks) > local_size:
+                raise ValueError(
+                    f"'{table_name}': the plan places it on {len(plan_ranks)} "
+                    f"ranks, more than the {local_size} in a node, but does "
+                    "not set num_nodes. The planner and the runtime disagree "
+                    "on how wide a node is."
+                )
+            if num_shards < local_size:
+                raise ValueError(
+                    f"'{table_name}': a single-node table needs at least one "
+                    f"shard per rank, but the plan has {num_shards} shards for "
+                    f"a node of {local_size} ranks."
+                )
+            return list(range(table_node * local_size, (table_node + 1) * local_size))
+
+        if self._is_2D_parallel:
+            raise ValueError(
+                f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is not "
+                "supported under 2D parallelism."
+            )
+        if len(plan_ranks) != num_shards:
+            raise ValueError(
+                f"'{table_name}': a multi-node table pairs each rank with one "
+                f"row block, but the plan has {len(plan_ranks)} placement "
+                f"ranks for {num_shards} shards."
+            )
+        if len(plan_ranks) != num_nodes * local_size:
+            raise ValueError(
+                f"'{table_name}': num_nodes={num_nodes} needs "
+                f"{num_nodes * local_size} ranks at a node width of "
+                f"{local_size}, but the plan places it on {len(plan_ranks)}. "
+                "The planner and the runtime disagree on how wide a node is."
+            )
+        if len(set(plan_ranks)) != len(plan_ranks):
+            raise ValueError(
+                f"'{table_name}': placement ranks {plan_ranks} repeat a rank; "
+                "each row block needs its own."
+            )
+        nodes = {plan_rank // local_size for plan_rank in plan_ranks}
+        if len(nodes) != num_nodes:
+            raise ValueError(
+                f"'{table_name}': num_nodes={num_nodes} but its "
+                f"{len(plan_ranks)} ranks spread over {len(nodes)} nodes, so a "
+                "node holds only part of a row block."
+            )
+        return plan_ranks
+
     def _shard(
         self,
         sharding_infos: List[EmbeddingShardingInfo],
@@ -177,6 +250,14 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
 
             table_name = info.embedding_config.name
             num_nodes: int = info.param_sharding.num_nodes or 1
+            placement_ranks = self._resolve_placement_ranks(
+                table_name=table_name,
+                num_nodes=num_nodes,
+                # pyrefly: ignore[bad-argument-type]
+                plan_ranks=list(info.param_sharding.ranks),
+                num_shards=len(shards),
+                table_node=table_node,
+            )
             if num_nodes > 1:
                 raise NotImplementedError(
                     f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is "
@@ -208,11 +289,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     stride=info.param.stride(),
                 )
 
-            for rank in range(
-                table_node * local_size,
-                (table_node + 1) * local_size,
-            ):
-                rank_idx = rank - (table_node * local_size)
+            for rank_idx, rank in enumerate(placement_ranks):
                 tables_per_rank[rank].append(
                     ShardedEmbeddingTable(
                         num_embeddings=info.embedding_config.num_embeddings,

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -10,7 +10,8 @@
 import itertools
 import logging
 import math
-from typing import Any, cast, Dict, List, Optional, Tuple, TypeVar
+from dataclasses import dataclass
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -69,6 +70,271 @@ W = TypeVar("W")
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _BucketGroup:
+    """Features that share one bucketize call."""
+
+    num_buckets: int
+    features: List[int]
+
+
+@dataclass(frozen=True)
+class _FeatureBucket:
+    """One key of the bucketized KJT."""
+
+    feature: int
+    bucket: int
+
+
+class _InputPlan:
+    """
+    How one input KJT is bucketized and reordered for the input AlltoAll.
+
+    The bucketize op takes one scalar bucket count per call, and that count
+    also routes ids at or above `block_size * count`, so features wanting
+    different counts cannot share a call: hence `bucket_groups`.
+    `rank_feature_bucket_indices` then reorders the feature buckets, which come
+    out group by group, into AlltoAll destination order.
+
+    Args:
+        num_buckets_per_feature (List[int]): buckets to cut each feature into.
+        feature_buckets (List[_FeatureBucket]): the feature bucket to place
+            at each position of the AlltoAll input, in destination order.
+        default_num_buckets (int): applies only when there are no features,
+            where one empty group keeps `_bucketize` on its single call path.
+    """
+
+    bucket_groups: List[_BucketGroup]
+    rank_feature_bucket_indices: List[int]
+
+    def __init__(
+        self,
+        num_buckets_per_feature: List[int],
+        feature_buckets: List[_FeatureBucket],
+        default_num_buckets: int,
+    ) -> None:
+        features_by_bucket_count: Dict[int, List[int]] = {}
+        for feature, num_buckets in enumerate(num_buckets_per_feature):
+            features_by_bucket_count.setdefault(num_buckets, []).append(feature)
+        self.bucket_groups = [
+            _BucketGroup(num_buckets, features)
+            for num_buckets, features in (
+                features_by_bucket_count or {default_num_buckets: []}
+            ).items()
+        ]
+
+        index_by_feature_bucket: Dict[_FeatureBucket, int] = {}
+        group_offset = 0
+        for group in self.bucket_groups:
+            for bucket in range(group.num_buckets):
+                for position, feature in enumerate(group.features):
+                    index_by_feature_bucket[_FeatureBucket(feature, bucket)] = (
+                        group_offset + bucket * len(group.features) + position
+                    )
+            group_offset += group.num_buckets * len(group.features)
+
+        self.rank_feature_bucket_indices = [
+            index_by_feature_bucket[feature_bucket]
+            for feature_bucket in feature_buckets
+        ]
+
+    @classmethod
+    def uniform(
+        cls,
+        num_features: int,
+        features_per_rank: List[int],
+        local_size: int,
+    ) -> "_InputPlan":
+        """
+        The plan for tables that each live on one node: every feature is cut
+        into `local_size` buckets and its node owns them all, so the
+        feature buckets go out in one contiguous run per node, one bucket
+        per rank within the node.
+        """
+        nodes = len(features_per_rank) // local_size
+        features_per_node = [
+            features_per_rank[node * local_size] for node in range(nodes)
+        ]
+        node_offsets = [0] + list(itertools.accumulate(features_per_node))
+        return cls(
+            [local_size] * num_features,
+            [
+                _FeatureBucket(feature, bucket)
+                for node in range(nodes)
+                for bucket in range(local_size)
+                for feature in range(node_offsets[node], node_offsets[node + 1])
+            ],
+            default_num_buckets=local_size,
+        )
+
+
+@dataclass
+class _FeatureInfo:
+    """One table feature shared by input routing and final output metadata."""
+
+    feature_name: str
+    hash_size: int
+    num_buckets: int
+    embedding_name: str
+    embedding_dim: int
+    shard_metadata: Optional[ShardMetadata]
+
+
+@dataclass
+class _SumSlice:
+    """A contiguous tensor slice added from `src` to `dst`."""
+
+    src: int
+    dst: int
+    length: int
+
+
+class _FeatureLayout:
+    """
+    Every table feature once, plus the two orderings that address that list.
+
+    `features` is in input and final output order, and `input_plan` routes the
+    input AlltoAll. The cross-node AlltoAll delivers one segment per node, each
+    carrying that node's partial sums over the rows it holds;
+    `_feature_indices` indexes `features` by those partials, in arrival order.
+    With no table spanning nodes there is one partial per feature,
+    `_feature_indices` is the identity and the combine is skipped; a multi-node
+    table has one partial per node, which the combine sums back together.
+
+    Args:
+        grouped_configs_per_rank (List[List[GroupedEmbeddingConfig]]): the
+            tables held by each rank.
+        table_placement_ranks (Dict[str, List[int]]): ranks holding each
+            table's row blocks, so row block `i` lives on `ranks[i]`.
+        local_size (int): number of ranks in each node.
+    """
+
+    features: List[_FeatureInfo]
+    input_plan: _InputPlan
+    _feature_indices: List[int]
+
+    def __init__(
+        self,
+        grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
+        table_placement_ranks: Dict[str, List[int]],
+        local_size: int,
+    ) -> None:
+        """
+        Walks every rank in order, which is input AlltoAll order, so each
+        rank's feature buckets land where the AlltoAll expects them. The
+        cross-node AlltoAll segments by node instead, so partials come from
+        each node's first rank, the same one
+        `_grouped_embedding_configs_per_node` reads.
+        """
+        features: List[_FeatureInfo] = []
+        feature_index_by_key: Dict[Tuple[str, int], int] = {}
+        feature_indices: List[int] = []
+        feature_buckets: List[_FeatureBucket] = []
+        for rank, grouped_configs in enumerate(grouped_configs_per_rank):
+            for grouped_config in grouped_configs:
+                for table in grouped_config.embedding_tables:
+                    placement_ranks = table_placement_ranks[table.name]
+                    for position, feature_name in enumerate(table.feature_names):
+                        key = (table.name, position)
+                        feature_index = feature_index_by_key.get(key)
+                        if feature_index is None:
+                            feature_index = len(features)
+                            feature_index_by_key[key] = feature_index
+                            features.append(
+                                _FeatureInfo(
+                                    feature_name=feature_name,
+                                    hash_size=table.num_embeddings,
+                                    num_buckets=len(placement_ranks),
+                                    embedding_name=table.embedding_names[position],
+                                    embedding_dim=table.local_cols,
+                                    shard_metadata=table.local_metadata,
+                                )
+                            )
+                        if rank % local_size == 0:
+                            feature_indices.append(feature_index)
+                        feature_buckets.append(
+                            _FeatureBucket(feature_index, placement_ranks.index(rank))
+                        )
+        self.features = features
+        self._feature_indices = feature_indices
+        self.input_plan = _InputPlan(
+            [feature.num_buckets for feature in features],
+            feature_buckets,
+            default_num_buckets=local_size,
+        )
+
+    def combine_callback(self) -> Optional[Callable[[torch.Tensor], torch.Tensor]]:
+        """The fixed-batch combine, or nothing when no feature repeats."""
+        if not self._needs_combine():
+            return None
+        return self._combine_callback(
+            [feature.embedding_dim for feature in self.features]
+        )
+
+    def variable_batch_combine(
+        self, batch_size_per_feature: List[int]
+    ) -> Tuple[List[int], Optional[Callable[[torch.Tensor], torch.Tensor]]]:
+        """
+        Returns each partial's batch size, in arrival order, and the combine
+        for the flattened tensor, or nothing when no feature repeats.
+        """
+        if len(batch_size_per_feature) != len(self.features):
+            raise ValueError(
+                f"expected {len(self.features)} feature batch sizes, "
+                f"got {len(batch_size_per_feature)}"
+            )
+        if not self._needs_combine():
+            return batch_size_per_feature, None
+        batch_size_per_partial = [
+            batch_size_per_feature[index] for index in self._feature_indices
+        ]
+        feature_sizes = [
+            batch_size * feature.embedding_dim
+            for batch_size, feature in zip(batch_size_per_feature, self.features)
+        ]
+        return batch_size_per_partial, self._combine_callback(feature_sizes)
+
+    def _needs_combine(self) -> bool:
+        return len(self.features) != len(self._feature_indices)
+
+    def _combine_callback(
+        self, feature_sizes: List[int]
+    ) -> Callable[[torch.Tensor], torch.Tensor]:
+        slices, destination_size = self._combine_slices(feature_sizes)
+
+        def _combine(tensor: torch.Tensor) -> torch.Tensor:
+            out = tensor.new_zeros((*tensor.shape[:-1], destination_size))
+            for s in slices:
+                out[..., s.dst : s.dst + s.length] += tensor[
+                    ..., s.src : s.src + s.length
+                ]
+            return out
+
+        return _combine
+
+    def _combine_slices(self, feature_sizes: List[int]) -> Tuple[List[_SumSlice], int]:
+        """
+        Builds the fewest contiguous slice additions for this layout.
+
+        Partials arrive in the order they are summed, so a run always chains in
+        the source; only the destination can break it, which it does whenever
+        the next partial is not for the next feature.
+        """
+        feature_offsets = list(itertools.accumulate(feature_sizes, initial=0))
+        source_sizes = [feature_sizes[index] for index in self._feature_indices]
+        source_offsets = list(itertools.accumulate(source_sizes, initial=0))
+        slices: List[_SumSlice] = []
+        for position, feature_index in enumerate(self._feature_indices):
+            src = source_offsets[position]
+            dst = feature_offsets[feature_index]
+            length = source_sizes[position]
+            if slices and dst == slices[-1].dst + slices[-1].length:
+                slices[-1].length += length
+            else:
+                slices.append(_SumSlice(src, dst, length))
+        return slices, feature_offsets[-1]
+
+
 class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
     """
     Base class for table wise row wise sharding.
@@ -111,7 +377,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             intra_pg.size() if intra_pg else get_local_size(self._world_size)
         )
 
-        sharded_tables_per_rank = self._shard(sharding_infos)
+        sharded_tables_per_rank, table_placement_ranks = self._shard(sharding_infos)
         self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
             []
         )
@@ -130,6 +396,12 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         ]:
             if group_config.has_feature_processor:
                 self._has_feature_processor = True
+
+        self._feature_layout = _FeatureLayout(
+            grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
+            table_placement_ranks=table_placement_ranks,
+            local_size=self._local_size,
+        )
 
     def _resolve_placement_ranks(
         self,
@@ -207,12 +479,18 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
     def _shard(
         self,
         sharding_infos: List[EmbeddingShardingInfo],
-    ) -> List[List[ShardedEmbeddingTable]]:
+    ) -> Tuple[List[List[ShardedEmbeddingTable]], Dict[str, List[int]]]:
+        """
+        Places every table's row blocks, returning the tables each rank holds
+        and, per table, the ranks holding its row blocks: row block `i` lives
+        on `ranks[i]`.
+        """
         world_size = self._world_size
         local_size = self._local_size
         tables_per_rank: List[List[ShardedEmbeddingTable]] = [
             [] for _ in range(world_size)
         ]
+        table_placement_ranks: Dict[str, List[int]] = {}
         peer_group = get_process_group_ranks(self._pg) if self._is_2D_parallel else None
         for info in sharding_infos:
             # Under 2D parallelism we transform rank to the logical ordering in a regular parallelism scheme
@@ -258,11 +536,6 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                 num_shards=len(shards),
                 table_node=table_node,
             )
-            if num_nodes > 1:
-                raise NotImplementedError(
-                    f"'{table_name}': TABLE_ROW_WISE num_nodes={num_nodes} is "
-                    "not supported by the runtime yet."
-                )
 
             # construct the global sharded_tensor_metadata
             global_metadata = ShardedTensorMetadata(
@@ -289,6 +562,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     stride=info.param.stride(),
                 )
 
+            table_placement_ranks[table_name] = placement_ranks
             for rank_idx, rank in enumerate(placement_ranks):
                 tables_per_rank[rank].append(
                     ShardedEmbeddingTable(
@@ -317,45 +591,25 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     )
                 )
 
-        return tables_per_rank
+        return tables_per_rank, table_placement_ranks
 
     def embedding_dims(self) -> List[int]:
-        embedding_dims = []
-        for grouped_embedding_configs in self._grouped_embedding_configs_per_node:
-            for grouped_config in grouped_embedding_configs:
-                embedding_dims.extend(grouped_config.embedding_dims())
-        return embedding_dims
+        return [feature.embedding_dim for feature in self._feature_layout.features]
 
     def embedding_names(self) -> List[str]:
-        embedding_names = []
-        for grouped_embedding_configs in self._grouped_embedding_configs_per_node:
-            for grouped_config in grouped_embedding_configs:
-                embedding_names.extend(grouped_config.embedding_names())
-        return embedding_names
+        return [feature.embedding_name for feature in self._feature_layout.features]
 
     def embedding_names_per_rank(self) -> List[List[str]]:
         raise NotImplementedError
 
     def embedding_shard_metadata(self) -> List[Optional[ShardMetadata]]:
-        embedding_shard_metadata = []
-        for grouped_config in self._grouped_embedding_configs_per_node:
-            for config in grouped_config:
-                embedding_shard_metadata.extend(config.embedding_shard_metadata())
-        return embedding_shard_metadata
+        return [feature.shard_metadata for feature in self._feature_layout.features]
 
     def feature_names(self) -> List[str]:
-        feature_names = []
-        for grouped_config in self._grouped_embedding_configs_per_node:
-            for config in grouped_config:
-                feature_names.extend(config.feature_names())
-        return feature_names
+        return [feature.feature_name for feature in self._feature_layout.features]
 
     def _get_feature_hash_sizes(self) -> List[int]:
-        feature_hash_sizes: List[int] = []
-        for grouped_config in self._grouped_embedding_configs_per_node:
-            for config in grouped_config:
-                feature_hash_sizes.extend(config.feature_hash_sizes())
-        return feature_hash_sizes
+        return [feature.hash_size for feature in self._feature_layout.features]
 
     def _dim_sum_per_node(self) -> List[int]:
         dim_sum_per_node = []
@@ -394,45 +648,45 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
 
     Args:
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
-        intra_pg (dist.ProcessGroup): ProcessGroup within single host group for AlltoAll
-            communication.
-        id_list_features_per_rank (List[int]): number of id list features to send to
+        local_size (int): number of ranks in each node.
+        features_per_rank (List[int]): number of feature buckets sent to
             each rank.
-        id_score_list_features_per_rank (List[int]): number of id score list features to
-            send to each rank.
-        id_list_feature_hash_sizes (List[int]): hash sizes of id list features.
-        id_score_list_feature_hash_sizes (List[int]): hash sizes of id score list
-            features.
+        feature_hash_sizes (List[int]): hash size of each input feature.
         device (Optional[torch.device]): device on which buffers will be allocated.
         has_feature_processor (bool): existence of a feature processor (ie. position
             weighted features).
+        need_pos (bool): whether to bucketize positions, used in place of
+            `has_feature_processor` once the features carry weights.
+        input_plan (Optional[_InputPlan]): the bucket groups and the AlltoAll
+            order of the feature buckets. Required once a table's rows span
+            several nodes, since that table appears once in the input but on
+            every node holding its rows, so its destination order cannot be
+            derived from `features_per_rank`. Defaults to `_InputPlan.uniform`,
+            which is what GRID_SHARD relies on.
 
     Example::
 
-        3 features
-        2 hosts with 2 devices each
+        2 nodes of 2 ranks. `(feature, bucket)` is one key of the bucketized
+        KJT, listed under the rank owning those rows.
 
-        Bucketize each feature into 2 buckets
-        Staggered shuffle with feature splits [2, 1]
-        AlltoAll operation
+        Single-node tables: every table sits on one node, so each feature is
+        cut into `local_size` = 2 buckets, both owned by its own node. Here f0
+        and f1 are on node 0, f2 on node 1::
 
-        NOTE: result of staggered shuffle and AlltoAll operation look the same after
-        reordering in AlltoAll
+            rank 0: (f0, 0) (f1, 0)    rank 2: (f2, 0)
+            rank 1: (f0, 1) (f1, 1)    rank 3: (f2, 1)
 
-        Result:
-            host 0 device 0:
-                feature 0 bucket 0
-                feature 1 bucket 0
+        Multi-node table: fb spans both nodes, so it is cut into
+        `num_nodes * local_size` = 4 buckets, one per rank, while the
+        single-node fa keeps 2::
 
-            host 0 device 1:
-                feature 0 bucket 1
-                feature 1 bucket 1
+            rank 0: (fa, 0) (fb, 0)    rank 2: (fb, 2)
+            rank 1: (fa, 1) (fb, 1)    rank 3: (fb, 3)
 
-            host 1 device 0:
-                feature 2 bucket 0
-
-            host 1 device 1:
-                feature 2 bucket 1
+        Taking the ranks in order gives the AlltoAll input: `features_per_rank`
+        = [2, 2, 1, 1] splits it, and `_InputPlan` permutes the bucketize
+        output into that sequence. The second case needs one bucketize call
+        per bucket count, since the count also routes out-of-range ids.
     """
 
     def __init__(
@@ -444,6 +698,7 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         device: Optional[torch.device] = None,
         has_feature_processor: bool = False,
         need_pos: bool = False,
+        input_plan: Optional[_InputPlan] = None,
     ) -> None:
         super().__init__()
         assert pg.size() % local_size == 0, "currently group granularity must be node"
@@ -451,13 +706,27 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         self._world_size: int = pg.size()
         self._local_size: int = local_size
         self._num_cross_nodes: int = self._world_size // self._local_size
+
+        if input_plan is None:
+            input_plan = _InputPlan.uniform(
+                len(feature_hash_sizes), features_per_rank, local_size
+            )
+        self._bucket_groups: List[_BucketGroup] = input_plan.bucket_groups
+
         feature_block_sizes = [
-            math.ceil(hash_size / self._local_size) for hash_size in feature_hash_sizes
+            math.ceil(feature_hash_sizes[feature] / group.num_buckets)
+            for group in input_plan.bucket_groups
+            for feature in group.features
+        ]
+        self._rank_feature_bucket_indices: List[int] = (
+            input_plan.rank_feature_bucket_indices
+        )
+        group_feature_indices = [
+            feature for group in input_plan.bucket_groups for feature in group.features
         ]
 
-        self._sf_staggered_shuffle: List[int] = self._staggered_shuffle(
-            features_per_rank
-        )
+        # Not persistent: all three follow from the sharding plan, so a
+        # checkpoint taken under a different one must not restore them.
         self.register_buffer(
             "_feature_block_sizes_tensor",
             torch.tensor(
@@ -465,14 +734,25 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
                 device=device,
                 dtype=torch.int32,
             ),
+            persistent=False,
         )
         self.register_buffer(
-            "_sf_staggered_shuffle_tensor",
+            "_rank_feature_bucket_indices_tensor",
             torch.tensor(
-                self._sf_staggered_shuffle,
+                self._rank_feature_bucket_indices,
                 device=device,
                 dtype=torch.int32,
             ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_group_feature_indices_tensor",
+            torch.tensor(
+                group_feature_indices,
+                device=device,
+                dtype=torch.int32,
+            ),
+            persistent=False,
         )
         self._dist = KJTAllToAll(
             pg=pg,
@@ -490,8 +770,8 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         sparse_features: KeyedJaggedTensor,
     ) -> Awaitable[Awaitable[KeyedJaggedTensor]]:
         """
-        Bucketizes sparse feature values into local world size number of buckets,
-        performs staggered shuffle on the sparse features, and then performs AlltoAll
+        Bucketizes sparse feature values into each feature's own number of
+        buckets, reorders them into rank order, and then performs an AlltoAll
         operation.
 
         Args:
@@ -502,44 +782,58 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[KeyedJaggedTensor]: awaitable of KeyedJaggedTensor.
         """
 
-        bucketized_features = bucketize_kjt_before_all2all(
+        bucketized_features = self._bucketize(
             sparse_features,
-            num_buckets=self._local_size,
-            # pyrefly: ignore[bad-argument-type]
-            block_sizes=self._feature_block_sizes_tensor,
-            output_permute=False,
             bucketize_pos=(
                 self._has_feature_processor
                 if sparse_features.weights_or_none() is None
                 else self._need_pos
             ),
-        )[0].permute(
-            self._sf_staggered_shuffle,
-            # pyrefly: ignore[bad-argument-type]
-            self._sf_staggered_shuffle_tensor,
         )
 
-        return self._dist(bucketized_features)
+        return self._dist(
+            bucketized_features.permute(
+                self._rank_feature_bucket_indices,
+                # pyrefly: ignore[bad-argument-type]
+                self._rank_feature_bucket_indices_tensor,
+            )
+        )
 
-    def _staggered_shuffle(self, features_per_rank: List[int]) -> List[int]:
-        """
-        Reorders sparse data such that data is in contiguous blocks and correctly
-        ordered for global TWRW layout.
-        """
+    def _bucketize(
+        self,
+        sparse_features: KeyedJaggedTensor,
+        bucketize_pos: bool,
+    ) -> KeyedJaggedTensor:
+        """One bucketize call per bucket group, concatenated."""
+        feature_block_sizes = cast(torch.Tensor, self._feature_block_sizes_tensor)
+        if len(self._bucket_groups) == 1:
+            return bucketize_kjt_before_all2all(
+                sparse_features,
+                num_buckets=self._bucket_groups[0].num_buckets,
+                block_sizes=feature_block_sizes,
+                output_permute=False,
+                bucketize_pos=bucketize_pos,
+            )[0]
 
-        nodes = self._world_size // self._local_size
-        features_per_node = [
-            features_per_rank[node * self._local_size] for node in range(nodes)
-        ]
-        node_offsets = [0] + list(itertools.accumulate(features_per_node))
-        num_features = node_offsets[-1]
-
-        return [
-            bucket * num_features + feature
-            for node in range(nodes)
-            for bucket in range(self._local_size)
-            for feature in range(node_offsets[node], node_offsets[node + 1])
-        ]
+        group_feature_indices = cast(torch.Tensor, self._group_feature_indices_tensor)
+        bucketized_features: List[KeyedJaggedTensor] = []
+        start = 0
+        for group in self._bucket_groups:
+            end = start + len(group.features)
+            bucketized_features.append(
+                bucketize_kjt_before_all2all(
+                    sparse_features.permute(
+                        group.features,
+                        group_feature_indices[start:end],
+                    ),
+                    num_buckets=group.num_buckets,
+                    block_sizes=feature_block_sizes[start:end],
+                    output_permute=False,
+                    bucketize_pos=bucketize_pos,
+                )[0]
+            )
+            start = end
+        return KeyedJaggedTensor.concat(bucketized_features)
 
 
 class TwRwPooledEmbeddingDist(
@@ -558,6 +852,8 @@ class TwRwPooledEmbeddingDist(
         dim_sum_per_node (List[int]): number of features (sum of dimensions) of the
             embedding for each host.
         emb_dim_per_node_per_feature (List[List[int]]):
+        feature_layout (_FeatureLayout): feature order and the per-node
+            partials that must be summed into it.
         device (Optional[torch.device]): device on which buffers will be allocated.
         qcomm_codecs_registry (Optional[Dict[str, QuantizedCommCodecs]]):
     """
@@ -569,11 +865,13 @@ class TwRwPooledEmbeddingDist(
         intra_pg: dist.ProcessGroup,
         dim_sum_per_node: List[int],
         emb_dim_per_node_per_feature: List[List[int]],
+        feature_layout: _FeatureLayout,
         device: Optional[torch.device] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__()
         self._rank = rank
+        self._feature_layout = feature_layout
         self._intra_pg: dist.ProcessGroup = intra_pg
         self._cross_pg: dist.ProcessGroup = cross_pg
         self._dim_sum_per_node = dim_sum_per_node
@@ -638,15 +936,23 @@ class TwRwPooledEmbeddingDist(
                 batch_size_per_rank_per_feature=batch_size_per_feature_sum_by_cross_group,
                 embedding_dims=self._emb_dim_per_node_per_feature[current_node],
             ).wait()
-            return cast(
+            batch_size_per_partial, combine_callback = (
+                self._feature_layout.variable_batch_combine(
+                    sharding_ctx.batch_size_per_feature_pre_a2a
+                )
+            )
+            awaitable = cast(
                 VariableBatchPooledEmbeddingsAllToAll, self._variable_cross_dist
             )(
                 rs_result,
                 batch_size_per_rank_per_feature=batch_size_per_rank_per_feature_by_cross_group[
                     local_rank
                 ],
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
+                batch_size_per_feature_pre_a2a=batch_size_per_partial,
             )
+            if combine_callback is not None:
+                awaitable.callbacks.append(combine_callback)
+            return awaitable
         elif (
             sharding_ctx is not None and len(set(sharding_ctx.batch_size_per_rank)) > 1
         ):
@@ -743,18 +1049,23 @@ class TwRwPooledEmbeddingDist(
                 pg=self._cross_pg,
                 emb_dim_per_rank_per_feature=self._emb_dim_per_node_per_feature,
                 device=self._device,
-                callbacks=None,  # don't pass permute callback, handle in LazyAwaitable
+                # Bound per step in `forward`, since offsets are batch dependent.
+                callbacks=None,
                 codecs=self._cross_codecs,
             )
         self._intra_dist = PooledEmbeddingsReduceScatter(
             pg=self._intra_pg,
             codecs=self._intra_codecs,
         )
+        # The two-dimensional pooled output has a fixed feature layout, so one
+        # persistent callback is safe here.
+        combine_callback = self._feature_layout.combine_callback()
         self._cross_dist = PooledEmbeddingsAllToAll(
             pg=self._cross_pg,
             dim_sum_per_rank=self._dim_sum_per_node,
             device=self._device,
             codecs=self._cross_codecs,
+            callbacks=[combine_callback] if combine_callback is not None else None,
         )
 
 
@@ -784,6 +1095,7 @@ class TwRwPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             has_feature_processor=self._has_feature_processor,
             need_pos=self._need_pos,
+            input_plan=self._feature_layout.input_plan,
         )
 
     def create_lookup(
@@ -811,6 +1123,7 @@ class TwRwPooledEmbeddingSharding(
             intra_pg=cast(dist.ProcessGroup, self._intra_pg),
             dim_sum_per_node=self._dim_sum_per_node(),
             emb_dim_per_node_per_feature=self._emb_dim_per_node_per_feature(),
+            feature_layout=self._feature_layout,
             device=device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -99,6 +99,7 @@ def calculate_shard_sizes_and_offsets(
     col_wise_shard_dim: Optional[int] = None,
     device_memory_sizes: Optional[List[int]] = None,
     num_buckets: Optional[int] = None,
+    num_nodes: Optional[int] = None,
 ) -> Tuple[List[List[int]], List[List[int]]]:
     """
     Calculates sizes and offsets for tensor sharded according to provided sharding type.
@@ -109,6 +110,9 @@ def calculate_shard_sizes_and_offsets(
         local_world_size (int): total number of devices in host group topology.
         sharding_type (str): provided ShardingType value.
         col_wise_shard_dim (Optional[int]): dimension for column wise sharding split.
+        num_nodes (Optional[int]): for TABLE_ROW_WISE, number of nodes the
+            table's rows are split across, in units of `local_world_size`.
+            Defaults to 1.
 
     Returns:
         Tuple[List[List[int]], List[List[int]]]: shard sizes, represented as a list of the dimensions of the sharded tensor on each device, and shard offsets, represented as a list of coordinates of placement on each device.
@@ -140,7 +144,9 @@ def calculate_shard_sizes_and_offsets(
             )
         )
     elif sharding_type == ShardingType.TABLE_ROW_WISE.value:
-        return _calculate_rw_shard_sizes_and_offsets(rows, local_world_size, columns)
+        return _calculate_rw_shard_sizes_and_offsets(
+            rows, (num_nodes or 1) * local_world_size, columns
+        )
     elif (
         sharding_type == ShardingType.COLUMN_WISE.value
         or sharding_type == ShardingType.TABLE_COLUMN_WISE.value
@@ -333,6 +339,7 @@ def _get_parameter_size_offsets(
     world_size: int,
     col_wise_shard_dim: Optional[int] = None,
     num_buckets: Optional[int] = None,
+    num_nodes: Optional[int] = None,
 ) -> List[Tuple[List[int], List[int]]]:
     (
         shard_sizes,
@@ -344,6 +351,7 @@ def _get_parameter_size_offsets(
         sharding_type=sharding_type.value,
         col_wise_shard_dim=col_wise_shard_dim,
         num_buckets=num_buckets,
+        num_nodes=num_nodes,
     )
     return list(zip(shard_sizes, shard_offsets))
 
@@ -396,6 +404,7 @@ def _get_parameter_sharding(
     sharder: ModuleSharder[nn.Module],
     placements: Optional[List[str]] = None,
     compute_kernel: Optional[str] = None,
+    num_nodes: Optional[int] = None,
 ) -> ParameterSharding:
     return ParameterSharding(
         sharding_spec=(
@@ -430,6 +439,7 @@ def _get_parameter_sharding(
             else _get_compute_kernel(sharder, param, sharding_type, device_type)
         ),
         ranks=[rank for (_, _, rank) in size_offset_ranks],
+        num_nodes=num_nodes,
     )
 
 
@@ -784,8 +794,11 @@ def table_row_wise(
     """
     Returns a generator of ParameterShardingPlan for `ShardingType::TABLE_ROW_WISE` for construct_module_sharding_plan.
 
+    Cuts the rows over the ranks of a single node. Use
+    `table_row_wise_multi_node` to spread them over several.
+
     Args:
-    host_index (int): index of host (node) to do row wise
+    host_index (int): index of the host (node) to do row wise
 
     Example::
 
@@ -797,6 +810,49 @@ def table_row_wise(
             },
         )
     """
+    return table_row_wise_multi_node(host_indexes=[host_index])
+
+
+def table_row_wise_multi_node(
+    host_indexes: List[int],
+) -> ParameterShardingGenerator:
+    """
+    Returns a generator of ParameterShardingPlan for `ShardingType::TABLE_ROW_WISE` for construct_module_sharding_plan.
+
+    Args:
+    host_indexes (List[int]): indexes of hosts (nodes) to split the rows across.
+        They need not be adjacent. Rows are cut over
+        `len(host_indexes) * local_size` ranks instead of one node's worth;
+        shards stay full width. The planner's equivalent
+        (`ParameterConstraints.num_nodes`) counts `Topology.intra_group_size`
+        ranks per node instead of `local_size`.
+
+    Example::
+
+        ebc = EmbeddingBagCollection(...)
+        plan = construct_module_sharding_plan(
+            ebc,
+            {
+                # rows split over hosts 0 and 3
+                "table_5": table_row_wise_multi_node(host_indexes=[0, 3]),
+            },
+        )
+    """
+    if not host_indexes:
+        raise ValueError(
+            "table_row_wise_multi_node: host_indexes must name at least one host."
+        )
+    if len(set(host_indexes)) != len(host_indexes):
+        raise ValueError(
+            f"table_row_wise_multi_node: host_indexes={host_indexes} names a host "
+            "twice. Two row blocks on one rank is a duplicate bucket destination."
+        )
+    # Sorted rather than caller order: a plan is persisted rank-ascending and
+    # reloaded with row offsets recomputed in that order, so an unsorted span
+    # would come back as a different placement. The planner's
+    # `_multi_hosts_partition` sorts for the same reason.
+    hosts: List[int] = sorted(host_indexes)
+    num_nodes: int = len(hosts)
 
     def _parameter_sharding_generator(
         param: nn.Parameter,
@@ -805,18 +861,30 @@ def table_row_wise(
         device_type: str,
         sharder: ModuleSharder[nn.Module],
     ) -> ParameterSharding:
+        total_num_hosts = world_size // local_size
+        out_of_range = [host for host in hosts if not 0 <= host < total_num_hosts]
+        if out_of_range:
+            raise ValueError(
+                f"table_row_wise_multi_node(host_indexes={hosts}) needs host(s) "
+                f"{out_of_range}, but there are only {total_num_hosts} "
+                f"(world_size={world_size}, local_size={local_size})."
+            )
+
         size_and_offsets = _get_parameter_size_offsets(
             param,
             ShardingType.TABLE_ROW_WISE,
             local_size,
             world_size,
+            num_nodes=num_nodes,
         )
 
         size_offset_ranks = []
-        assert len(size_and_offsets) <= local_size
-        for (size, offset), rank in zip(size_and_offsets, range(local_size)):
-            rank_offset = host_index * local_size
-            size_offset_ranks.append((size, offset, rank_offset + rank))
+        placement_ranks = [
+            host * local_size + rank for host in hosts for rank in range(local_size)
+        ]
+        assert len(size_and_offsets) <= len(placement_ranks)
+        for (size, offset), rank in zip(size_and_offsets, placement_ranks):
+            size_offset_ranks.append((size, offset, rank))
 
         return _get_parameter_sharding(
             param,
@@ -825,6 +893,8 @@ def table_row_wise(
             local_size,
             device_type,
             sharder,
+            # Unset for a single node: keeps pre-feature plans byte-identical.
+            num_nodes=num_nodes if num_nodes > 1 else None,
         )
 
     return _parameter_sharding_generator

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -9,14 +9,18 @@
 
 import os
 import unittest
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, cast, Dict, Optional, Tuple, Type
 
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import assume, given, Phase, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
-from torchrec.distributed.planner import ParameterConstraints
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
 from torchrec.distributed.test_utils.test_model import (
     TestSparseNN,
     TestTowerCollectionSparseNN,
@@ -28,7 +32,8 @@ from torchrec.distributed.test_utils.test_sharding import (
     SharderType,
     sharding_single_rank_test,
 )
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import EmbeddingModuleShardingPlan, ShardingType
+from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import PoolingType
 from torchrec.test_utils import skip_if_asan_class
 
@@ -526,4 +531,168 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             variable_batch_per_feature=variable_batch_per_feature,
             has_weighted_tables=False,
             global_constant_batch=global_constant_batch,
+        )
+
+    # The mixed placement most multi-node tests below run with.
+    MIXED_NUM_NODES: Dict[str, int] = {"table_0": 2, "table_3": 2}
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_twrw_num_nodes_constraints_really_split(self) -> None:
+        """
+        Pins that `MIXED_NUM_NODES` actually splits those tables here.
+
+        A `num_nodes` that fails to reach the planner is indistinguishable
+        from single-node TABLE_ROW_WISE at runtime: the sharded model still builds
+        and still matches the unsharded reference. Without this, every
+        multi-node test below could pass while exercising nothing.
+        """
+        self._build_tables_and_groups()
+        model = TestSparseNN(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            embedding_groups=self.embedding_groups,
+            sparse_device=torch.device("meta"),
+            num_float_features=16,
+        )
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size=4,
+                local_world_size=2,
+                compute_device="cuda",
+                ssd_cap=2 * 1024**4,
+            ),
+            constraints={
+                name: ParameterConstraints(num_nodes=num_nodes)
+                for name, num_nodes in self.MIXED_NUM_NODES.items()
+            },
+        )
+        plan = planner.plan(
+            module=model,
+            # pyrefly: ignore[bad-argument-type]
+            sharders=[
+                create_test_sharder(
+                    SharderType.EMBEDDING_BAG_COLLECTION.value,
+                    ShardingType.TABLE_ROW_WISE.value,
+                    EmbeddingComputeKernel.FUSED.value,
+                    device=torch.device("cuda"),
+                ),
+            ],
+        )
+        ebc_plan = cast(EmbeddingModuleShardingPlan, plan.plan["sparse.ebc"])
+
+        for name in self.MIXED_NUM_NODES:
+            parameter_sharding = ebc_plan[name]
+            self.assertEqual(
+                parameter_sharding.num_nodes, 2, f"{name} is not multi-node"
+            )
+            ranks = none_throws(parameter_sharding.ranks)
+            self.assertEqual(len(ranks), 4, f"{name} ranks: {ranks}")
+            # Both nodes, so the tests below actually reach the cross-node
+            # combine.
+            self.assertEqual({rank // 2 for rank in ranks}, {0, 1})
+
+        # The remaining tables stay on one node, so this exercises both
+        # placements in the same sharding instance.
+        for name in self.table_names:
+            if name in self.MIXED_NUM_NODES:
+                continue
+            parameter_sharding = ebc_plan[name]
+            self.assertIsNone(parameter_sharding.num_nodes, f"{name} opted in")
+            ranks = none_throws(parameter_sharding.ranks)
+            self.assertEqual(len({rank // 2 for rank in ranks}), 1, f"{name}: {ranks}")
+
+    def _test_twrw_num_nodes(
+        self,
+        num_nodes_by_table: Dict[str, int],
+        pooling: PoolingType = PoolingType.SUM,
+        variable_batch_size: bool = False,
+        variable_batch_per_feature: bool = False,
+    ) -> None:
+        """
+        Runs the TABLE_ROW_WISE suite with `num_nodes` set on some tables.
+
+        world_size=4, local_size=2, so there are two nodes and `num_nodes=2`
+        splits a table's rows across all four ranks. The shared harness scores
+        this against an unsharded reference after one SGD step, so it covers
+        bucketize routing, the input AlltoAll, the intra-node reduce-scatter,
+        the cross-node AlltoAll, summing the per-node partials, and the
+        gradients back through all of it.
+        """
+        self._test_sharding(
+            # pyrefly: ignore[bad-argument-type]
+            sharders=[
+                create_test_sharder(
+                    SharderType.EMBEDDING_BAG_COLLECTION.value,
+                    ShardingType.TABLE_ROW_WISE.value,
+                    EmbeddingComputeKernel.FUSED.value,
+                    device=torch.device("cuda"),
+                ),
+            ],
+            backend="nccl",
+            world_size=4,
+            local_size=2,
+            constraints={
+                name: ParameterConstraints(num_nodes=num_nodes)
+                for name, num_nodes in num_nodes_by_table.items()
+            },
+            variable_batch_size=variable_batch_size,
+            variable_batch_per_feature=variable_batch_per_feature,
+            has_weighted_tables=not variable_batch_per_feature,
+            pooling=pooling,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharding_nccl_twrw_mixed_num_nodes(self) -> None:
+        # The case the design hinges on: multi-node and single-node tables in
+        # ONE sharding instance, sharing its collectives. `table_0` is also the
+        # shared-feature case, declaring `feature_0` alongside single-node
+        # `table_4`, so the two copies must stay apart or `table_4`'s ids take
+        # `table_0`'s bucket count.
+        self._test_twrw_num_nodes(self.MIXED_NUM_NODES)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharding_nccl_twrw_all_num_nodes(self) -> None:
+        # Every unweighted table spans both nodes; weighted tables stay on one.
+        self._test_twrw_num_nodes(dict.fromkeys(self.table_names, 2))
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharding_nccl_twrw_mixed_num_nodes_mean_pooling(self) -> None:
+        # TBE sums per rank and the reduce-scatter makes one partial per node.
+        # Mean pooling divides their combined value using the lengths from
+        # before bucketization.
+        self._test_twrw_num_nodes(self.MIXED_NUM_NODES, pooling=PoolingType.MEAN)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharding_nccl_twrw_mixed_num_nodes_variable_batch(self) -> None:
+        # Batch varies per rank, but remains constant across features.
+        self._test_twrw_num_nodes(self.MIXED_NUM_NODES, variable_batch_size=True)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharding_nccl_twrw_mixed_num_nodes_variable_batch_per_feature(
+        self,
+    ) -> None:
+        # The only case reaching the variable-batch-per-feature combine;
+        # `variable_batch_size` alone uses the regular pooled-output path.
+        self._test_twrw_num_nodes(
+            self.MIXED_NUM_NODES,
+            variable_batch_size=True,
+            variable_batch_per_feature=True,
         )

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -9,7 +9,7 @@
 
 import copy
 import unittest
-from typing import Any, Dict, List, Optional
+from typing import Any, cast, Dict, List, Optional
 
 import hypothesis.strategies as st
 import torch
@@ -39,6 +39,7 @@ from torchrec.distributed.sharding_plan import (
     QuantEmbeddingCollectionSharder,
     row_wise,
     table_row_wise,
+    table_row_wise_multi_node,
     table_wise,
 )
 from torchrec.distributed.test_utils.multi_process import (
@@ -55,6 +56,7 @@ from torchrec.distributed.types import (
     ShardingType,
     ShardMetadata,
 )
+from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import data_type_to_dtype, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
@@ -1124,6 +1126,98 @@ class ConstructParameterShardingTest(unittest.TestCase):
         self.assertIn(
             "column dim of 65 cannot be evenly divided across [0, 1]",
             str(context.exception),
+        )
+
+    def _multi_node_plan(
+        self,
+        per_param_sharding: Dict[str, ParameterShardingGenerator],
+        world_size: int,
+        num_embeddings: int = 1000,
+    ) -> EmbeddingModuleShardingPlan:
+        tables = [
+            EmbeddingBagConfig(
+                name=name,
+                feature_names=["feature_" + name],
+                embedding_dim=64,
+                num_embeddings=num_embeddings,
+                data_type=DataType.FP32,
+            )
+            for name in per_param_sharding
+        ]
+        return construct_module_sharding_plan(
+            EmbeddingBagCollection(tables=tables),
+            per_param_sharding=per_param_sharding,
+            local_size=2,
+            world_size=world_size,
+            device_type="cuda",
+        )
+
+    def test_table_row_wise_multi_node_rejects_empty_span(self) -> None:
+        """An empty span leaves no ranks to place the table on."""
+        with self.assertRaisesRegex(ValueError, "at least one host"):
+            table_row_wise_multi_node(host_indexes=[])
+
+    def test_table_row_wise_multi_node_rejects_repeated_host(self) -> None:
+        """Two row blocks on one rank is a duplicate bucket destination."""
+        with self.assertRaisesRegex(ValueError, "names a host twice"):
+            table_row_wise_multi_node(host_indexes=[1, 1])
+
+    def test_table_row_wise_multi_node_rejects_host_past_the_end(self) -> None:
+        """Hosts are bounded against the world, or the plan names ranks that do
+        not exist."""
+        for host_indexes in ([1, 2], [-1, 0]):  # a 2-host world
+            with self.subTest(host_indexes=host_indexes):
+                with self.assertRaisesRegex(ValueError, r"but there are only 2"):
+                    self._multi_node_plan(
+                        {
+                            "table_0": table_row_wise_multi_node(
+                                host_indexes=host_indexes
+                            )
+                        },
+                        world_size=4,
+                    )
+
+    def test_table_row_wise_multi_node_sorts_a_scattered_span(self) -> None:
+        """Hosts need not be adjacent; the span is sorted because a plan is
+        persisted rank-ascending and reloaded with offsets in that order. The
+        span ends on the last host, so an off-by-one bound fails here."""
+        plan = self._multi_node_plan(
+            {
+                "table_0": table_row_wise_multi_node(host_indexes=[3, 0]),
+                "table_1": table_row_wise_multi_node(host_indexes=[1]),
+            },
+            world_size=8,
+        )
+        self.assertEqual(none_throws(plan["table_0"].ranks), [0, 1, 6, 7])
+        self.assertEqual(plan["table_0"].num_nodes, 2)
+        # A one-node span stays indistinguishable from a pre-feature plan.
+        self.assertEqual(none_throws(plan["table_1"].ranks), [2, 3])
+        self.assertIsNone(plan["table_1"].num_nodes)
+
+    def test_table_row_wise_multi_node_cuts_rows_across_the_span(self) -> None:
+        """Rows are partitioned over the span, not replicated per node: 10 rows
+        over 4 ranks is a `ceil` cut of 3/3/3/1."""
+        plan = self._multi_node_plan(
+            {
+                "table_0": table_row_wise_multi_node(host_indexes=[2, 0]),
+                "table_1": table_row_wise_multi_node(host_indexes=[1]),
+            },
+            world_size=8,
+            num_embeddings=10,
+        )
+
+        shards = none_throws(
+            cast(
+                EnumerableShardingSpec, none_throws(plan["table_0"].sharding_spec)
+            ).shards
+        )
+        self.assertEqual(
+            [tuple(shard.shard_sizes) for shard in shards],
+            [(3, 64), (3, 64), (3, 64), (1, 64)],
+        )
+        self.assertEqual(
+            [tuple(shard.shard_offsets) for shard in shards],
+            [(0, 0), (3, 0), (6, 0), (9, 0)],
         )
 
 

--- a/torchrec/distributed/tests/test_twrw_multi_node.py
+++ b/torchrec/distributed/tests/test_twrw_multi_node.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import math
+import unittest
+from typing import Dict, List, Optional, Tuple
+
+import torch
+from torchrec.distributed.embedding_sharding import bucketize_kjt_before_all2all
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.distributed.sharding.twrw_sharding import (
+    _BucketGroup,
+    _FeatureBucket,
+    _FeatureLayout,
+    _InputPlan,
+    TwRwSparseFeaturesDist,
+)
+from torchrec.distributed.utils import none_throws
+from torchrec.modules.embedding_configs import PoolingType
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.types import DataType
+
+
+def _all_feature_buckets(
+    num_buckets_per_feature: List[int],
+) -> List[_FeatureBucket]:
+    return [
+        _FeatureBucket(feature, bucket)
+        for feature, num_buckets in enumerate(num_buckets_per_feature)
+        for bucket in range(num_buckets)
+    ]
+
+
+def _bucket_values(kjt: KeyedJaggedTensor) -> List[List[int]]:
+    """Values in each key of a one-sample-per-key bucketize output."""
+    values = kjt.values().tolist()
+    out: List[List[int]] = []
+    start = 0
+    for length in kjt.lengths().tolist():
+        out.append(values[start : start + length])
+        start += length
+    return out
+
+
+def _feature_names(table: str, num_features: int) -> List[str]:
+    return (
+        [table] if num_features == 1 else [f"{table}f{i}" for i in range(num_features)]
+    )
+
+
+def _layout(
+    tables_per_rank: List[List[str]],
+    dim_by_table: Dict[str, int],
+    local_size: int = 1,
+    features_by_table: Optional[Dict[str, int]] = None,
+) -> _FeatureLayout:
+    """
+    Builds a layout from grouped configs, one feature per table named after it
+    unless `features_by_table` asks for more.
+
+    Defaults to one rank per node, so `tables_per_rank` then reads as the
+    tables each node holds.
+    """
+    table_placement_ranks: Dict[str, List[int]] = {}
+    for rank, tables in enumerate(tables_per_rank):
+        for table in tables:
+            table_placement_ranks.setdefault(table, []).append(rank)
+    names_by_table = {
+        table: _feature_names(table, (features_by_table or {}).get(table, 1))
+        for tables in tables_per_rank
+        for table in tables
+    }
+    return _FeatureLayout(
+        grouped_configs_per_rank=[
+            [
+                GroupedEmbeddingConfig(
+                    data_type=DataType.FP32,
+                    pooling=PoolingType.SUM,
+                    is_weighted=False,
+                    has_feature_processor=False,
+                    compute_kernel=EmbeddingComputeKernel.DENSE,
+                    embedding_tables=[
+                        ShardedEmbeddingTable(
+                            name=table,
+                            num_embeddings=16,
+                            embedding_dim=dim_by_table[table],
+                            local_cols=dim_by_table[table],
+                            feature_names=names_by_table[table],
+                            embedding_names=names_by_table[table],
+                        )
+                        for table in tables
+                    ],
+                )
+            ]
+            for tables in tables_per_rank
+        ],
+        table_placement_ranks=table_placement_ranks,
+        local_size=local_size,
+    )
+
+
+def _total_dim(tables_per_node: List[List[str]], dim_by_table: Dict[str, int]) -> int:
+    return sum(dim_by_table[table] for tables in tables_per_node for table in tables)
+
+
+class InputPlanTest(unittest.TestCase):
+    def test_single_count_is_the_ungrouped_layout(self) -> None:
+        """When every feature wants the same bucket count (every single-node
+        TABLE_ROW_WISE and GRID_SHARD instance), grouping is a no-op and the
+        index of `(feature, bucket)` is still `bucket * num_features +
+        feature`, which the pre-existing staggered shuffle assumes."""
+        num_features, buckets = 5, 4
+        feature_buckets = _all_feature_buckets([buckets] * num_features)
+        plan = _InputPlan(
+            [buckets] * num_features, feature_buckets, default_num_buckets=buckets
+        )
+
+        self.assertEqual(
+            plan.bucket_groups, [_BucketGroup(buckets, list(range(num_features)))]
+        )
+        for index, fb in zip(plan.rank_feature_bucket_indices, feature_buckets):
+            self.assertEqual(index, fb.bucket * num_features + fb.feature)
+
+    def test_uniform_order_matches_the_staggered_shuffle(self) -> None:
+        """The single-node path is the general path: `local_size` buckets each
+        and an order that reproduces the original staggered shuffle."""
+        features_per_rank, local_size = [3, 3, 2, 2], 2
+        num_features = 5
+        plan = _InputPlan.uniform(num_features, features_per_rank, local_size)
+
+        node_offsets = [0, 3, 5]
+        self.assertEqual(
+            plan.rank_feature_bucket_indices,
+            [
+                bucket * num_features + feature
+                for node in range(2)
+                for bucket in range(local_size)
+                for feature in range(node_offsets[node], node_offsets[node + 1])
+            ],
+        )
+
+    def test_mixed_counts_assign_every_index_by_feature_bucket(self) -> None:
+        """Four features of single-node tables at 2 buckets, two of a
+        multi-node table at 4."""
+        num_buckets_per_feature = [2, 4, 2, 2, 4, 2]
+        feature_buckets = _all_feature_buckets(num_buckets_per_feature)
+        plan = _InputPlan(
+            num_buckets_per_feature, feature_buckets, default_num_buckets=2
+        )
+
+        # Groups in order of first use, every feature in exactly one.
+        self.assertEqual(
+            plan.bucket_groups, [_BucketGroup(2, [0, 2, 3, 5]), _BucketGroup(4, [1, 4])]
+        )
+
+        # Every (feature, bucket) has one unique index in the concatenated
+        # bucketized KJT.
+        self.assertEqual(
+            sorted(plan.rank_feature_bucket_indices),
+            list(range(len(feature_buckets))),
+        )
+
+    def test_no_features_still_yields_one_group(self) -> None:
+        """An empty instance keeps `local_size` rather than yielding no group."""
+        plan = _InputPlan([], [], default_num_buckets=8)
+        self.assertEqual(plan.bucket_groups, [_BucketGroup(8, [])])
+        self.assertEqual(plan.rank_feature_bucket_indices, [])
+
+
+class BucketizeByBucketCountTest(unittest.TestCase):
+    """
+    A single-node table must bucketize exactly as it would without a
+    multi-node table in the same sharding instance.
+
+    `block_bucketize_sparse_features` takes per-feature block sizes but one
+    scalar bucket count, and that scalar routes ids at or above
+    `block_size * num_buckets` to rank `id % num_buckets` — a path fbgemm
+    documents as supported. One shared call at the largest count would
+    therefore move the out-of-range ids of every table that asked for fewer.
+    """
+
+    # One feature lives on a 2-rank node; the other spans both nodes.
+    HASH_SIZE: int = 16
+    SINGLE_NODE_BUCKETS: int = 2
+    MULTI_NODE_BUCKETS: int = 4
+    # 20 and 21 are at or above `block_size * num_buckets` at this feature's own
+    # count, so they take the out-of-range path.
+    SINGLE_NODE_IDS: List[int] = [0, 9, 20, 21]
+    MULTI_NODE_IDS: List[int] = [1, 5, 11, 15]
+
+    def _kjt(self, keys: List[str], ids_per_key: List[List[int]]) -> KeyedJaggedTensor:
+        values: List[int] = [i for ids in ids_per_key for i in ids]
+        return KeyedJaggedTensor(
+            keys=keys,
+            values=torch.tensor(values, dtype=torch.int64),
+            lengths=torch.tensor([len(ids) for ids in ids_per_key], dtype=torch.int32),
+        )
+
+    def _block_sizes(self, num_buckets_per_feature: List[int]) -> torch.Tensor:
+        return torch.tensor(
+            [
+                math.ceil(self.HASH_SIZE / buckets)
+                for buckets in num_buckets_per_feature
+            ],
+            dtype=torch.int64,
+        )
+
+    def _grouped(
+        self, num_buckets_per_feature: List[int], ids_per_key: List[List[int]]
+    ) -> Tuple[List[List[int]], Dict[_FeatureBucket, int]]:
+        """Runs the production grouping + bucketize over a mixed KJT."""
+        feature_buckets = _all_feature_buckets(num_buckets_per_feature)
+        plan = _InputPlan(
+            num_buckets_per_feature,
+            feature_buckets,
+            default_num_buckets=min(num_buckets_per_feature),
+        )
+        index_by_feature_bucket = dict(
+            zip(feature_buckets, plan.rank_feature_bucket_indices)
+        )
+        group_feature_indices = [
+            feature for group in plan.bucket_groups for feature in group.features
+        ]
+        bucketizer = TwRwSparseFeaturesDist.__new__(TwRwSparseFeaturesDist)
+        torch.nn.Module.__init__(bucketizer)
+        bucketizer._bucket_groups = plan.bucket_groups
+        bucketizer._group_feature_indices_tensor = torch.tensor(
+            group_feature_indices, dtype=torch.int32
+        )
+        bucketizer._feature_block_sizes_tensor = self._block_sizes(
+            [num_buckets_per_feature[feature] for feature in group_feature_indices]
+        )
+        out = bucketizer._bucketize(
+            self._kjt(
+                [f"f{i}" for i in range(len(num_buckets_per_feature))], ids_per_key
+            ),
+            bucketize_pos=False,
+        )
+        return _bucket_values(out), index_by_feature_bucket
+
+    def _alone(
+        self,
+        num_buckets: int,
+        ids: List[int],
+        block_size_for: Optional[int] = None,
+    ) -> List[List[int]]:
+        """
+        The reference: that feature bucketized on its own.
+
+        `block_size_for` is the bucket count whose block size to use, so a
+        caller can vary the scalar while holding the block size fixed;
+        production passes block sizes per feature and only the count is shared.
+        """
+        out = bucketize_kjt_before_all2all(
+            self._kjt(["f"], [ids]),
+            num_buckets=num_buckets,
+            block_sizes=self._block_sizes(
+                [num_buckets if block_size_for is None else block_size_for]
+            ),
+            output_permute=False,
+            bucketize_pos=False,
+        )[0]
+        return _bucket_values(out)
+
+    def test_in_range_ids_ignore_the_bucket_count(self) -> None:
+        """`rank = id / block_size`, `row = id % block_size`: no `num_buckets`
+        anywhere, so both counts give the same answer, which is why raising
+        the count looked safe."""
+        in_range = [0, 9]
+        self.assertEqual(self._alone(self.SINGLE_NODE_BUCKETS, in_range), [[0], [1]])
+        self.assertEqual(
+            self._alone(
+                self.MULTI_NODE_BUCKETS,
+                in_range,
+                block_size_for=self.SINGLE_NODE_BUCKETS,
+            )[: self.SINGLE_NODE_BUCKETS],
+            [[0], [1]],
+        )
+
+    def test_shared_max_bucket_count_moves_out_of_range_ids(self) -> None:
+        """The defect with no grouping in sight: one feature, one block size,
+        only the scalar changes."""
+        at_own_count = self._alone(self.SINGLE_NODE_BUCKETS, self.SINGLE_NODE_IDS)
+        at_shared_max = self._alone(
+            self.MULTI_NODE_BUCKETS,
+            self.SINGLE_NODE_IDS,
+            block_size_for=self.SINGLE_NODE_BUCKETS,
+        )[: self.SINGLE_NODE_BUCKETS]
+        self.assertNotEqual(
+            at_own_count,
+            at_shared_max,
+            "if these matched, the bucket count would not affect routing and "
+            "the per-count grouping would be unnecessary",
+        )
+
+    def test_grouping_leaves_the_single_node_table_untouched(self) -> None:
+        """The single-node table's feature is unaffected by the multi-node
+        table's."""
+        bucket_values, index_by_feature_bucket = self._grouped(
+            [self.SINGLE_NODE_BUCKETS, self.MULTI_NODE_BUCKETS],
+            [self.SINGLE_NODE_IDS, self.MULTI_NODE_IDS],
+        )
+
+        single_node = [
+            bucket_values[index_by_feature_bucket[_FeatureBucket(0, bucket)]]
+            for bucket in range(self.SINGLE_NODE_BUCKETS)
+        ]
+        self.assertEqual(
+            single_node,
+            self._alone(self.SINGLE_NODE_BUCKETS, self.SINGLE_NODE_IDS),
+        )
+
+        multi_node = [
+            bucket_values[index_by_feature_bucket[_FeatureBucket(1, bucket)]]
+            for bucket in range(self.MULTI_NODE_BUCKETS)
+        ]
+        self.assertEqual(
+            multi_node,
+            self._alone(self.MULTI_NODE_BUCKETS, self.MULTI_NODE_IDS),
+        )
+        self.assertEqual(
+            sum(len(bucket) for bucket in single_node + multi_node),
+            len(self.SINGLE_NODE_IDS) + len(self.MULTI_NODE_IDS),
+        )
+
+    def test_single_group_matches_the_ungrouped_call(self) -> None:
+        """A single bucket count takes the original bucketization path."""
+        ids = [self.SINGLE_NODE_IDS, [2, 7, 30]]
+        bucket_values, index_by_feature_bucket = self._grouped(
+            [self.SINGLE_NODE_BUCKETS] * 2, ids
+        )
+
+        ungrouped = _bucket_values(
+            bucketize_kjt_before_all2all(
+                self._kjt(["f0", "f1"], ids),
+                num_buckets=self.SINGLE_NODE_BUCKETS,
+                block_sizes=self._block_sizes([self.SINGLE_NODE_BUCKETS] * 2),
+                output_permute=False,
+                bucketize_pos=False,
+            )[0]
+        )
+        self.assertEqual(bucket_values, ungrouped)
+
+
+class FeatureLayoutTest(unittest.TestCase):
+    # (local_size, features of each table on each node). No table spans nodes,
+    # so every case must route exactly as the pre-existing single-node path,
+    # which GRID_SHARD still takes.
+    SINGLE_NODE_TOPOLOGIES: List[Tuple[int, List[List[int]]]] = [
+        (1, [[1]]),  # one rank holding one table
+        (2, [[1, 1]]),  # one node of two ranks
+        (1, [[1], [1]]),  # two nodes of one rank
+        (2, [[1, 1], [1]]),  # uneven table counts per node
+        (2, [[1, 1, 1], []]),  # a node holding nothing
+        (2, [[2], [1]]),  # a table with two features
+        (3, [[3, 1], [2], [1]]),  # mixed feature counts, three nodes
+        (2, [[], []]),  # no tables at all
+    ]
+
+    def test_single_node_plans_match_the_uniform_plan(self) -> None:
+        for local_size, features_per_table_by_node in self.SINGLE_NODE_TOPOLOGIES:
+            with self.subTest(local_size=local_size, nodes=features_per_table_by_node):
+                features_by_table = {
+                    f"n{node}t{table}": num_features
+                    for node, tables in enumerate(features_per_table_by_node)
+                    for table, num_features in enumerate(tables)
+                }
+                tables_per_rank = [
+                    [f"n{node}t{table}" for table in range(len(tables))]
+                    for node, tables in enumerate(features_per_table_by_node)
+                    for _ in range(local_size)
+                ]
+                features_per_rank = [
+                    sum(features_by_table[table] for table in tables)
+                    for tables in tables_per_rank
+                ]
+
+                feature_layout = _layout(
+                    tables_per_rank,
+                    dict.fromkeys(features_by_table, 4),
+                    local_size,
+                    features_by_table,
+                )
+                input_plan = feature_layout.input_plan
+                uniform_input_plan = _InputPlan.uniform(
+                    sum(features_by_table.values()), features_per_rank, local_size
+                )
+
+                self.assertEqual(
+                    input_plan.bucket_groups, uniform_input_plan.bucket_groups
+                )
+                self.assertEqual(
+                    input_plan.rank_feature_bucket_indices,
+                    uniform_input_plan.rank_feature_bucket_indices,
+                )
+
+    def test_derives_the_feature_list_and_both_orderings(self) -> None:
+        """2 nodes of 2 ranks: `a` on node 0 only, `b` on both."""
+        feature_layout = _layout(
+            [["a", "b"], ["a", "b"], ["b"], ["b"]],
+            {"a": 4, "b": 6},
+            local_size=2,
+        )
+
+        # Each feature once, in the order the ranks first reach it, cut into as
+        # many buckets as it has row blocks.
+        self.assertEqual(
+            [
+                (feature.feature_name, feature.num_buckets, feature.embedding_dim)
+                for feature in feature_layout.features
+            ],
+            [("a", 2, 4), ("b", 4, 6)],
+        )
+        # Node 0's segment carries a and b, node 1's carries b again.
+        self.assertEqual(feature_layout._feature_indices, [0, 1, 1])
+        # One feature bucket per rank per table it holds, in rank order:
+        # (a, 0) (b, 0) | (a, 1) (b, 1) | (b, 2) | (b, 3), resolved against a
+        # bucketize output of a's 2 buckets then b's 4.
+        self.assertEqual(
+            feature_layout.input_plan.rank_feature_bucket_indices,
+            [0, 2, 1, 3, 4, 5],
+        )
+
+
+class FeatureLayoutCombineTest(unittest.TestCase):
+    """
+    Checks the combine against a reference that adds one partial at a time,
+    independent of the coalescing production does. Each node can hold a
+    different set of features, so a feature's partials are not necessarily
+    adjacent.
+    """
+
+    # (tables each node holds, embedding dim per table), one rank per node.
+    NODE_PLACEMENTS: List[Tuple[List[List[str]], Dict[str, int]]] = [
+        ([["a"]], {"a": 4}),  # nothing repeats
+        ([["a"], ["a"]], {"a": 4}),  # one table on both nodes
+        ([["a", "b"], ["b"]], {"a": 3, "b": 2}),  # repeat at the end
+        ([["a", "b"], ["a"]], {"a": 3, "b": 2}),  # repeat at the start
+        ([["a", "b", "c"], ["b"]], {"a": 4, "b": 6, "c": 5}),  # repeat in the middle
+        ([["a", "b"], ["a", "b"]], {"a": 3, "b": 2}),  # a whole node repeats
+        ([["a", "b"], ["b", "a"]], {"a": 3, "b": 2}),  # reordered, defeats coalescing
+        ([["a"], ["a"], ["a"]], {"a": 2}),  # three nodes
+        ([["a", "b"], [], ["b"]], {"a": 1, "b": 1}),  # a node holding nothing
+        ([["a", "b", "c"], ["a", "c"]], {"a": 2, "b": 3, "c": 1}),  # a subset repeats
+    ]
+
+    @staticmethod
+    def _reference(
+        tables_per_node: List[List[str]],
+        dim_by_table: Dict[str, int],
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        """Adds one partial at a time into the final feature order."""
+        destination_by_table: Dict[str, int] = {}
+        offset = 0
+        for table in dict.fromkeys(
+            table for tables in tables_per_node for table in tables
+        ):
+            destination_by_table[table] = offset
+            offset += dim_by_table[table]
+        expected = torch.zeros(tensor.shape[0], offset)
+        source = 0
+        for tables in tables_per_node:
+            for table in tables:
+                destination = destination_by_table[table]
+                embedding_dim = dim_by_table[table]
+                expected[:, destination : destination + embedding_dim] += tensor[
+                    :, source : source + embedding_dim
+                ]
+                source += embedding_dim
+        return expected
+
+    @staticmethod
+    def _combine(feature_layout: _FeatureLayout, tensor: torch.Tensor) -> torch.Tensor:
+        """Applies the combine, which is skipped when no feature repeats."""
+        callback = feature_layout.combine_callback()
+        return tensor if callback is None else callback(tensor)
+
+    def _assert_matches_reference(
+        self, tables_per_node: List[List[str]], dim_by_table: Dict[str, int]
+    ) -> None:
+        feature_layout = _layout(tables_per_node, dim_by_table)
+        total_dim = _total_dim(tables_per_node, dim_by_table)
+        tensor = torch.arange(3 * total_dim, dtype=torch.float32).view(3, total_dim)
+        torch.testing.assert_close(
+            self._combine(feature_layout, tensor),
+            self._reference(tables_per_node, dim_by_table, tensor),
+        )
+
+    def test_variable_batch_combine_flattens_per_feature_batches(self) -> None:
+        """b repeats, so its two partials carry b's batch size and are summed
+        inside a flattened tensor."""
+        feature_layout = _layout([["a", "b", "c"], ["b"]], {"a": 2, "b": 3, "c": 1})
+
+        batch_size_per_partial, callback = feature_layout.variable_batch_combine(
+            [2, 1, 3]
+        )
+        self.assertEqual(batch_size_per_partial, [2, 1, 3, 1])
+
+        tensor = torch.arange(13, dtype=torch.float32)
+        expected = torch.cat((tensor[:4], tensor[4:7] + tensor[10:13], tensor[7:10]))
+        torch.testing.assert_close(none_throws(callback)(tensor), expected)
+
+    def test_variable_batch_rejects_a_wrong_length(self) -> None:
+        """The batch sizes come from the sharding context, so a count that
+        disagrees with the layout would silently misalign the flattened
+        tensor."""
+        feature_layout = _layout([["a", "b"]], {"a": 3, "b": 5})
+
+        with self.assertRaisesRegex(ValueError, r"expected 2 feature batch sizes"):
+            feature_layout.variable_batch_combine([1, 2, 3])
+
+    def test_gradient_reaches_every_partial(self) -> None:
+        tables_per_node = [["a", "b"], ["b"]]
+        dim_by_table = {"a": 3, "b": 2}
+        feature_layout = _layout(tables_per_node, dim_by_table)
+
+        total_dim = _total_dim(tables_per_node, dim_by_table)
+        # `requires_grad` after the view, so `tensor` is a leaf and keeps a grad.
+        tensor = torch.arange(2 * total_dim, dtype=torch.float32).view(2, total_dim)
+        tensor.requires_grad_(True)
+        self._combine(feature_layout, tensor).sum().backward()
+        torch.testing.assert_close(none_throws(tensor.grad), torch.ones(2, total_dim))
+
+    def test_matches_reference_across_node_placements(self) -> None:
+        for tables_per_node, dim_by_table in self.NODE_PLACEMENTS:
+            with self.subTest(nodes=tables_per_node):
+                self._assert_matches_reference(tables_per_node, dim_by_table)
+
+    def test_single_node_layout_is_a_pass_through(self) -> None:
+        feature_layout = _layout([["a", "b"]], {"a": 3, "b": 5})
+
+        # Nothing to sum, so no callback is attached to either awaitable and
+        # the variable batch sizes pass through.
+        self.assertIsNone(feature_layout.combine_callback())
+        batch_size_per_partial, callback = feature_layout.variable_batch_combine([2, 3])
+        self.assertEqual(batch_size_per_partial, [2, 3])
+        self.assertIsNone(callback)

--- a/torchrec/distributed/tests/test_twrw_placement.py
+++ b/torchrec/distributed/tests/test_twrw_placement.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, List, Optional
+
+import torch
+from torch.distributed._shard.sharding_spec import EnumerableShardingSpec
+from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo
+from torchrec.distributed.sharding.twrw_sharding import BaseTwRwEmbeddingSharding
+from torchrec.distributed.types import ParameterSharding, ShardingType, ShardMetadata
+from torchrec.distributed.utils import none_throws
+from torchrec.modules.embedding_configs import EmbeddingTableConfig
+
+_LOCAL_SIZE: int = 4
+
+
+class _PlacementResolver:
+    """
+    `_resolve_placement_ranks` with only the two attributes it reads.
+
+    The real constructor needs a live `dist` world, and `object.__new__` is out
+    too: `EmbeddingSharding` is an ABC that `BaseTwRwEmbeddingSharding` does not
+    fully implement. Borrowing the function keeps these tests on shipped code.
+    """
+
+    _resolve_placement_ranks = BaseTwRwEmbeddingSharding._resolve_placement_ranks
+
+    def __init__(self, local_size: int, is_2D_parallel: bool = False) -> None:
+        self._local_size = local_size
+        self._is_2D_parallel = is_2D_parallel
+
+
+def _resolve(
+    num_nodes: int,
+    plan_ranks: List[int],
+    num_shards: Optional[int] = None,
+    table_node: int = 0,
+    local_size: int = _LOCAL_SIZE,
+    is_2D_parallel: bool = False,
+) -> List[int]:
+    resolver = _PlacementResolver(local_size, is_2D_parallel)
+    # pyrefly: ignore[bad-argument-type]
+    return resolver._resolve_placement_ranks(
+        table_name="table_0",
+        num_nodes=num_nodes,
+        plan_ranks=plan_ranks,
+        num_shards=len(plan_ranks) if num_shards is None else num_shards,
+        table_node=table_node,
+    )
+
+
+class ResolvePlacementRanksTest(unittest.TestCase):
+    """
+    Every rejection in `_resolve_placement_ranks`, plus the two accepted shapes.
+
+    It is the last check before a collective constructor: past it, a
+    contradictory `num_nodes` becomes a duplicate bucket destination or an
+    out-of-range rank inside an all-to-all, which hangs rather than raises.
+    """
+
+    def test_shard_and_rank_counts_must_match(self) -> None:
+        """Multi-node only, where `ranks[i]` pairs with `shards[i]`: a mismatch
+        reads past the end of `shards` or leaves a block unplaced."""
+        for placed, num_shards in ((8, 7), (0, 8)):
+            with self.subTest(placed=placed):
+                with self.assertRaisesRegex(
+                    ValueError, rf"{placed} placement ranks for {num_shards} shards"
+                ):
+                    _resolve(
+                        num_nodes=2,
+                        plan_ranks=list(range(placed)),
+                        num_shards=num_shards,
+                    )
+
+    def test_single_node_shard_shortfall_is_rejected(self) -> None:
+        """The single-node branch fills the node from `table_node`, so too few
+        shards is a bare IndexError in `_shard`."""
+        with self.assertRaisesRegex(ValueError, r"2 shards for a node of 4 ranks"):
+            _resolve(num_nodes=1, plan_ranks=[0, 1], num_shards=2)
+
+    def test_num_nodes_below_one_is_rejected(self) -> None:
+        """0 makes the width check `num_nodes * local_size` demand zero ranks;
+        a negative demands a negative number."""
+        for num_nodes in (0, -1):
+            with self.subTest(num_nodes=num_nodes):
+                with self.assertRaisesRegex(
+                    ValueError, rf"num_nodes={num_nodes} must be >= 1"
+                ):
+                    _resolve(num_nodes=num_nodes, plan_ranks=[0, 1, 2, 3])
+
+    def test_multi_node_under_2d_parallelism_is_rejected(self) -> None:
+        """Under 2D `plan_ranks` is global while `_shard` maps it through the
+        peer group, so a multi-node placement has no defined meaning yet."""
+        with self.assertRaisesRegex(
+            ValueError, r"num_nodes=2 is not supported under 2D parallelism"
+        ):
+            _resolve(
+                num_nodes=2,
+                plan_ranks=list(range(8)),
+                is_2D_parallel=True,
+            )
+
+    def test_single_node_placed_wider_than_a_node_is_rejected(self) -> None:
+        """The case `num_nodes` exists to disambiguate: 8 ranks at a node width
+        of 4 is either a two-node placement or a planner/runtime disagreement
+        about node width. Undeclared, it is the second, and inferring the first
+        would activate the feature on a table that never asked for it."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"the plan places it on 8 ranks, more than the 4 in a node",
+        ):
+            _resolve(num_nodes=1, plan_ranks=list(range(8)))
+
+    def test_rank_count_must_match_num_nodes_times_local_size(self) -> None:
+        """The same node-width disagreement from the opt-in side: `num_nodes=2`
+        at a runtime node width of 4 needs exactly 8 ranks, under or over."""
+        for placed in (6, 12):
+            with self.subTest(placed=placed):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    r"num_nodes=2 needs 8 ranks at a node width of 4, but the "
+                    rf"plan places it on {placed}",
+                ):
+                    _resolve(num_nodes=2, plan_ranks=list(range(placed)))
+
+    def test_repeated_rank_is_rejected(self) -> None:
+        """Two row blocks on one rank, breaking the `ranks[i]` to `shards[i]`
+        pairing. Whole-node reuse is what an oversized `num_nodes` produces:
+        `_multi_hosts_partition` selects hosts circularly."""
+        for num_nodes, plan_ranks in (
+            (2, [0, 1, 2, 2, 4, 5, 6, 7]),
+            (2, [0, 1, 2, 3, 0, 1, 2, 3]),
+            (3, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3]),
+        ):
+            with self.subTest(plan_ranks=plan_ranks):
+                with self.assertRaisesRegex(ValueError, r"repeat a rank"):
+                    _resolve(num_nodes=num_nodes, plan_ranks=plan_ranks)
+
+    def test_span_wider_than_num_nodes_is_rejected(self) -> None:
+        """The right rank count, all distinct, but spread wider than declared.
+        Distinct ranks cannot span fewer, so this is the only shape left once
+        the duplicate check above has run."""
+        with self.assertRaisesRegex(ValueError, r"8 ranks spread over 3 nodes"):
+            _resolve(num_nodes=2, plan_ranks=[0, 1, 2, 3, 4, 5, 8, 9])
+
+    def test_single_node_derives_the_whole_node(self) -> None:
+        """The stock placement: the table owns its node's ranks, derived from
+        `table_node` rather than echoed from the plan, so an unsorted plan
+        still comes back in node order."""
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[8, 9, 10, 11], table_node=2),
+            [8, 9, 10, 11],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[0, 1, 2, 3], table_node=0),
+            [0, 1, 2, 3],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[11, 10, 9, 8], table_node=2),
+            [8, 9, 10, 11],
+        )
+
+    def test_single_node_accepts_a_first_rank_only_plan(self) -> None:
+        """`_shard` only ever read `ranks[0]` for TABLE_ROW_WISE, so a plan
+        listing one rank has always been enough; requiring one per shard now
+        would reject plans that load today."""
+        self.assertEqual(
+            _resolve(num_nodes=1, plan_ranks=[8], num_shards=4, table_node=2),
+            [8, 9, 10, 11],
+        )
+
+    def test_single_node_wider_than_a_node_is_allowed_under_2d(self) -> None:
+        """2D is exempt from the width check: `plan_ranks` is a global
+        placement that `_shard` remaps, so it legitimately exceeds the sharding
+        group's node width. Dropping the guard would break every 2D
+        TABLE_ROW_WISE model, which no other case here catches."""
+        self.assertEqual(
+            _resolve(
+                num_nodes=1,
+                plan_ranks=list(range(8)),
+                table_node=1,
+                is_2D_parallel=True,
+            ),
+            [4, 5, 6, 7],
+        )
+
+    def test_multi_node_returns_plan_order_unsorted(self) -> None:
+        """`ranks[i]` pairs with `shards[i]`, so sorting would pair a rank with
+        a different row range."""
+        self.assertEqual(
+            _resolve(
+                num_nodes=2,
+                plan_ranks=[2, 3, 0, 1],
+                # Would give a different answer via the single-node branch.
+                table_node=1,
+                local_size=2,
+            ),
+            [2, 3, 0, 1],
+        )
+        self.assertEqual(
+            _resolve(num_nodes=3, plan_ranks=[4, 5, 0, 1, 2, 3], local_size=2),
+            [4, 5, 0, 1, 2, 3],
+        )
+
+        # Ascending comes back unchanged too, so the above is order
+        # preservation and not the function reversing.
+        self.assertEqual(
+            _resolve(num_nodes=2, plan_ranks=[0, 1, 2, 3], local_size=2),
+            [0, 1, 2, 3],
+        )
+
+
+class _Sharder:
+    """`_shard` with only the attributes it reads; see `_PlacementResolver`."""
+
+    _resolve_placement_ranks = BaseTwRwEmbeddingSharding._resolve_placement_ranks
+    _shard = BaseTwRwEmbeddingSharding._shard
+
+    def __init__(self, world_size: int, local_size: int) -> None:
+        self._world_size = world_size
+        self._local_size = local_size
+        self._is_2D_parallel = False
+        self._pg = None
+        self._env: Any = type("_Env", (), {"output_dtensor": False})()
+
+
+def _sharding_info(
+    name: str,
+    rows: int,
+    dim: int,
+    ranks: List[int],
+    num_shards: int,
+    num_nodes: Optional[int] = None,
+) -> EmbeddingShardingInfo:
+    rows_per_shard = rows // num_shards
+    return EmbeddingShardingInfo(
+        embedding_config=EmbeddingTableConfig(
+            num_embeddings=rows,
+            embedding_dim=dim,
+            name=name,
+            feature_names=[f"f_{name}"],
+            embedding_names=[f"f_{name}"],
+        ),
+        param_sharding=ParameterSharding(
+            sharding_type=ShardingType.TABLE_ROW_WISE.value,
+            compute_kernel="dense",
+            ranks=ranks,
+            sharding_spec=EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_sizes=[rows_per_shard, dim],
+                        shard_offsets=[i * rows_per_shard, 0],
+                        placement=f"rank:{i}/cpu",
+                    )
+                    for i in range(num_shards)
+                ]
+            ),
+            num_nodes=num_nodes,
+        ),
+        param=torch.empty(rows, dim, device="meta"),
+    )
+
+
+class ShardPlacementTest(unittest.TestCase):
+    """
+    `_shard` itself, which `ResolvePlacementRanksTest` does not reach.
+
+    Without it, an implementation that resolved the placement and then threw it
+    away, keeping the loop `_resolve_placement_ranks` replaced, passes every
+    other test here.
+    """
+
+    def test_single_node_pairs_shards_with_the_derived_node(self) -> None:
+        """Row block `i` lands on the `i`th rank of the derived node."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        # One rank in the plan and four shards: all `_shard` ever read.
+        info = _sharding_info("t", rows=400, dim=8, ranks=[4], num_shards=4)
+        # pyrefly: ignore[bad-argument-type]
+        per_rank = sharder._shard([info])
+
+        placed = {r: t for r, t in enumerate(per_rank) if t}
+        self.assertEqual(sorted(placed), [4, 5, 6, 7])
+        self.assertEqual(
+            [
+                none_throws(placed[r][0].local_metadata).shard_offsets[0]
+                for r in sorted(placed)
+            ],
+            [0, 100, 200, 300],
+        )
+
+    def test_multi_node_is_refused_until_the_forward_path_exists(self) -> None:
+        """The placement resolves, but nothing bucketizes ids across nodes or
+        sums the per-node partials yet."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        info = _sharding_info(
+            "t", rows=800, dim=8, ranks=list(range(8)), num_shards=8, num_nodes=2
+        )
+        with self.assertRaisesRegex(NotImplementedError, r"num_nodes=2"):
+            # pyrefly: ignore[bad-argument-type]
+            sharder._shard([info])
+
+    def test_multi_node_shard_rank_mismatch_raises(self) -> None:
+        """`_shard` surfaces the resolver's rejections rather than swallowing
+        them."""
+        sharder = _Sharder(world_size=8, local_size=4)
+        info = _sharding_info(
+            "t", rows=800, dim=8, ranks=list(range(8)), num_shards=8, num_nodes=2
+        )
+        info.param_sharding.ranks = list(range(7))
+        with self.assertRaisesRegex(ValueError, r"7 placement ranks for 8 shards"):
+            # pyrefly: ignore[bad-argument-type]
+            sharder._shard([info])

--- a/torchrec/distributed/tests/test_twrw_placement.py
+++ b/torchrec/distributed/tests/test_twrw_placement.py
@@ -60,9 +60,9 @@ class ResolvePlacementRanksTest(unittest.TestCase):
     """
     Every rejection in `_resolve_placement_ranks`, plus the two accepted shapes.
 
-    It is the last check before a collective constructor: past it, a
-    contradictory `num_nodes` becomes a duplicate bucket destination or an
-    out-of-range rank inside an all-to-all, which hangs rather than raises.
+    It is the last check before the placement is used: past it, a contradictory
+    `num_nodes` becomes an `IndexError` in `_shard` or a duplicate bucket
+    destination that silently routes ids to the wrong row block.
     """
 
     def test_shard_and_rank_counts_must_match(self) -> None:
@@ -283,8 +283,9 @@ class ShardPlacementTest(unittest.TestCase):
         # One rank in the plan and four shards: all `_shard` ever read.
         info = _sharding_info("t", rows=400, dim=8, ranks=[4], num_shards=4)
         # pyrefly: ignore[bad-argument-type]
-        per_rank = sharder._shard([info])
+        per_rank, placement_ranks = sharder._shard([info])
 
+        self.assertEqual(placement_ranks["t"], [4, 5, 6, 7])
         placed = {r: t for r, t in enumerate(per_rank) if t}
         self.assertEqual(sorted(placed), [4, 5, 6, 7])
         self.assertEqual(
@@ -295,16 +296,28 @@ class ShardPlacementTest(unittest.TestCase):
             [0, 100, 200, 300],
         )
 
-    def test_multi_node_is_refused_until_the_forward_path_exists(self) -> None:
-        """The placement resolves, but nothing bucketizes ids across nodes or
-        sums the per-node partials yet."""
+    def test_multi_node_pairs_shards_with_the_plan_order(self) -> None:
+        """Row block `i` lands on `plan_ranks[i]`, in the planner's order."""
         sharder = _Sharder(world_size=8, local_size=4)
+        # Deliberately not ascending: node 1 before node 0.
+        ranks = [4, 5, 6, 7, 0, 1, 2, 3]
         info = _sharding_info(
-            "t", rows=800, dim=8, ranks=list(range(8)), num_shards=8, num_nodes=2
+            "t", rows=800, dim=8, ranks=ranks, num_shards=8, num_nodes=2
         )
-        with self.assertRaisesRegex(NotImplementedError, r"num_nodes=2"):
-            # pyrefly: ignore[bad-argument-type]
-            sharder._shard([info])
+        # pyrefly: ignore[bad-argument-type]
+        per_rank, placement_ranks = sharder._shard([info])
+
+        self.assertEqual(placement_ranks["t"], ranks)
+        # `ranks[i]` holds `shards[i]`, so rank 4 holds row block 0 and rank 0
+        # holds row block 4. Sorting the placement would swap them.
+        offsets = {
+            r: none_throws(t[0].local_metadata).shard_offsets[0]
+            for r, t in enumerate(per_rank)
+            if t
+        }
+        self.assertEqual(offsets[4], 0)
+        self.assertEqual(offsets[0], 400)
+        self.assertEqual(sorted(offsets.values()), [i * 100 for i in range(8)])
 
     def test_multi_node_shard_rank_mismatch_raises(self) -> None:
         """`_shard` surfaces the resolver's rejections rather than swallowing

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -816,11 +816,15 @@ class ParameterSharding:
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
         output_dtype (Optional[DataType]): output dtype.
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE or PS.
+        num_nodes (Optional[int]): number of nodes this table's rows are split
+            across; see `ParameterConstraints.num_nodes`.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
       ShardingType.COLUMN_WISE - rank where the embedding shards are placed, seen as individual tables
-      ShardingType.TABLE_ROW_WISE  - first rank when this embedding is placed
+      ShardingType.TABLE_ROW_WISE  - first rank when this embedding is placed;
+        with num_nodes > 1, one rank per row block, positionally paired with
+        sharding_spec.shards
       ShardingType.ROW_WISE, ShardingType.DATA_PARALLEL - unused
 
     """
@@ -835,6 +839,7 @@ class ParameterSharding:
     bounds_check_mode: Optional[BoundsCheckMode] = None
     output_dtype: Optional[DataType] = None
     key_value_params: Optional[KeyValueParams] = None
+    num_nodes: Optional[int] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):


### PR DESCRIPTION
Summary:
The planner can place a table's rows across several nodes and `_shard` can
resolve that placement, but nothing routes ids to it or reassembles the result,
so `_shard` still refuses `num_nodes > 1`. This is the runtime, and it lifts
that refusal.

Everything follows from one fact: a table's rows now live on several nodes, so
the table is no longer one thing on one node. That breaks feature identity,
input routing and output combination.

Feature identity. `embedding_dims`, `embedding_names`,
`embedding_shard_metadata`, `feature_names` and `_get_feature_hash_sizes` each
concatenated over `_grouped_embedding_configs_per_node`, one entry per node, so
a table on two nodes would appear twice in every one of them. `_FeatureLayout`
walks `_grouped_embedding_configs_per_rank` once instead and records each table
feature once, keyed on `(table name, position in the table)`; those five methods
read from it. The walk needs the placement, so `_shard` now returns the one it
resolves rather than only the per-rank tables.

Input routing. A multi-node table appears once in the input but is needed on
every node holding its rows, so it is cut into `num_nodes * local_size` buckets
rather than `local_size`, and each bucket must reach the rank owning those rows,
an order `features_per_rank` cannot express. `_InputPlan` carries both: the
bucketize calls to make, and where each feature bucket goes.

Grouping those calls is forced by the op. `block_bucketize_sparse_features`
takes one scalar bucket count per call, and that count also routes ids at or
above `block_size * count`, sending them to `id % count`. A single call at the
largest count would silently re-route the out-of-range ids of every table that
asked for fewer, a path fbgemm documents as supported and hash-based tables rely
on. Features are therefore grouped by bucket count, one call each, concatenated.

Output combination. Within a node the reduce-scatter sums its ranks'
contributions into that node's pooled result. When the node holds only part of a
table's rows that result is itself partial, so the cross-node AlltoAll delivers
one such partial per node and they have to be summed, which is valid because the
row sets are disjoint. `_FeatureLayout` knows which arrivals belong to which
feature and turns that into the fewest contiguous slice additions. A fixed batch
attaches one callback when the output dist is built; a variable batch rebuilds
it per step, since the offsets move with the batch, and also spreads
`batch_size_per_feature` over the per-node partials.

Nothing spans nodes, nothing changes. The plan yields one bucket group and an
order identical to the previous staggered shuffle, `_bucketize` takes its single
call path, and no combine callback is attached at all. GRID_SHARD passes no plan
and keeps the `_InputPlan.uniform` default.

The three derived buffers are `persistent=False`: all follow from the sharding
plan, so a checkpoint taken under a different one must not restore them over
what the rank computed. `RwSparseFeaturesDist` already does this; the two
pre-existing TWRW buffers did not, and reaching a `state_dict` at all requires
`ShardedEmbeddingBag`, which builds its own from `_lookup`.

Differential Revision: D117328947


