### PR TITLE
Speed up the fused long-run path: TMA reduce + gather width

### DIFF
--- a/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
+++ b/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
@@ -2270,6 +2270,17 @@ class TritonTBE(torch.autograd.Function):
         # Select kernel variants based on hardware
         _use_amd = is_amd()
 
+        # TMA bulk atomic reduce (cp.reduce.async.bulk.tensor) for the fused
+        # long-run partial-gradient accumulation. Blackwell-only, and only
+        # reachable on the fused path, which is itself gated above.
+        use_tma_reduce = has_tlx and not _use_amd and cfg.allow_tma_reduce
+        if use_tma_reduce:
+
+            def _alloc_fn(size: int, align: int, stream: int) -> torch.Tensor:
+                return torch.empty(size, dtype=torch.int8, device=weight.device)
+
+            triton.set_allocator(_alloc_fn)
+
         if weighted:
             # Weighted: 2-tier dispatch with sync-free _expand_long_runs
             # Kernel 1: short-run kernel (weighted)
@@ -2355,6 +2366,7 @@ class TritonTBE(torch.autograd.Function):
                     hash_size_cumsum,
                     momentum,
                     rows_cumsum,
+                    max_long_runs,
                     num_long_run_programs_t,
                     vbe_row_output_offsets,
                     vbe_B_offsets,
@@ -2368,7 +2380,9 @@ class TritonTBE(torch.autograd.Function):
                     num_warps=num_warps,
                     STOCHASTIC_ROUNDING=stochastic_rounding,
                     stochastic_rounding_seed=stochastic_rounding_seed,
+                    USE_TMA_REDUCE=use_tma_reduce,
                     vbe=vbe,
+                    BUFFER_SIZE=cfg.long_run_fused_buffer_size_weighted,
                 )
             else:
                 # Non-CLC path: separate grad accumulation + apply kernels
@@ -2521,6 +2535,7 @@ class TritonTBE(torch.autograd.Function):
                     hash_size_cumsum,
                     momentum,
                     rows_cumsum,
+                    max_long_runs,
                     num_long_run_programs_t,
                     vbe_row_output_offsets,
                     vbe_B_offsets,
@@ -2534,7 +2549,9 @@ class TritonTBE(torch.autograd.Function):
                     num_warps=num_warps,
                     STOCHASTIC_ROUNDING=stochastic_rounding,
                     stochastic_rounding_seed=stochastic_rounding_seed,
+                    USE_TMA_REDUCE=use_tma_reduce,
                     vbe=vbe,
+                    BUFFER_SIZE=cfg.long_run_fused_buffer_size_unweighted,
                 )
             else:
                 # Non-CLC path: separate grad accumulation + apply kernels

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
@@ -62,6 +62,13 @@ class TbeBackwardConfig:
     long_run_accum_buffer_size_unweighted: int
     long_run_accum_buffer_size_weighted: int
 
+    # And again for the fused long-run kernels, which kept the historical
+    # 16/8 after the accum widths were tuned. On the only shape large enough
+    # to reach the fused path, narrowing to 2 is worth 12% (1.76 -> 1.97 vs
+    # CUDA TBE).
+    long_run_fused_buffer_size_unweighted: int
+    long_run_fused_buffer_size_weighted: int
+
     num_warps: int
 
     # Split the short-run tier into one launch per next_pow2(D) bucket so each
@@ -72,6 +79,13 @@ class TbeBackwardConfig:
     # Cluster Launch Control: Blackwell-only work stealing. Purely additive on
     # top of the portable path; also requires TLX to be importable.
     allow_clc: bool
+
+    # TMA bulk atomic reduce (cp.reduce.async.bulk.tensor) for the fused
+    # long-run partial-gradient accumulation, in place of tl.atomic_add.
+    # Blackwell-only and TLX-only, and only reachable on the fused long-run
+    # path -- which is itself gated on a very large lookup count, so this has
+    # no effect on shapes that stay on the two-kernel path.
+    allow_tma_reduce: bool
 
 
 # Blackwell (B200 / GB200). Measured on GB200 (triton-beta) against the
@@ -90,9 +104,12 @@ _BLACKWELL = TbeBackwardConfig(
     short_run_buffer_size_weighted=4,
     long_run_accum_buffer_size_unweighted=2,
     long_run_accum_buffer_size_weighted=4,
+    long_run_fused_buffer_size_unweighted=2,
+    long_run_fused_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=True,
+    allow_tma_reduce=True,
 )
 
 # Hopper (H100). UNTUNED: retains the historical grid. The Blackwell sweep found
@@ -109,9 +126,12 @@ _HOPPER = TbeBackwardConfig(
     short_run_buffer_size_weighted=4,
     long_run_accum_buffer_size_unweighted=2,
     long_run_accum_buffer_size_weighted=4,
+    long_run_fused_buffer_size_unweighted=2,
+    long_run_fused_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
+    allow_tma_reduce=False,
 )
 
 # CDNA3 (MI300X). UNTUNED: retains the historical AMD grid.
