### PR TITLE
Benchmark autotune restore_value for mutating inputs

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_ops.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_ops.py
@@ -107,6 +107,7 @@ class TritonOpConfig(BenchFuncConfig):
     num_profiles: int = 10
     seed: int = 42
     debug_mode: bool = False
+    run_warmup: bool = True
 
     def make_inputs(self, device: torch.device) -> Dict[str, Any]:
         """Build everything the benchmark consumes.
@@ -115,6 +116,9 @@ class TritonOpConfig(BenchFuncConfig):
         data generation never land in the measurement.
         """
         return {}
+
+    def validate_outputs(self, kwargs: Dict[str, Any]) -> None:
+        """Validate benchmark state after all timed and profiled iterations."""
 
 
 def _make_benchmark_kwargs(arg: TritonOpConfig, device: torch.device) -> Dict[str, Any]:
@@ -151,9 +155,10 @@ def single_rank_runner(
 
     # Warm up outside the measurement, then reconstruct inputs so mutating ops do not
     # turn a requested dirty-path measurement into a clean-path measurement.
-    warmup_kwargs = _make_benchmark_kwargs(arg, device)
-    bench_func([], **warmup_kwargs)
-    del warmup_kwargs
+    if arg.run_warmup:
+        warmup_kwargs = _make_benchmark_kwargs(arg, device)
+        bench_func([], **warmup_kwargs)
+        del warmup_kwargs
     torch.manual_seed(arg.seed)
     kwargs = _make_benchmark_kwargs(arg, device)
 
@@ -168,6 +173,7 @@ def single_rank_runner(
         **arg.benchmark_func_kwargs(name=name),
     )
 
+    arg.validate_outputs(kwargs)
     print(result)
 
 
@@ -428,6 +434,171 @@ def autotune_triton(
                 workload.length_bucket,
                 workload.dim_bucket,
             )
+
+
+######################## autotune restore_value demonstration ########################
+_AUTOTUNE_ADD_ONE_CONFIGS = [
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8),
+]
+
+
+# Triton TR001: autotune the pointwise tile size used for the mutation.
+@triton.autotune(
+    configs=_AUTOTUNE_ADD_ONE_CONFIGS,
+    key=["numel"],
+    restore_value=["values"],
+)
+@triton.jit
+def _autotune_add_one_with_restore_kernel(
+    values,
+    numel,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    value = tl.load(values + offsets, mask=mask)
+    tl.store(values + offsets, value + 1, mask=mask)
+
+
+# Triton TR001: use the same choices as the restore_value treatment.
+@triton.autotune(
+    configs=_AUTOTUNE_ADD_ONE_CONFIGS,
+    key=["numel"],
+)
+@triton.jit
+def _autotune_add_one_without_restore_kernel(
+    values,
+    numel,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    value = tl.load(values + offsets, mask=mask)
+    tl.store(values + offsets, value + 1, mask=mask)
+
+
+@dataclass
+class AutotuneRestoreValueState:
+    values: torch.Tensor
+    sample_indices: torch.Tensor
+    logical_invocations: int = 0
+
+
+def _read_autotune_restore_value_samples(
+    state: AutotuneRestoreValueState,
+) -> List[float]:
+    return state.values.index_select(0, state.sample_indices).cpu().tolist()
+
+
+def _trace_autotune_restore_value_samples(
+    state: AutotuneRestoreValueState,
+) -> None:
+    if not torch.autograd.profiler._is_profiler_enabled:
+        return
+
+    # The readback intentionally synchronizes only profiled iterations. Keeping it in
+    # a separate range makes the validation overhead explicit and excludes it from the
+    # autotune_restore_value timing range.
+    with record_function("## autotune_restore_value validation readback ##"):
+        observed = _read_autotune_restore_value_samples(state)
+    observed_label = ",".join(f"{value:g}" for value in observed)
+    with record_function(
+        "## autotune_restore_value validation result "
+        f"logical_invocations={state.logical_invocations} "
+        f"sample_values={observed_label} ##"
+    ):
+        pass
+
+
+@dataclass
+class AutotuneRestoreValueConfig(TritonOpConfig):
+    """Expose the correctness and memory cost of restoring a mutating input.
+
+    The default FP16 input is 12 GB, representative of an embedding table mutated by
+    TBE backward. Clearing the autotune cache before each outer iteration makes every
+    iteration exercise candidate benchmarking. Warmup is disabled so that disabling
+    retune_each_iteration shows one cold call followed by cached steady-state calls.
+    """
+
+    num_benchmarks: int = 0
+    memory_snapshot: bool = True
+    run_warmup: bool = False
+    numel: int = 6_000_000_000
+    restore_value: bool = True
+    retune_each_iteration: bool = True
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        if self.numel <= 0:
+            raise ValueError("numel must be positive")
+        # Citrine C3: allocate the large input directly on its target GPU.
+        values = torch.zeros(self.numel, device=device, dtype=torch.float16)
+        sample_indices = torch.tensor(
+            [0, self.numel // 2, self.numel - 1],
+            device=device,
+        )
+        return {
+            "state": AutotuneRestoreValueState(
+                values=values,
+                sample_indices=sample_indices,
+            )
+        }
+
+    def validate_outputs(self, kwargs: Dict[str, Any]) -> None:
+        state = kwargs["state"]
+        assert isinstance(state, AutotuneRestoreValueState)
+        observed = _read_autotune_restore_value_samples(state)
+        expected = float(state.logical_invocations)
+        cache_is_warm_before_inputs = self.run_warmup and not self.retune_each_iteration
+        if self.restore_value or cache_is_warm_before_inputs:
+            if observed != [expected] * len(observed):
+                raise AssertionError(
+                    "restore_value failed to preserve one mutation per logical "
+                    f"invocation: expected {expected}, observed {observed}"
+                )
+        elif not all(value > expected for value in observed):
+            raise AssertionError(
+                "unrestored autotune did not expose candidate mutations: "
+                f"expected values above {expected}, observed {observed}"
+            )
+        logger.info(
+            "Validated autotune mutation count: logical=%d observed=%s",
+            state.logical_invocations,
+            observed,
+        )
+
+
+@register_benchmark(AutotuneRestoreValueConfig)
+def autotune_restore_value(
+    _batch_inputs: List[Dict[str, Any]],
+    state: AutotuneRestoreValueState,
+    restore_value: bool,
+    retune_each_iteration: bool,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    kernel = (
+        _autotune_add_one_with_restore_kernel
+        if restore_value
+        else _autotune_add_one_without_restore_kernel
+    )
+    if retune_each_iteration:
+        kernel.cache.clear()
+
+    numel = state.values.numel()
+
+    def grid(meta: Dict[str, Any]) -> tuple[Any, ...]:
+        return (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+
+    with record_function(
+        "## autotune_restore_value "
+        f"bytes={state.values.nbytes} "
+        f"restore_value={restore_value} "
+        f"retune_each_iteration={retune_each_iteration} ##"
+    ):
+        kernel[grid](state.values, numel)
+    state.logical_invocations += 1
+    _trace_autotune_restore_value_samples(state)
 
 
 ############################### TBE bounds check configs ###############################

--- a/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
+++ b/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
@@ -52,6 +52,10 @@ from torchrec.distributed.triton_tbe.triton_tbe_backward_utils import (
 )
 
 
+_VBE_SMALL_DIM_BAGS_PER_PROGRAM = 64
+_VBE_SMALL_DIM_NUM_WARPS = 4
+
+
 def is_amd() -> bool:
     return torch.version.hip is not None
 
@@ -360,6 +364,79 @@ def table_batched_embedding_bag_grad_per_sample_weights_kernel(  # noqa: TR001
         )
         grad_per_sample_weight = tl.sum(row.to(tl.float32) * dout_row, axis=0)
         tl.store(grad_per_sample_weights_ptr + idx, grad_per_sample_weight)
+
+
+@triton.jit
+# Triton TR001: BLOCK_SIZE is the fixed embedding-width bound for this VBE path.
+def _table_batched_embedding_bag_forward_vbe_small_dim_kernel(  # noqa: TR001
+    output_ptr,
+    indices_ptr,
+    offsets_ptr,
+    weight_ptr,
+    table_offsets_ptr,
+    embedding_dims_ptr,
+    feature_table_map_ptr,
+    row_output_offsets_ptr,
+    b_t_map_ptr,
+    total_B,
+    info_B_num_bits,
+    BLOCK_SIZE: tl.constexpr,
+    BAGS_PER_PROGRAM: tl.constexpr,
+) -> None:
+    bag_slots = tl.arange(0, BAGS_PER_PROGRAM)
+    b_t = tl.program_id(0).to(tl.int64) * BAGS_PER_PROGRAM + bag_slots
+    active_bags = b_t < total_B
+
+    info = tl.load(b_t_map_ptr + b_t, mask=active_bags, other=0).to(tl.uint32)
+    features = (info >> info_B_num_bits).to(tl.int32)
+    table_indices = tl.load(
+        feature_table_map_ptr + features,
+        mask=active_bags,
+        other=0,
+    )
+    table_offsets = tl.load(
+        table_offsets_ptr + table_indices,
+        mask=active_bags,
+        other=0,
+    )
+    embedding_dims = tl.load(
+        embedding_dims_ptr + features,
+        mask=active_bags,
+        other=0,
+    )
+    starts = tl.load(offsets_ptr + b_t, mask=active_bags, other=0)
+    ends = tl.load(offsets_ptr + b_t + 1, mask=active_bags, other=0)
+    lengths = ends - starts
+
+    columns = tl.arange(0, BLOCK_SIZE)
+    output = tl.zeros((BAGS_PER_PROGRAM, BLOCK_SIZE), dtype=tl.float32)
+    for row_offset in range(0, tl.max(lengths)):
+        active_rows = active_bags & (row_offset < lengths)
+        row_indices = tl.load(
+            indices_ptr + starts + row_offset,
+            mask=active_rows,
+            other=0,
+        )
+        rows = tl.load(
+            weight_ptr
+            + table_offsets[:, None]
+            + row_indices[:, None] * embedding_dims[:, None]
+            + columns[None, :],
+            mask=active_rows[:, None] & (columns[None, :] < embedding_dims[:, None]),
+            other=0,
+        )
+        output += rows.to(tl.float32)
+
+    row_output_offsets = tl.load(
+        row_output_offsets_ptr + b_t,
+        mask=active_bags,
+        other=0,
+    )
+    tl.store(
+        output_ptr + row_output_offsets[:, None] + columns[None, :],
+        output,
+        mask=active_bags[:, None] & (columns[None, :] < embedding_dims[:, None]),
+    )
 
 
 @triton.jit
@@ -1911,28 +1988,14 @@ class TritonTBE(torch.autograd.Function):
                     num_warps=num_warps,
                 )
             else:
-                bags_per_program = (
-                    4
-                    if optimized_histogram_features
-                    else (
-                        2
-                        if not vbe and B >= 65536 and weight.dtype != torch.float32
-                        else 1
-                    )
-                )
-                feature_ranges = []
-                feature_start = 0
-                for feature in sorted(set(optimized_histogram_features)):
-                    if feature_start < feature:
-                        feature_ranges.append((feature_start, feature))
-                    feature_start = feature + 1
-                if feature_start < T:
-                    feature_ranges.append((feature_start, T))
-                for feature_start, feature_end in feature_ranges:
-                    if feature_start >= feature_end:
-                        continue
-                    table_batched_embedding_bag_forward_unweighted_kernel[
-                        (triton.cdiv(B, bags_per_program),)
+                if vbe and block_size == 8:
+                    _table_batched_embedding_bag_forward_vbe_small_dim_kernel[
+                        (
+                            triton.cdiv(
+                                total_B,
+                                _VBE_SMALL_DIM_BAGS_PER_PROGRAM,
+                            ),
+                        )
                     ](
                         output,
                         indices,
@@ -1940,24 +2003,63 @@ class TritonTBE(torch.autograd.Function):
                         weight,
                         table_offsets,
                         embedding_dims,
-                        embedding_offsets,
                         feature_table_map,
-                        rows_cumsum,
-                        bounds_check_warning_ptr,
                         row_output_offsets_ptr,
-                        B_offsets_ptr,
-                        total_embedding_dim,
-                        B,
-                        T,
+                        b_t_map_ptr,
+                        total_B,
+                        info_B_num_bits,
                         BLOCK_SIZE=block_size,
-                        vbe=vbe,
-                        FEATURE_START=feature_start,
-                        FEATURE_END=feature_end,
-                        BAGS_PER_PROGRAM=bags_per_program,
-                        UNROLL8=bags_per_program == 2,
-                        FUSED_BOUNDS_CHECK=fused_bounds_check,
-                        num_warps=num_warps,
+                        BAGS_PER_PROGRAM=_VBE_SMALL_DIM_BAGS_PER_PROGRAM,
+                        num_warps=_VBE_SMALL_DIM_NUM_WARPS,
                     )
+                else:
+                    bags_per_program = (
+                        4
+                        if optimized_histogram_features
+                        else (
+                            2
+                            if not vbe and B >= 65536 and weight.dtype != torch.float32
+                            else 1
+                        )
+                    )
+                    feature_ranges = []
+                    feature_start = 0
+                    for feature in sorted(set(optimized_histogram_features)):
+                        if feature_start < feature:
+                            feature_ranges.append((feature_start, feature))
+                        feature_start = feature + 1
+                    if feature_start < T:
+                        feature_ranges.append((feature_start, T))
+                    for feature_start, feature_end in feature_ranges:
+                        if feature_start >= feature_end:
+                            continue
+                        table_batched_embedding_bag_forward_unweighted_kernel[
+                            (triton.cdiv(B, bags_per_program),)
+                        ](
+                            output,
+                            indices,
+                            offsets,
+                            weight,
+                            table_offsets,
+                            embedding_dims,
+                            embedding_offsets,
+                            feature_table_map,
+                            rows_cumsum,
+                            bounds_check_warning_ptr,
+                            row_output_offsets_ptr,
+                            B_offsets_ptr,
+                            total_embedding_dim,
+                            B,
+                            T,
+                            BLOCK_SIZE=block_size,
+                            vbe=vbe,
+                            FEATURE_START=feature_start,
+                            FEATURE_END=feature_end,
+                            BAGS_PER_PROGRAM=bags_per_program,
+                            UNROLL8=bags_per_program == 2,
+                            FUSED_BOUNDS_CHECK=fused_bounds_check,
+                            num_warps=num_warps,
+                        )
 
         # Record a CUDA event to mark forward kernel completion.
         # This is needed for synchronization before NCCL collectives.


### PR DESCRIPTION
Summary:
- Adds a benchmark-only Triton in-place add-one workload for studying autotune restore_value on a 12 GB FP16 tensor representative of large TBE embedding weights.
- Exercises always-cold and natural cold-to-cached execution, both with and without restore_value, while recording the logical invocation count and three sampled values in each profile.
- Enables allocator snapshots and disables measured benchmark iterations and runner warm-up for this workload so the trace begins with the first mutation.
- Makes runner warm-up configurable while leaving it enabled for every existing TorchRec Triton benchmark.

H100 results use 10 profiled iterations. Effective bandwidth counts all HBM reads and writes and is compared with the H100 2.4 TB/s peak.

[triton autotune.zip](https://github.com/user-attachments/files/31977323/triton.autotune.zip)

| Case | Cache behavior | Restore | Trace GPU time | Effective HBM bandwidth | Peak allocated / reserved | Sample values | Add-one kernels |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Always cold | Cache cleared every profile | Yes | [990.70 ms/profile](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D119203043/trace-autotune_restore_value_always_cold_restore_12gb-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.20 TB/s, 91.8% peak | [22.60 / 33.54 GiB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D119203043/memory-autotune_restore_value_always_cold_restore_12gb-rank0.pickle) | 1 through 10 | 310 total |
| Always cold | Cache cleared every profile | No | [550.64 ms/profile](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D119203043/trace-autotune_restore_value_always_cold_no_restore_12gb-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.18 TB/s, 90.8% peak | [11.43 / 11.43 GiB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D119203043/memory-autotune_restore_value_always_cold_no_restore_12gb-rank0.pickle) | 50 through 500 | 500 total |
| Cold then cached | First profile tunes; next nine use winner | Yes | [990.70 ms cold; 10.96 ms cached](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D119203043/trace-autotune_restore_value_cold_then_cached_restore_12gb-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.20 / 2.19 TB/s, 91.8% / 91.2% peak | [22.60 / 33.54 GiB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D119203043/memory-autotune_restore_value_cold_then_cached_restore_12gb-rank0.pickle) | 1 through 10 | 40 total |
| Cold then cached | First profile tunes; next nine use winner | No | [550.66 ms cold; 10.96 ms cached](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D119203043/trace-autotune_restore_value_cold_then_cached_no_restore_12gb-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.18 / 2.19 TB/s, 90.8% / 91.2% peak | [11.43 / 11.43 GiB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D119203043/memory-autotune_restore_value_cold_then_cached_no_restore_12gb-rank0.pickle) | 50 through 59 | 59 total |

Differential Revision: D119203043


