### PR TITLE
[detailed][ops] Add TBE benchmark (#4685)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_tbe.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_tbe.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Trace-derived Triton TBE benchmarks with an FBGEMM CUDA baseline.
+
+The request shapes come from Kineto metadata for production column-wise embedding
+lookups. Where exact table cardinalities are unavailable or aggregate metadata would
+produce cache-resident tables, the profile uses fixed, randomly sampled table sizes
+with realistic total weight footprints.
+
+Example:
+
+    buck2 run @fbcode//mode/opt \
+        fbcode//torchrec/distributed/benchmark:benchmark_triton_tbe -- \
+        triton_tbe_forward --workload=cmf_vle_fb_ad_vpv_offline
+
+Run the matching FBGEMM baseline by replacing ``triton_tbe_forward`` with
+``fbgemm_tbe_forward``.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import (
+        BoundsCheckMode,
+        EmbeddingLocation,
+        PoolingMode,
+    )
+except ImportError:
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        BoundsCheckMode,
+        EmbeddingLocation,
+        PoolingMode,
+    )
+
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    cmd_conf,
+)
+from torchrec.distributed.triton_tbe.triton_table_batched_embeddings import (
+    TritonTableBatchedEmbeddingBags,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# pyrefly: ignore[missing-argument]
+_cc = cmd_conf()
+
+_LENGTH_BUILD_CHUNK = 1 << 20
+
+
+@dataclass(frozen=True)
+class TraceShape:
+    feature_batch_sizes: tuple[int, ...]
+    num_indices: int
+    max_batch_per_rank: int | None = None
+
+    @property
+    def num_bags(self) -> int:
+        return sum(self.feature_batch_sizes)
+
+
+@dataclass(frozen=True)
+class TraceWorkload:
+    table_rows: tuple[int, ...]
+    embedding_dims: tuple[int, ...]
+    shapes: tuple[TraceShape, ...]
+    num_ranks: int | None = None
+
+
+@dataclass(frozen=True)
+class TraceRequest:
+    indices: torch.Tensor
+    offsets: torch.Tensor
+    batch_size_per_feature_per_rank: list[list[int]] | None
+
+
+@dataclass
+class TraceTBEForwardConfig(BenchFuncConfig):
+    name: str = ""
+    world_size: int = 1
+    device_type: str = "cuda"
+    profile_dir: str = "."
+    num_benchmarks: int = 100
+    num_profiles: int = 10
+    workload: str = "cmf_vle_fb_ad_vpv_offline"
+    shape_index: int = 0
+    all_shapes: bool = False
+    seed: int = 42
+
+
+_TRACE_WORKLOADS: dict[str, TraceWorkload] = {
+    "cmf_vle_fb_ad_vpv_offline": TraceWorkload(
+        # Randomly sampled with seed 42 and fixed for reproducibility. The FP16
+        # weights total exactly 10 GB.
+        table_rows=(395_427_677, 229_572_323),
+        embedding_dims=(8, 8),
+        shapes=(
+            TraceShape((24_332_144, 4_080), 24_333_157, 240_288),
+            TraceShape((24_995_184, 4_064), 24_996_120, 241_376),
+            TraceShape((23_793_584, 4_016), 23_794_477, 236_064),
+            TraceShape((24_617_648, 4_064), 24_618_572, 232_672),
+            TraceShape((24_588_368, 4_048), 24_589_253, 237_968),
+        ),
+        num_ranks=128,
+    ),
+    "cmf_vle_user_conv_ads_event_long_retention": TraceWorkload(
+        # Randomly sampled with seed 43 and fixed for reproducibility. The FP16
+        # weights total exactly 10 GB.
+        table_rows=(75_327_265, 414_756_718, 134_916_017),
+        embedding_dims=(8, 8, 8),
+        shapes=(
+            TraceShape((13_566_048, 1_963_760, 1_963_760), 32_955_824, 134_960),
+            TraceShape((13_960_048, 2_019_344, 2_019_344), 33_901_749, 136_016),
+            TraceShape((13_282_928, 1_926_672, 1_926_672), 32_307_556, 134_912),
+            TraceShape((13_692_848, 1_981_664, 1_981_664), 33_261_650, 130_016),
+            TraceShape((13_654_672, 1_987_096, 1_987_096), 33_277_289, 130_784),
+        ),
+        num_ranks=128,
+    ),
+    "cmf_ebc": TraceWorkload(
+        # Randomly sampled with seed 42 and fixed here for reproducible comparisons.
+        # The skewed tables retain the trace's table count and sum/max dimensions;
+        # their FP16 weights total 9.999998928 GB.
+        table_rows=(
+            2_144_222,
+            9_692_111,
+            7_153_649,
+            3_780_603,
+            3_745_277,
+            5_284_712,
+            5_941_361,
+            2_688_465,
+            4_102_227,
+            1_437_625,
+            1_859_649,
+            26_408_384,
+            2_152_945,
+            2_372_867,
+            8_740_201,
+        ),
+        embedding_dims=(64, 40, 64, 72, 40, 40, 72, 88, 56, 80, 80, 48, 112, 96, 56),
+        shapes=(
+            TraceShape((196_608,) * 15, 85_606_593),
+            TraceShape((196_608,) * 15, 85_398_310),
+            TraceShape((196_608,) * 15, 85_297_569),
+            TraceShape((196_608,) * 15, 85_583_487),
+            TraceShape((196_608,) * 15, 85_272_046),
+        ),
+    ),
+    "cmf_vle_public_sparse": TraceWorkload(
+        table_rows=(12_500_000,),
+        embedding_dims=(8,),
+        shapes=(
+            TraceShape((12_044_043,), 12_043_905, 143_165),
+            TraceShape((12_098_277,), 12_098_114, 147_239),
+            TraceShape((11_909_628,), 11_909_472, 139_738),
+            TraceShape((11_967_270,), 11_967_126, 141_906),
+            TraceShape((12_029_680,), 12_029_544, 147_665),
+        ),
+        num_ranks=96,
+    ),
+}
+
+
+def _partition_evenly(total: int, parts: int) -> list[int]:
+    quotient, remainder = divmod(total, parts)
+    return [quotient + int(part < remainder) for part in range(parts)]
+
+
+def _partition_with_observed_max(
+    total: int,
+    parts: int,
+    observed_max: int,
+) -> list[int]:
+    if observed_max < (total + parts - 1) // parts:
+        raise ValueError(
+            f"observed max {observed_max} cannot partition {total} over {parts} ranks"
+        )
+    return [observed_max] + _partition_evenly(total - observed_max, parts - 1)
+
+
+def _make_batch_size_per_feature_per_rank(
+    shape: TraceShape,
+    num_ranks: int,
+) -> list[list[int]]:
+    if shape.max_batch_per_rank is None:
+        raise ValueError("VBE shape requires max_batch_per_rank")
+    result = []
+    for feature, batch_size in enumerate(shape.feature_batch_sizes):
+        if feature == 0:
+            per_rank = _partition_with_observed_max(
+                batch_size,
+                num_ranks,
+                shape.max_batch_per_rank,
+            )
+        else:
+            per_rank = _partition_evenly(batch_size, num_ranks)
+
+        # Avoid aligning every feature's largest partitions to the same rank.
+        rotate = (feature * 17) % num_ranks
+        result.append(per_rank[rotate:] + per_rank[:rotate])
+    return result
+
+
+def _allocate_indices_per_feature(shape: TraceShape) -> list[int]:
+    scaled = [shape.num_indices * batch for batch in shape.feature_batch_sizes]
+    counts = [value // shape.num_bags for value in scaled]
+    remaining = shape.num_indices - sum(counts)
+    remainders = sorted(
+        range(len(counts)),
+        key=lambda feature: scaled[feature] % shape.num_bags,
+        reverse=True,
+    )
+    for feature in remainders[:remaining]:
+        counts[feature] += 1
+    return counts
+
+
+def _fill_lengths(lengths: torch.Tensor, num_indices: int) -> None:
+    num_bags = lengths.numel()
+    base, extra = divmod(num_indices, num_bags)
+    lengths.fill_(base)
+    if extra == 0:
+        return
+
+    # Citrine C3: construct the large request tensors directly on the target GPU.
+    for start in range(0, num_bags, _LENGTH_BUILD_CHUNK):
+        end = min(start + _LENGTH_BUILD_CHUNK, num_bags)
+        positions = torch.arange(
+            start,
+            end,
+            dtype=torch.int64,
+            device=lengths.device,
+        )
+        previous = torch.div(positions * extra, num_bags, rounding_mode="floor")
+        current = torch.div(
+            (positions + 1) * extra,
+            num_bags,
+            rounding_mode="floor",
+        )
+        lengths[start:end] += current - previous
+
+
+def _make_request(
+    workload: TraceWorkload,
+    shape: TraceShape,
+    device: torch.device,
+) -> TraceRequest:
+    feature_indices = _allocate_indices_per_feature(shape)
+    lengths = torch.empty(shape.num_bags, dtype=torch.int64, device=device)
+    indices = torch.empty(shape.num_indices, dtype=torch.int64, device=device)
+
+    bag_cursor = 0
+    index_cursor = 0
+    for batch_size, num_indices, table_rows in zip(
+        shape.feature_batch_sizes,
+        feature_indices,
+        workload.table_rows,
+    ):
+        _fill_lengths(lengths[bag_cursor : bag_cursor + batch_size], num_indices)
+        indices[index_cursor : index_cursor + num_indices].random_(0, table_rows)
+        bag_cursor += batch_size
+        index_cursor += num_indices
+
+    offsets = torch.empty(shape.num_bags + 1, dtype=torch.int64, device=device)
+    offsets[0] = 0
+    torch.cumsum(lengths, dim=0, out=offsets[1:])
+
+    return TraceRequest(
+        indices=indices,
+        offsets=offsets,
+        batch_size_per_feature_per_rank=(
+            _make_batch_size_per_feature_per_rank(shape, workload.num_ranks)
+            if workload.num_ranks is not None
+            else None
+        ),
+    )
+
+
+def _make_triton_tbe(
+    workload: TraceWorkload,
+    device: torch.device,
+) -> TritonTableBatchedEmbeddingBags:
+    module = TritonTableBatchedEmbeddingBags(
+        embedding_specs=list(zip(workload.table_rows, workload.embedding_dims)),
+        feature_table_map=list(range(len(workload.table_rows))),
+        weights_precision=torch.float16,
+        output_dtype=torch.float32,
+        stochastic_rounding=False,
+        learning_rate=0.01,
+        eps=0.1,
+        optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+        device=device,
+        fused_bounds_check=False,
+    )
+    with torch.no_grad():
+        module.weight.uniform_(-0.01, 0.01)
+    return module
+
+
+def _make_fbgemm_tbe(
+    workload: TraceWorkload,
+    device: torch.device,
+) -> SplitTableBatchedEmbeddingBagsCodegen:
+    module = SplitTableBatchedEmbeddingBagsCodegen(
+        [
+            (
+                rows,
+                dim,
+                EmbeddingLocation.DEVICE,
+                ComputeDevice.CUDA,
+            )
+            for rows, dim in zip(workload.table_rows, workload.embedding_dims)
+        ],
+        feature_table_map=list(range(len(workload.table_rows))),
+        optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+        learning_rate=0.01,
+        eps=0.1,
+        weights_precision=SparseType.FP16,
+        output_dtype=SparseType.FP32,
+        stochastic_rounding=False,
+        pooling_mode=PoolingMode.SUM,
+        bounds_check_mode=BoundsCheckMode.V2_WARNING,
+    ).to(device)
+    module.init_embedding_weights_uniform(-0.01, 0.01)
+    return module
+
+
+def _run_forward(
+    _batch_inputs: list[dict[str, Any]],
+    module: torch.nn.Module,
+    request: TraceRequest,
+) -> None:
+    module(
+        request.indices,
+        request.offsets,
+        batch_size_per_feature_per_rank=(request.batch_size_per_feature_per_rank),
+    )
+
+
+def _run_backend(
+    backend: str,
+    workload_name: str,
+    workload: TraceWorkload,
+    shape_index: int,
+    shape: TraceShape,
+    request: TraceRequest,
+    config: TraceTBEForwardConfig,
+    device: torch.device,
+) -> None:
+    module: torch.nn.Module
+    if backend == "triton":
+        module = _make_triton_tbe(workload, device)
+    else:
+        module = _make_fbgemm_tbe(workload, device)
+
+    _run_forward([], module, request)
+    torch.cuda.synchronize(device)
+
+    suffix = f"_{config.name}" if config.name else ""
+    result = benchmark_func(
+        func_to_benchmark=_run_forward,
+        bench_inputs=[],
+        prof_inputs=[],
+        benchmark_func_kwargs={"module": module, "request": request},
+        sample_count=shape.num_indices,
+        **config.benchmark_func_kwargs(
+            name=f"{backend}_tbe_forward_{workload_name}_shape_{shape_index}{suffix}",
+            rank=0,
+        ),
+    )
+    print(result)
+
+
+def _run_trace_workload(config: TraceTBEForwardConfig, backend: str) -> None:
+    config.maybe_enable_expandable_segments()
+    if not torch.cuda.is_available():
+        raise RuntimeError("benchmark_triton_tbe requires a CUDA device")
+    config.set_log_level()
+
+    if config.workload not in _TRACE_WORKLOADS:
+        raise ValueError(
+            f"--workload must be one of {sorted(_TRACE_WORKLOADS)}, "
+            f"got {config.workload}"
+        )
+    workload = _TRACE_WORKLOADS[config.workload]
+    if config.shape_index < 0 or config.shape_index >= len(workload.shapes):
+        raise ValueError(
+            f"--shape-index must be in [0, {len(workload.shapes)}), "
+            f"got {config.shape_index}"
+        )
+
+    shape_indices = (
+        range(len(workload.shapes)) if config.all_shapes else (config.shape_index,)
+    )
+    device = torch.device(torch.cuda.current_device())
+
+    for shape_index in shape_indices:
+        shape = workload.shapes[shape_index]
+        torch.manual_seed(config.seed + shape_index)
+        request = _make_request(workload, shape, device)
+        logger.info(
+            "workload=%s shape=%d T=%d R=%s bags=%d indices=%d mean_L=%.6f",
+            config.workload,
+            shape_index,
+            len(workload.table_rows),
+            workload.num_ranks if workload.num_ranks is not None else "fixed-B",
+            shape.num_bags,
+            shape.num_indices,
+            shape.num_indices / shape.num_bags,
+        )
+        torch.manual_seed(config.seed)
+        _run_backend(
+            backend,
+            config.workload,
+            workload,
+            shape_index,
+            shape,
+            request,
+            config,
+            device,
+        )
+
+
+def register_benchmark(
+    config: type[TraceTBEForwardConfig],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    def decorator(func: Callable[..., None]) -> Callable[..., None]:
+        func.__annotations__ = {"config": config, "return": None}
+        # pyrefly: ignore[missing-attribute]
+        _cc.register(func)
+        return func
+
+    return decorator
+
+
+@dataclass
+class TritonTBEForwardConfig(TraceTBEForwardConfig):
+    """Benchmark TorchRec's Triton TBE on a trace-derived production shape."""
+
+
+@register_benchmark(TritonTBEForwardConfig)
+def triton_tbe_forward(config: TraceTBEForwardConfig) -> None:
+    _run_trace_workload(config, "triton")
+
+
+@dataclass
+class FbgemmTBEForwardConfig(TraceTBEForwardConfig):
+    """Benchmark the FBGEMM CUDA TBE baseline on the identical request."""
+
+
+@register_benchmark(FbgemmTBEForwardConfig)
+def fbgemm_tbe_forward(config: TraceTBEForwardConfig) -> None:
+    _run_trace_workload(config, "fbgemm")
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[missing-attribute]
+    _cc.main()


### PR DESCRIPTION
Summary:
# Triton TBE Design

A walkthrough of the Triton implementation of Table Batched Embedding in TorchRec, covering the
memory layout, every kernel in the forward and backward paths, the optimizer fusion, the numerics,
and the TorchRec integration.

References:
[#4455](https://github.com/meta-pytorch/torchrec/pull/4455), [#4484](https://github.com/meta-pytorch/torchrec/pull/4484), [#4485](https://github.com/meta-pytorch/torchrec/pull/4485), [#4486](https://github.com/meta-pytorch/torchrec/pull/4486), [#4487](https://github.com/meta-pytorch/torchrec/pull/4487), [#4488](https://github.com/meta-pytorch/torchrec/pull/4488), [#4489](https://github.com/meta-pytorch/torchrec/pull/4489), [#4490](https://github.com/meta-pytorch/torchrec/pull/4490), [#4491](https://github.com/meta-pytorch/torchrec/pull/4491), [#4548](https://github.com/meta-pytorch/torchrec/pull/4548)

## 1. Scope and motivation

TBE packs many embedding tables into one flat weight buffer and serves all of their lookups with a
single fused kernel, with the optimizer update fused into the backward pass. The production
implementation is FBGEMM CUDA generated from Jinja2 templates, exposed as
SplitTableBatchedEmbeddingBagsCodegen. TritonTBE is a reimplementation of the same operator in
Triton.

<img width="1148" height="677" alt="image" src="https://github.com/user-attachments/assets/41214287-fe6a-403e-bc24-ed5dccfd96d6" />

**Figure 1** Fusion of multiple embedding table lookups

Figures in this doc are reused from the internal TBE wikis and describe the operator and the
FBGEMM algorithm. The Triton implementation follows the same structure unless noted.

**Machine efficiency.** Embedding traffic scales with the number of ranks times the pooling
factor, so the sparse arch moves far more bytes than the dense arch at the same batch size. The
forward pass usually overlaps with other streams. The backward pass generally does not, so its
latency shows up directly in train QPS. An internal status summary puts TBE at roughly 13% of
fleetwide GPU compute time.

**Developer efficiency.** The CUDA backward lives in 12 Jinja2 templates, about 7K lines under
codegen/training/backward. The generator renders them once per optimizer across the weighted,
nobag, VBE, and SSD axes, and 18 optimizers are registered, so the emitted CUDA is several times
the template size. An optimizer is expressed as a dict of code fragments plus capability flags
rather than as a kernel, which is compact for optimizers that fit the mold and awkward for
anything that does not. The Triton backward instead inlines the optimizer update as a branch on an
integer constexpr, in Python that can be edited in place.

Note what is not a codegen axis in FBGEMM. Weight precision is handled by C++ template parameters
(emb_t, grad_t, cache_t) dispatched at compile time, and sharding is a TorchRec concept that TBE
never sees.

Timeline from the commit history: an early prototype existed by early 2024 and did not reach
production. The current effort picked up in September 2025 with accumulator precision fixes, added
weighted support and rowwise Adagrad in December 2025, and has landed continuously since. The
kernels moved from FBGEMM into TorchRec in July 2026.

## 2. Code map

| Path | Contents |
|---|---|
| [triton_tbe/triton_table_batched_embeddings.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py) | 3,532 lines. Forward kernels, backward kernels, autograd Function, training module, quantized inference module |
| [triton_tbe/triton_tbe_backward_utils.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py) | 278 lines. Run classification, long-run expansion, stochastic rounding, grid sizing |
| [triton_tbe/triton_tbe_backward_long_run_fused.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/triton_tbe/triton_tbe_backward_long_run_fused.py) | 423 lines. TLX-fused long-run backward |
| [distributed/batched_embedding_kernel.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/batched_embedding_kernel.py) | TritonBatchedFusedEmbeddingBag, TritonEmbeddingFusedOptimizer |
| [distributed/embedding_types.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/embedding_types.py) | The FUSED_TRITON compute kernel enum value |
| [ads_mkl/ops/triton/amd/triton_table_batched_embeddings.py](https://www.internalfb.com/code/fbsource/fbcode/ads_mkl/ops/triton/amd/triton_table_batched_embeddings.py) | ROCm fork of every kernel |
| [fb/triton/triton_ops.cpp](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/triton_ops.cpp), [triton_ops.h](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/triton_ops.h) | Registers nbit_TBE_forward_16bits and _32bits as fbgemm CUDA ops |
| [fb/triton/triton_aot.py](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/triton_aot.py), [aot/](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/aot) | Ahead-of-time compiler for the n-bit inference kernels |
| [fb/triton/triton_table_batched_embeddings_aot.py](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/triton_table_batched_embeddings_aot.py) | TritonNBitTBEAOT, dispatches to the precompiled ops instead of JIT |
| [fb/triton/test](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/test), [fb/triton/bench](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/triton/bench) | Correctness tests and the Triton vs FBGEMM benchmark |

The CUDA baseline for comparison, all public in
[pytorch/FBGEMM](https://github.com/pytorch/FBGEMM):
[codegen/training/backward](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/codegen/training/backward)
holds the Jinja2 templates,
[codegen/genscript/optimizers.py](https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/codegen/genscript/optimizers.py)
holds the optimizer definitions, and
[split_table_batched_embeddings_ops_training.py](https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py)
is SplitTableBatchedEmbeddingBagsCodegen.

Rows linking to github.com are OSS-synced. Rows linking to internalfb.com are under fb/ or ads_mkl
and have no public mirror.

The kernels started in fbgemm under fb/triton and moved into TorchRec in July 2026. No training
implementation remains in fbgemm. What is left there is the tests, the benchmarks, and the
ahead-of-time inference path, and all of it now depends on
//torchrec/distributed/triton_tbe:triton_table_batched_embeddings. The dependency direction is
inverted from the usual one, with fbgemm consuming torchrec.

The AOT files import the JIT kernels from the torchrec module and compile them ahead of time, so
the two halves of the inference story are split across repos. Note that fb/triton/BUCK has no
target for triton_aot.py or the AOT wrapper, so that path looks unwired at present.

## 3. What the operator computes

Forward, sum pooling, for bag b of feature t:

```
output[b, D_offset(t) : D_offset(t) + D_t] = sum over l in bag(b, t) of
    weight[table(t)][ indices[l] ]            # unweighted
    weight[table(t)][ indices[l] ] * w[l]     # weighted
```

<img width="548" height="206" alt="image" src="https://github.com/user-attachments/assets/89b2bd63-eb6b-4411-bed4-a1d1904cfa4e" />

**Figure 2** Pooled embedding forward. Offsets delimit bags, and each bag sums its looked-up rows

Backward produces a gradient only for rows that were looked up, so it is sparse. Because a row can
appear in many bags, the gradient for that row is the sum over all of its occurrences. The
optimizer is applied in the same kernel, so no dense gradient tensor is ever materialized.

<img width="624" height="284" alt="image" src="https://github.com/user-attachments/assets/dc9b2a6b-f581-4c57-86f9-9864421f291c" />

**Figure 3** Pooled embedding backward. The uncoalesced form has one gradient row per lookup, and
coalescing sums the rows that share an index. TBE never materializes either tensor, and instead
coalesces on the fly and applies the optimizer in the same kernel

The hard part is that row frequency follows a power law. A design-doc example cites 83M total
indices, 3M unique, and one row appearing 125K times. A scheme that assigns one worker per unique
row leaves most workers idle while a few grind through enormous segments.

## 4. Module and memory layout

TritonTableBatchedEmbeddingBags is constructed from embedding_specs, a list of (rows, dim) per
physical table, plus an optional feature_table_map so several features can share one table.

Everything is precomputed into device tensors at construction:

| Tensor | Shape | Indexed by | Purpose |
|---|---|---|---|
| weight | [sum(rows*dim)] | flat | All tables concatenated, 1-D, requires_grad |
| table_offsets | [T_+1] | table | Element offset of each table in weight |
| embedding_dims | [T] | feature | Dimension of each feature |
| embedding_offsets | [T] | feature | Column offset of each feature in the output row |
| feature_table_map_tensor | [T] | feature | Feature to physical table |
| hash_size_cumsum | [T+1] | feature | Base for linearizing indices across tables |
| rows_cumsum | [T_+1] | table | Base for indexing momentum |
| rows_per_table | [T] | feature | Row counts for bounds checking |
| momentum | [total_rows] or [1] | flat row | Rowwise Adagrad state, FP32 |
| _D_offsets | [T+1] int32 | feature | Dimension cumsum for VBE metadata |

Two indexing conventions coexist and are easy to confuse. Dimensions and column offsets are per
feature. Table offsets and momentum bases are per physical table. The kernels convert between them
with feature_table_map.

<img width="599" height="347" alt="image" src="https://github.com/user-attachments/assets/ade3bacd-0036-4f6e-9c68-404d8a1abef6" />

**Figure 4** Feature to table mapping. Several features can share one physical table, which is why
dimensions are indexed by feature and table offsets by table

Derived scalars: total_embedding_dim is the sum of feature dims, total_hash_size_bits is
int(log2(total_hash_size) + 1), and block_size is next_power_of_2 of the largest table dimension.
Block size is the tile width for every kernel, so a dimension of 96 runs on a 128-wide tile with a
mask.

## 5. Forward, host side

Module forward does the following before touching a kernel:

1. Cast offsets to the indices dtype, and per-sample weights to float.
2. If batch_size_per_feature_per_rank is set, build VBE metadata once and reuse it for both the
   bounds check and the kernels. This calls generate_vbe_metadata, get_infos_metadata, and the
   FBGEMM generate_vbe_metadata op to produce row_output_offsets and b_t_map.
3. Choose a bounds-check path.
4. Call TritonTBE.apply.

The bounds-check choice matters. The default mode is V2_WARNING, which routes to the FBGEMM
bounds_check_indices CUDA op. The fused path is taken only when all of these hold: the
fused_bounds_check flag is set, the mode is WARNING, there is no VBE, there are no per-sample
weights, the transpose is not hoisted, and the device is not AMD. In that case the host runs two
small Triton kernels instead:

- The offsets kernel validates that offsets are monotonic and in range, over blocks of 256 bags,
  and atomically increments a warning counter.
- The repair kernel runs single-threaded and clamps offsets back into a valid monotonic sequence,
  but only if the warning counter is non-zero. Under a feature gate it asserts instead.

The per-index range check is then folded into the gather loop itself.

## 6. Forward kernels

### 6.1 Unweighted

The workhorse. Grid is ceil(B / BAGS_PER_PROGRAM), one program per bag or small group of bags.
Each program loops over a feature range, and for each feature over its assigned bags.

Inside a bag the index loop is manually unrolled by 4, or by 8 when UNROLL8 is set. Four or eight
loads are issued before any result is consumed, which is what keeps several independent gathers in
flight. Triton will not do this automatically because the trip count is data dependent. A scalar
tail loop handles the remainder.

The accumulator is FP64 when weights are FP32, and FP32 otherwise. FP32 weights with an FP32
accumulator lost too much precision over long bags. The store always converts to FP32 regardless
of the accumulator or the weight dtype.

Four constexpr knobs specialize the kernel:

| Knob | Set when | Effect |
|---|---|---|
| BAGS_PER_PROGRAM | 4 if any histogram feature is active, else 2 if not VBE and B >= 65536 and weights are not FP32, else 1 | Coarsens scheduling, fewer programs each doing more |
| UNROLL8 | BAGS_PER_PROGRAM == 2 | Widens the gather issue from 4 to 8 |
| FEATURE_START, FEATURE_END | Always | Lets the host skip features already handled by the small-table kernel |
| FUSED_BOUNDS_CHECK | Fused path selected | Clamps bad indices to row 0 inline and counts them |

The feature-range slicing exists because the small-table kernel handles some features separately.
The host builds the complement of the handled set and launches one kernel per contiguous range.

### 6.2 Weighted

Simpler and less tuned. Grid is total_B, one program per (feature, bag) pair, with the pair decoded
either from b_t_map under VBE or by division. Unroll is fixed at 4, and there is no
bags-per-program or feature-range machinery, no fused bounds check, and no small-table path.
Per-sample weights multiply each row after conversion to FP32.

### 6.3 Small-table histogram kernel

A specialization for tables that are short and heavily pooled. It is selected at construction when
bag_size_hints are provided, weights are FP16, output is FP32, and some feature has at most 64
rows, a dimension between 64 and 128, and a hint of at least 64. Among candidates the one with the
largest hint times dimension wins.

Instead of gathering rows one at a time, the kernel processes 16 bags per program and builds a
histogram of row indices over the first 256 positions of each bag, encoding bag and row into one
bin index. The pooled result is then a single tl.dot of the count matrix against the entire table,
which fits in registers. Positions beyond 256 fall back to a scalar tail loop, and a flag is raised
so the backward knows the counts are incomplete.

<img width="266" height="134" alt="image" src="https://github.com/user-attachments/assets/f05514ee-d74a-45c8-b41a-78d5e9eda165" />

**Figure 5** The count matrix the histogram kernel builds. Multiplying it by the whole table gives
the pooled output for every bag at once, turning a gather loop into a matmul

When the plan qualifies, the counts are also stored as FP16 for reuse in the backward pass.

## 7. Backward, data structures

### 7.1 Index transpose

The first stage reuses the FBGEMM CUDA op transpose_embedding_input unchanged. It linearizes
indices across tables using hash_size_cumsum, sorts them, and run-length encodes them:

| Output | Meaning |
|---|---|
| linear_indices | Per-position linearized row id, unsorted |
| infos_sorted | Per-position packed (feature, bag), sorted alongside the indices |
| sorted_linear_indices_run | The unique linear index of each run |
| sorted_linear_indices_num_runs | Number of runs, as a GPU scalar |
| sorted_linear_indices_cumulative_run_lengths | Prefix sum of run lengths |

The info word packs the feature index in the high bits and the bag index in the low bits, with the
split given by info_B_num_bits and info_B_mask from get_infos_metadata.

<img width="656" height="592" alt="image" src="https://github.com/user-attachments/assets/4e845ed2-6754-4584-9e67-9da4082bc2ce" />

**Figure 6** The backward pipeline. Steps 1 to 4 are transpose_embedding_input, reused from FBGEMM
CUDA unchanged. TritonTBE replaces only step 5, and inserts its own run classification between the
prefix sum and the compute kernels

Keeping this in CUDA is a deliberate scope cut. It relies on a CUB radix sort, and the design doc
flags rewriting it in Triton as future work, since it is the piece that would have to change to
support new embedding algorithms.

By default the transpose is hoisted into the forward pass and cached on the autograd context. It
depends only on indices, offsets, and hash_size_cumsum, never on the output gradient, so moving it
is bit-exact. A flag preserves the old behavior for A/B comparison.

### 7.2 Run classification

Two Triton kernels split runs into short and long against a threshold of 256, with no host sync.

The classify kernel runs over blocks of 1024 runs. Each block computes a boolean mask of long
versus short, reduces it with tl.sum to get block counts, reserves output space with a single
atomic add per class, and uses tl.cumsum to place each element within the reserved span. This is
stream compaction without a sort and without a scan across blocks.

The expand kernel runs one program per long run, computes how many 256-entry sub-segments it needs,
reserves that many slots with an atomic, and writes the segment bounds plus a grad_buffer_id equal
to the long run's slot index.

Everything downstream reads counts from GPU tensors. An earlier version computed this in Python
with .item() calls, which forced a host sync on every backward.

## 8. Backward kernels

### 8.1 Work distribution

Every backward kernel launches with a fixed grid and distributes work with the same arithmetic:

```
c = n // num_programs
r = n - c * num_programs
local_id     = c * pid + max(pid - num_programs + r, 0)
local_id_end = local_id + c + (pid >= num_programs - r)
```

Every program gets c items and the last r programs get one extra, with no atomics and no imbalance
beyond a single item. Programs with nothing to do exit immediately.

Grid sizes come from get_grid_size:

| Platform | Short-run grid | Long-run grid |
|---|---|---|
| NVIDIA, no CLC | min(24576, max_num_runs) | min(24576, max_long_run_programs) |
| NVIDIA, CLC | min(786432, max_num_runs) | min(786432, max_long_run_programs) |
| AMD | min(65536, max_num_runs) | min(65536, max_long_run_programs) |

The 24576 figure is 192 SMs times 32 warps times 4 waves. The source comment records that below it
there are not enough programs to fill the machine, and above it the scheduling overhead of excess
programs starts to cost. The AMD number is 256 CUs times 64 warps times 4 waves.

### 8.2 Short-run kernel

One program handles one run at a time. It reads the run's segment bounds, then walks the segment in
tiles of 8 info entries, or 16 when weighted. For each tile it decodes the bag and feature per
entry, computes a vector of row start pointers into the output gradient, loads a 2-D tile of shape
[buffer_size, BLOCK_SIZE], and reduces along the entry axis with tl.sum. A scalar tail loop
finishes the segment.

One subtlety: the table for the row is taken from the first info entry of the run, but the output
gradient offset is recomputed per entry. A run is a unique linear index, and when several features
share a physical table the same row can be reached from different features whose output columns
differ.

The accumulated gradient is FP32. The kernel then loads the embedding row, applies the optimizer
inline, and stores.

Backward runs with num_warps=1, so a program is a single warp. This matches warp_per_row in CUDA
TBE.

<img width="335" height="187" alt="image" src="https://github.com/user-attachments/assets/82e2fb73-996c-4a25-bdbd-be8775fa7534" />

**Figure 7** One warp per run. Each warp owns all occurrences of a single row and updates it once,
which is what avoids the racing updates that an unsorted scatter would produce. Runs longer than
256 entries go to the long-run path instead

### 8.3 Long-run path

Long runs are split into 256-entry sub-segments. Stage one runs one program per sub-segment,
accumulates a partial gradient the same way as the short-run kernel, and does a single atomic add
into a scratch buffer of shape [max_long_runs, block_size] indexed by grad_buffer_id. Stage two
runs one program per long run, reads the accumulated row, applies the optimizer, and stores. This
mirrors cta_per_row in CUDA TBE.

Stage two is shared between weighted and unweighted, since by that point the per-sample weights
have already been folded into the accumulated gradient.

### 8.4 Fused long-run kernel

A TLX variant merges the two stages into one launch. After its atomic add, each sub-program issues
a GPU-scope fence and then decrements a per-run counter initialized to the sub-program count. The
program that observes a remaining count of 1 is the last one, so it reads back the accumulated
gradient and performs the optimizer update.

This path is narrow. It requires CLC support and

```
max_num_runs > _CLC_FIXED_GRID * _LONG_RUN_THRESHOLD = 786432 * 256 = 201,326,592
```

so it only engages above roughly 201M indices in a batch. Below that, even on Blackwell, the
two-kernel path runs, and the long-run accumulate grid drops back to 24576.

### 8.5 Cluster Launch Control

On Blackwell, TLX exposes CLC. A program that runs out of work issues an async request to the
hardware scheduler and receives another tile id, so it persists and steals work rather than
exiting. In the short-run kernel this is a producer/consumer pair wrapped around the main loop,
with phase bits toggled each round, gated at runtime on compute capability major >= 10 and on TLX
being importable.

The original design argued that CLC removes the need for the software short/long split, since load
imbalance becomes a hardware concern. That is not where it landed. The two-tier dispatch was kept
and later extended to the weighted path, partly because a single kernel with a grid sized to the
index count overwhelmed the block scheduler, and partly because CLC does not exist on H100 or
MI350X. Both mechanisms are carried, with CLC as an optional layer.

### 8.6 Histogram backward

When the forward saved histogram counts, the backward for those features skips the run machinery
entirely. It splits the output gradient into FP16 high and low parts around a power-of-two scale
derived from the max absolute value, runs two matmuls with an FP32 output accumulator, and
recombines. The gradient for the whole small table comes out as a dense matrix, and a small kernel
applies rowwise Adagrad with one program per row.

The two-term split recovers precision that a single FP16 matmul would lose. After the handled
features are processed, the host trims indices, offsets, dims, and the feature table map so the
remaining features go through the normal path. If nothing is left, backward returns early.

This path is gated off during CUDA graph capture, because it reads the invalid flag back to the
host.

## 9. Optimizer fusion

The optimizer is selected by an integer constexpr, mapped from the FBGEMM enum:

| Enum | Int | Update |
|---|---|---|
| EXACT_SGD | 0 | row -= lr * grad |
| EXACT_ROWWISE_ADAGRAD | 1 | mean of squared gradient across the row is added to a per-row momentum scalar, then row -= lr / (sqrt(momentum) + eps) * grad |

Only these two are supported. This is the sharpest functional gap against the CUDA codegen, which
generates a kernel per optimizer from templates.

Both branches appear at every apply site: the short-run kernel, the long-run apply kernel, the
fused long-run kernel, and the histogram apply kernel. The SGD update is computed unconditionally
and overwritten when the Adagrad branch is taken, which keeps the code uniform at the cost of a
dead multiply.

The learning rate is not baked in. TritonEmbeddingFusedOptimizer pushes param_groups[0]["lr"] onto
the module in both step and zero_grad, and the module passes it as a runtime scalar. Passing it as
a kernel argument rather than a constexpr is what avoids recompiling on every learning-rate change.

## 10. Numerics

**Accumulators.** Forward uses FP64 for FP32 weights and FP32 otherwise, on NVIDIA. AMD uses FP32
in both cases, because FP64 throughput there makes the wider accumulator too expensive. Backward
accumulates in FP32 everywhere.

**Output dtype.** The forward store always converts to FP32 before writing, and the output buffer
is allocated with the configured output dtype. An early NE gap came from emitting FP16 output when
weights were FP16, where CUDA TBE outputs FP32 during training.

**Stochastic rounding.** Required for FP16 weights to converge. CUDA TBE adds noise and truncates
toward zero, which Triton cannot express because it has no round-toward-zero FP16 conversion
intrinsic. The Triton version computes the round-to-nearest FP16 value, derives the adjacent
representable value by integer arithmetic on the bit pattern, measures the error, and picks between
the two with probability proportional to proximity:

```
P(pick adjacent) = |val - rne(val)| / ulp
```

One seed is drawn per backward call on the host and shared by all kernels. Each kernel supplies a
different offset into the random stream, derived from its work id and column index.

## 11. Variable batch size (VBE)

Under VBE each feature has a different batch size per rank, so the output is a flat buffer rather
than a rectangle. Support threads through three extra tensors. B_offsets gives each feature's batch
range, row_output_offsets gives the output offset of every (feature, bag) pair, and b_t_map packs
the pair for reverse lookup.

Every kernel takes a vbe constexpr and branches between computing the output offset arithmetically
and loading it from row_output_offsets. The metadata is computed once in module forward and passed
down as precomputed arguments so the autograd Function does not recompute it, with a fallback path
that recomputes if it was not supplied.

VBE is incompatible with the fused bounds check and with the small-table kernel.

## 12. AMD fork

The ROCm variants live in a separate file under ads_mkl and are imported under aliases, with
dispatch on torch.version.hip at each launch site. The module docstring lists three deltas: no CLC,
FP32 accumulation instead of FP64, and plain range loops instead of tl.range with NVIDIA-specific
keyword arguments.

Beyond those, the AMD backward batches consecutive segments sharing a grad_buffer_id before a
single atomic flush, to cut contention, and uses a grid of 65536. The forward has no
bags-per-program or feature-range machinery, so it launches with a grid of B.

The cost of this arrangement is that every kernel exists twice, and a change on the NVIDIA side
does not automatically reach AMD. The most recent commit in the history is an AMD kernel fix.

## 13. Inference: TritonNBitTBE

A separate module for quantized inference, forward only, no autograd.

Weights are a single flat uint8 buffer, additionally viewed as int16 and int32 so the kernels can
address rows in 2-byte or 4-byte units. Row size is rounded per the quantization type and the row
alignment, and each table is padded to a cache line. Scale and shift are stored inline at the start
of each row.

Two kernels cover five types:

| Kernel | Types | Block size minimums |
|---|---|---|
| 32-bit | FP32, INT8, INT4 | 64, 128, 256 |
| 16-bit | FP16, INT2 | 64, 256 |

Both may launch in the same forward when a model mixes types, each handling the tables that match
it and skipping the rest via a branch on the per-table type code. Grid is B*T, one program per
(table, bag), num_warps=1.

The low-precision paths unpack in registers. INT2 is the most involved. It loads a row as uint16,
extracts eight 2-bit lanes with shifts and masks, applies scale times value plus shift per lane
with two different pre-scaled constants, and stores the eight result vectors at stride 8 into the
output row.

**Ahead-of-time variant.** The JIT module above lives in TorchRec. Its AOT counterpart lives in
fbgemm. TritonNBitTBEAOT subclasses the JIT module but calls torch.ops.fbgemm.nbit_TBE_forward_16bits
and _32bits, which are registered from triton_ops.cpp and backed by kernels that triton_aot.py
compiled ahead of time from the same Triton sources. This removes runtime compilation for
inference serving. The build has no BUCK target for these files at present, so treat the path as
present but not currently wired.

## 14. TorchRec integration

TritonBatchedFusedEmbeddingBag wraps the module and plugs into the standard path:

- A compute kernel enum value FUSED_TRITON, with a planner bandwidth entry equal to the CUDA fused
  kernel, so the planner will select it without preferring it.
- Configuration through fused_params: optimizer, learning_rate, eps, output_dtype,
  stochastic_rounding, bag_size_hints, fused_bounds_check.
- TritonEmbeddingFusedOptimizer with shard-aware parameter keys, so column-wise shards of one table
  merge into a single checkpoint entry and match the CUDA fused optimizer.
- split_embedding_weights, flush, reset_cache_states, split_optimizer_states, get_optimizer_state.
  flush and reset_cache_states are no-ops, since there is no cache.
- record_forward_event after the forward kernel, and wait_for_forward before NCCL collectives in
  output dist. Triton kernels run on the current stream but NCCL may not, so the ordering is made
  explicit with a CUDA event.

Constraints: CUDA or ROCm only, and local column counts must be divisible by 4. The Triton import
is lazy so backends without Triton are unaffected.

Notably absent relative to CUDA TBE: no UVM or managed memory placement, no LXU software cache, no
SSD tier, no pruning, and pooling is sum only.

## 15. Performance

From the internal design doc and the H1 2026 status summary. Not reproduced here.

B200, T=32, E=100000, D=128, L=20, FP32 weights, unweighted, exact SGD:

| Batch size | Forward, Triton over FBGEMM | Backward, Triton over FBGEMM |
|---|---|---|
| 131072 | 0.78x | 1.14x |
| 524288 | 1.18x | 1.30x |

Reported elsewhere: H100 weighted backward at 1.04x bandwidth, about 11 ms against 18 ms in traces,
with a 4% end-to-end QPS gain on one Ads model. MI350X unweighted backward at 1.22x and weighted at
1.13x, with a 2% QPS gain on an OmniFM configuration.

Three caveats on reading these:

1. The bandwidth metric is not HBM bandwidth. The benchmark computes accessed bytes as B times the
   sum over tables of D times L, which counts duplicated rows that were served from L2. Values
   above 8 TB/s on B200 exceed the hardware peak, which is the tell. It is a useful relative metric
   between backends on identical input, not a roofline distance. No profiler-based measurement
   surfaced.
2. The B200 table used exact SGD, not the production rowwise Adagrad, which was not implemented in
   Triton at the time.
3. The small-batch forward was a regression when measured. Later forward work is referenced as
   closing that gap, but the follow-up is a comment rather than a published table.

The benchmark harness builds both backends in one process, runs matched inputs, and prints a JSON
line per backend. It supports variable E and D per table, variable pooling factors, VBE, weighted
mode, and GPU tracing.

## 16. Tradeoffs

**What Triton buys.** The implementation is Python that can be edited in place, and the AMD port is
a fork of one file with three documented deltas rather than a parallel HIP codegen pipeline.
Experiments like the histogram small-table path are cheap to try, and hard to express in the
templated CUDA. The compiler handles vectorization, coalescing, and shared memory placement, which
is a large share of what the CUDA kernels spend lines on.

**What it costs.** Control comes back through indirect knobs. The wins here came from manual loop
unrolling, hand-picked tile widths of 8 and 16, forcing num_warps to 1, and fixed grids tuned to a
specific SM count. That is tuning through a narrower interface rather than less tuning. Hardware
features need TLX, which is a Meta dialect, so the portability argument weakens exactly where CLC
was supposed to help. Numerics need explicit attention when intrinsics do not line up, as the
stochastic rounding rewrite shows.

On code volume, be careful with the often-quoted ratio. The design doc's "~100 lines versus ~1,300"
described the early prototype. The current implementation is about 4,200 lines across three files,
plus the AMD fork, against roughly 7K lines of templates that expand several times over. The
implementation is smaller and far more readable, and it is not an order of magnitude.

**Where the boundary sits.** Triton moved the cost rather than removing it. It is clearly better
for the parts that change often and for porting across vendors. The current state is a hybrid that
still depends on FBGEMM CUDA for sorting, VBE metadata, info packing, and the default bounds check.

## 17. Open items

- The index transpose is still CUDA and CUB-based, and is the blocker for new embedding algorithms.
- Optimizer coverage is exact SGD and exact rowwise Adagrad only.
- CLC is Blackwell-only, and its fused long-run path needs roughly 201M indices before it engages,
  so the software path carries nearly all production traffic.
- Memory hierarchy features from CUDA TBE are absent: UVM, LXU cache, SSD.
- The AMD fork duplicates kernels rather than parameterizing one source.
- No published profiler-based roofline analysis, so remaining headroom is unclear.

Differential Revision: D118071619