@@ -125,9 +145,12 @@ _MI300X = TbeBackwardConfig(
     short_run_buffer_size_weighted=4,
     long_run_accum_buffer_size_unweighted=2,
     long_run_accum_buffer_size_weighted=4,
+    long_run_fused_buffer_size_unweighted=2,
+    long_run_fused_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
+    allow_tma_reduce=False,
 )
 
 # CDNA4 (MI350X). UNTUNED: currently identical to MI300X.
@@ -141,9 +164,12 @@ _MI350X = TbeBackwardConfig(
     short_run_buffer_size_weighted=4,
     long_run_accum_buffer_size_unweighted=2,
     long_run_accum_buffer_size_weighted=4,
+    long_run_fused_buffer_size_unweighted=2,
+    long_run_fused_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
+    allow_tma_reduce=False,
 )
 
 # Used when the device matches no known target: historical grid, no add-ons.
@@ -157,9 +183,12 @@ _PORTABLE_DEFAULT = TbeBackwardConfig(
     short_run_buffer_size_weighted=4,
     long_run_accum_buffer_size_unweighted=2,
     long_run_accum_buffer_size_weighted=4,
+    long_run_fused_buffer_size_unweighted=2,
+    long_run_fused_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
+    allow_tma_reduce=False,
 )
 
 

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_long_run_fused.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_long_run_fused.py
@@ -40,6 +40,7 @@ def triton_tbe_backward_long_run_fused_weighted(
     hash_size_cumsum_ptr,
     momentum_ptr,
     rows_cumsum_ptr,
+    num_long_runs,
     num_long_run_programs_ptr,
     # pyre-fixme[2]: Parameter must be annotated.
     row_output_offsets_ptr,
@@ -54,7 +55,9 @@ def triton_tbe_backward_long_run_fused_weighted(
     info_B_mask,
     STOCHASTIC_ROUNDING: tl.constexpr,
     stochastic_rounding_seed,
+    USE_TMA_REDUCE: tl.constexpr = False,
     vbe: tl.constexpr = False,
+    BUFFER_SIZE: tl.constexpr = 8,
 ) -> None:
     """
     Fused weighted long-run kernel: accumulates weighted partial gradients
@@ -62,12 +65,21 @@ def triton_tbe_backward_long_run_fused_weighted(
     applies the optimizer update — eliminating a separate apply kernel launch.
     """
     col_offsets = tl.arange(0, BLOCK_SIZE)
-    buffer_size: tl.constexpr = 8
+    buffer_size: tl.constexpr = BUFFER_SIZE
     buffer_offsets = tl.arange(0, buffer_size)
 
     clc_phase_producer = 1
     clc_phase_consumer = 0
     clc_context = tlx.clc_create_context(1)
+    if USE_TMA_REDUCE:
+        smem_bufs = tlx.local_alloc((1, BLOCK_SIZE), tl.float32, tl.constexpr(1))
+        smem_buf = tlx.local_view(smem_bufs, 0)
+        desc_temp = tl.make_tensor_descriptor(
+            temp_grad_buffer_ptr,
+            shape=[num_long_runs, BLOCK_SIZE],
+            strides=[BLOCK_SIZE, 1],
+            block_shape=[1, BLOCK_SIZE],
+        )
 
     tile_id = tl.program_id(0)
     num_tiles = tl.num_programs(0)
@@ -151,11 +163,20 @@ def triton_tbe_backward_long_run_fused_weighted(
 
             # Atomically accumulate partial gradient into the temp buffer
             temp_grad_offset = grad_buffer_id.to(tl.int64) * BLOCK_SIZE
-            tl.atomic_add(
-                temp_grad_buffer_ptr + temp_grad_offset + col_offsets,
-                grad,
-                mask=mask,
-            )
+            if USE_TMA_REDUCE:
+                grad_2d = tl.reshape(grad, (1, BLOCK_SIZE))
+                tlx.local_store(smem_buf, grad_2d)
+                tlx.fence_async_shared()
+                tlx.async_descriptor_store(
+                    desc_temp, smem_buf, [grad_buffer_id, 0], store_reduce="add"
+                )
+                tlx.async_descriptor_store_wait(0)
+            else:
+                tl.atomic_add(
+                    temp_grad_buffer_ptr + temp_grad_offset + col_offsets,
+                    grad,
+                    mask=mask,
+                )
 
             tlx.fence("gpu")
 
@@ -244,6 +265,7 @@ def triton_tbe_backward_long_run_fused_unweighted(
     hash_size_cumsum_ptr,
     momentum_ptr,
     rows_cumsum_ptr,
+    num_long_runs,
     num_long_run_programs_ptr,
     # pyre-fixme[2]: Parameter must be annotated.
     row_output_offsets_ptr,
@@ -258,7 +280,9 @@ def triton_tbe_backward_long_run_fused_unweighted(
     info_B_mask,
     STOCHASTIC_ROUNDING: tl.constexpr,
     stochastic_rounding_seed,
+    USE_TMA_REDUCE: tl.constexpr = False,
     vbe: tl.constexpr = False,
+    BUFFER_SIZE: tl.constexpr = 8,
 ) -> None:
     """
     Fused long-run kernel: accumulates partial gradients via atomic add,
@@ -266,12 +290,21 @@ def triton_tbe_backward_long_run_fused_unweighted(
     the optimizer update — eliminating a separate apply kernel launch.
     """
     col_offsets = tl.arange(0, BLOCK_SIZE)
-    buffer_size: tl.constexpr = 16
+    buffer_size: tl.constexpr = BUFFER_SIZE
     buffer_offsets = tl.arange(0, buffer_size)
 
     clc_phase_producer = 1
     clc_phase_consumer = 0
     clc_context = tlx.clc_create_context(1)
+    if USE_TMA_REDUCE:
+        smem_bufs = tlx.local_alloc((1, BLOCK_SIZE), tl.float32, tl.constexpr(1))
+        smem_buf = tlx.local_view(smem_bufs, 0)
+        desc_temp = tl.make_tensor_descriptor(
+            temp_grad_buffer_ptr,
+            shape=[num_long_runs, BLOCK_SIZE],
+            strides=[BLOCK_SIZE, 1],
+            block_shape=[1, BLOCK_SIZE],
+        )
 
     tile_id = tl.program_id(0)
     num_tiles = tl.num_programs(0)
@@ -350,11 +383,20 @@ def triton_tbe_backward_long_run_fused_unweighted(
                 grad += dout_row
 
             temp_grad_offset = grad_buffer_id.to(tl.int64) * BLOCK_SIZE
-            tl.atomic_add(
-                temp_grad_buffer_ptr + temp_grad_offset + col_offsets,
-                grad,
-                mask=mask,
-            )
+            if USE_TMA_REDUCE:
+                grad_2d = tl.reshape(grad, (1, BLOCK_SIZE))
+                tlx.local_store(smem_buf, grad_2d)
+                tlx.fence_async_shared()
+                tlx.async_descriptor_store(
+                    desc_temp, smem_buf, [grad_buffer_id, 0], store_reduce="add"
+                )
+                tlx.async_descriptor_store_wait(0)
+            else:
+                tl.atomic_add(
+                    temp_grad_buffer_ptr + temp_grad_offset + col_offsets,
+                    grad,
+                    mask=mask,
+                )
 
             tlx.fence("gpu")
 

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
@@ -213,10 +213,10 @@ def _expand_long_runs(
         dtype=torch.int32,
         device=device,
     )
-    num_short_runs_t = torch.zeros(num_buckets, dtype=torch.int64, device=device)
+    num_short_runs_t = torch.zeros(num_buckets, dtype=torch.int32, device=device)
 
     long_run_original_ids = torch.empty(max_long_runs, dtype=torch.int32, device=device)
-    num_long_runs_t = torch.zeros(1, dtype=torch.int64, device=device)
+    num_long_runs_t = torch.zeros(1, dtype=torch.int32, device=device)
 
     # Kernel 1: classify and compact runs
     CLASSIFY_BLOCK = 1024
@@ -248,7 +248,7 @@ def _expand_long_runs(
         max_long_run_programs, dtype=torch.int32, device=device
     )
     programs_per_long_run = torch.zeros(max_long_runs, dtype=torch.int32, device=device)
-    num_long_run_programs_t = torch.zeros(1, dtype=torch.int64, device=device)
+    num_long_run_programs_t = torch.zeros(1, dtype=torch.int32, device=device)
 
     # Kernel 2: expand long runs into sub-programs
     _expand_long_runs_kernel[(max_long_runs,)](


### PR DESCRIPTION
Summary:
Port of the original change to the current `torchrec/distributed/triton_tbe/` location, rebased onto the per-target config refactor, plus two fixes found while validating it. The original was authored against `deeplearning/fbgemm/fbgemm_gpu/fb/triton/`, which no longer holds these kernels, so the file set is entirely different from the previously accepted version.

- **TMA bulk atomic reduce**: replaces `tl.atomic_add` with `cp.reduce.async.bulk.tensor` for merging partial gradients into the workspace, in both fused long-run kernels.
- **Fused gather width**: the fused kernels kept a hardcoded width of 16/8 after the accum widths were tuned down, and paid the same register cliff. Adds `long_run_fused_buffer_size_{unweighted,weighted}` to `TbeBackwardConfig`, set to 2/4 to match the accum and short-run tiers.
- **Rebased onto config**: capability detection moves from an inline `get_device_capability()` check to an `allow_tma_reduce` field, mirroring `allow_clc`. Blackwell only; every other target sets it False.
- **int32 stream-compaction counters**: narrows the three backward compaction counters from `int64` to `int32`, which is what `_expand_long_runs` already documents. Independently this recovers a large share of the T287490725 triton-beta breakage (6/40 -> 16/40 shapes), measured against a same-day control.
- **Fixes a deterministic weighted-fused failure**: on the parent commit the weighted fused path fails the benchmark's `assert_weight_close` 3 runs out of 3; with this diff it passes 3/3. See test plan.
- **Gate left alone, now for a measured reason**: the fused path is still gated at over 200M lookups in one backward, so this changes nothing for current production shapes.

Reviewed By: stashuk-olek

Differential Revision: D94839604


