### PR TITLE
[ops] Add batch index select benchmark (#4688)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_ops.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_ops.py
@@ -51,6 +51,7 @@ from torchrec.distributed.triton_tbe.triton_table_batched_embeddings import (
     _repair_offsets_kernel,
 )
 from torchrec.sparse.jagged_tensor import _kt_regroup_arguments, JaggedTensor
+from torchrec.sparse.triton_batch_index_select import triton_batch_index_select_dim0
 from torchrec.sparse.triton_permute_2d import (
     MIN_SEGMENTS,
     PERSEG_MIN_MEAN,
@@ -69,6 +70,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops")
 except OSError:
     pass
 
@@ -185,7 +187,7 @@ def register_benchmark(
     given config class. The decorated function is the per-iteration benchmark and
     its name is the CLI subcommand. Define the config class first, then:
 
-    @register_benchmark(BoundsCheckTritonConfig)
+    @register_benchmark(BoundsCheckConfig)
     def bounds_check_triton(_batch_inputs, offsets, ..., **_kwargs): ...
     """
 
@@ -194,7 +196,7 @@ def register_benchmark(
             single_rank_runner(arg=arg, bench_func=func)
 
         # CLI subcommand key = benchmark function name; the annotation must be the
-        # concrete config subclass so cmd_conf builds its argparse from its fields
+        # concrete config class so cmd_conf builds its argparse from its fields
         dispatch.__name__ = func.__name__
         dispatch.__annotations__ = {"arg": config, "return": None}
         # pyrefly: ignore[missing-attribute]
@@ -762,24 +764,7 @@ def bounds_check_triton(
             )
 
 
-@dataclass
-class BoundsCheckCudaConfig(BoundsCheckConfig):
-    """
-    run commands:
-    1. baseline against bounds_check_triton on identical input
-    > python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_cuda \
-        --name=clean
-
-    use case:
-        the fbgemm CUDA op the Triton kernels replace, run on the same seed and shape.
-        Note it does strictly more work than the Triton offsets kernel: it validates row
-        ids as well as the offsets array, which the Triton path folds into the gather
-        loop instead (_load_checked_index). Read the pair as backend A/B on the offsets
-        sweep, not as an equal-work comparison.
-    """
-
-
-@register_benchmark(BoundsCheckCudaConfig)
+@register_benchmark(BoundsCheckConfig)
 def bounds_check_cuda(
     _batch_inputs: List[Dict[str, Any]],
     indices: torch.Tensor,
@@ -788,6 +773,11 @@ def bounds_check_cuda(
     warning: torch.Tensor,
     **_kwargs: Dict[str, Any],
 ) -> None:
+    """Benchmark FBGEMM's CUDA baseline on the same seed and shape.
+
+    It validates row IDs and offsets, while the Triton benchmark only times its offsets
+    kernel because row validation is fused into the gather loop.
+    """
     with record_function("## zero warning counter ##"):
         warning.zero_()
 
@@ -878,28 +868,7 @@ class Permute2dConfig(TritonOpConfig):
         }
 
 
-@dataclass
-class Permute2dTritonConfig(Permute2dConfig):
-    """
-    run commands:
-    1. blocked kernel (default): many short segments
-    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton \
-        --name=blocked
-
-    2. per-segment kernel: fewer, longer segments
-    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton \
-        --name=perseg \
-        --mean_pooling_factor=1024
-
-    use case:
-        the Triton replacement for fbgemm.permute_2D_sparse_data, which wins on the two
-        regimes fbgemm's per-segment launch shape handles badly: very many short
-        segments, and length skew across keys. Pair with permute_2d_fbgemm on the same
-        seed and shape.
-    """
-
-
-@register_benchmark(Permute2dTritonConfig)
+@register_benchmark(Permute2dConfig)
 def permute_2d_triton(
     _batch_inputs: List[Dict[str, Any]],
     permute: torch.Tensor,
@@ -909,33 +878,14 @@ def permute_2d_triton(
     permuted_lengths_sum: int,
     **_kwargs: Dict[str, Any],
 ) -> None:
+    """Benchmark TorchRec's Triton replacement for permute_2D_sparse_data."""
     with record_function("## triton_permute_2d_sparse_data ##"):
         triton_permute_2d_sparse_data(
             permute, lengths, values, weights, permuted_lengths_sum
         )
 
 
-@dataclass
-class Permute2dFbgemmConfig(Permute2dConfig):
-    """
-    run commands:
-    1. baseline against permute_2d_triton on identical input
-    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm \
-        --name=blocked
-
-    2. baseline against permute_2d_triton on identical input with pf=1024
-    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm \
-        --name=blocked_1024 \
-        --mean_pooling_factor=1024
-
-    use case:
-        the fbgemm CUDA baseline. It hands each block 32 consecutive segments and picks
-        vectorised or scalar loads per segment, which is efficient for few long aligned
-        segments and degrades as segment count and key-level length skew grow.
-    """
-
-
-@register_benchmark(Permute2dFbgemmConfig)
+@register_benchmark(Permute2dConfig)
 def permute_2d_fbgemm(
     _batch_inputs: List[Dict[str, Any]],
     permute: torch.Tensor,
@@ -945,10 +895,179 @@ def permute_2d_fbgemm(
     permuted_lengths_sum: int,
     **_kwargs: Dict[str, Any],
 ) -> None:
+    """Benchmark FBGEMM's CUDA permute_2D_sparse_data baseline."""
     with record_function("## permute_2D_sparse_data ##"):
         torch.ops.fbgemm.permute_2D_sparse_data(
             permute, lengths, values, weights, permuted_lengths_sum
         )
+
+
+######################## batch index select dim 0 configs ############################
+@dataclass
+class BatchIndexSelectDim0Config(TritonOpConfig):
+    """Inputs matching VariableBatchEmbeddingBagCollectionAwaitable.
+
+    Embedding dimensions cycle through embedding_dims. Setting different minimum
+    and maximum input row counts exercises variable batch sizes before all-to-all;
+    output_batch_size is the common reconstructed batch size.
+    """
+
+    num_features: int = 165
+    min_input_rows: int = 1024
+    max_input_rows: int = 4096
+    output_batch_size: int = 4096
+    embedding_dims: str = "16,16,16,16,48,80,112,128,160"
+    run_backward: bool = False
+    dtype: str = "float16"
+    gpu_backlog_ms: float = 20.0
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        dtype = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }.get(self.dtype)
+        if dtype is None:
+            raise ValueError("dtype must be float32, float16, or bfloat16")
+        if self.min_input_rows <= 0 or self.max_input_rows < self.min_input_rows:
+            raise ValueError("input row bounds must be positive and ordered")
+        if self.max_input_rows > self.output_batch_size:
+            raise ValueError(
+                "input row counts cannot exceed the reconstructed output batch size"
+            )
+        dimensions = [int(value) for value in self.embedding_dims.split(",")]
+        if not dimensions or any(dimension <= 0 for dimension in dimensions):
+            raise ValueError("embedding_dims must contain positive integers")
+        input_columns = [
+            dimensions[index % len(dimensions)] for index in range(self.num_features)
+        ]
+        input_rows = torch.randint(
+            self.min_input_rows,
+            self.max_input_rows + 1,
+            (self.num_features,),
+        ).tolist()
+        inputs = torch.randn(
+            sum(rows * columns for rows, columns in zip(input_rows, input_columns)),
+            device=device,
+            dtype=dtype,
+            requires_grad=self.run_backward,
+        )
+        indices = torch.cat(
+            [
+                torch.cat(
+                    [
+                        torch.arange(rows, device=device, dtype=torch.int64),
+                        torch.randint(
+                            0,
+                            rows,
+                            (self.output_batch_size - rows,),
+                            device=device,
+                            dtype=torch.int64,
+                        ),
+                    ]
+                )[torch.randperm(self.output_batch_size, device=device)]
+                for rows in input_rows
+            ]
+        )
+        grad_output = (
+            torch.randn(
+                self.output_batch_size * sum(input_columns),
+                device=device,
+                dtype=dtype,
+            )
+            if self.run_backward
+            else None
+        )
+        return {
+            "inputs": inputs,
+            "indices": indices,
+            "input_rows": input_rows,
+            "input_columns": input_columns,
+            "grad_output": grad_output,
+        }
+
+
+def _run_batch_index_select_backward(
+    output: torch.Tensor,
+    inputs: torch.Tensor,
+    grad_output: Optional[torch.Tensor],
+    run_backward: bool,
+) -> None:
+    if run_backward:
+        assert grad_output is not None
+        torch.autograd.grad(output, inputs, grad_output)
+
+
+@register_benchmark(BatchIndexSelectDim0Config)
+def batch_index_select_dim0_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    input_rows: List[int],
+    input_columns: List[int],
+    grad_output: Optional[torch.Tensor],
+    output_batch_size: int,
+    run_backward: bool,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_batch_index_select_dim0 ##"):
+        output = triton_batch_index_select_dim0(
+            inputs, indices, output_batch_size, input_rows, input_columns
+        )
+        _run_batch_index_select_backward(output, inputs, grad_output, run_backward)
+
+
+@register_benchmark(BatchIndexSelectDim0Config)
+def batch_index_select_dim0_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    input_rows: List[int],
+    input_columns: List[int],
+    grad_output: Optional[torch.Tensor],
+    output_batch_size: int,
+    run_backward: bool,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## fbgemm_batch_index_select_dim0 ##"):
+        output = torch.ops.fbgemm.batch_index_select_dim0(
+            inputs=inputs,
+            indices=indices,
+            input_num_indices=[output_batch_size] * len(input_columns),
+            input_rows=input_rows,
+            input_columns=input_columns,
+            permute_output_dim_0_1=True,
+        )
+        _run_batch_index_select_backward(output, inputs, grad_output, run_backward)
+
+
+@register_benchmark(BatchIndexSelectDim0Config)
+def batch_index_select_dim0_torch(
+    _batch_inputs: List[Dict[str, Any]],
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    input_rows: List[int],
+    input_columns: List[int],
+    grad_output: Optional[torch.Tensor],
+    output_batch_size: int,
+    run_backward: bool,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## torch_batch_index_select_dim0 ##"):
+        input_splits = inputs.split(
+            [rows * columns for rows, columns in zip(input_rows, input_columns)]
+        )
+        index_splits = indices.split(output_batch_size)
+        output = torch.cat(
+            [
+                input_part.view(rows, columns).index_select(0, index_part)
+                for input_part, index_part, rows, columns in zip(
+                    input_splits, index_splits, input_rows, input_columns
+                )
+            ],
+            dim=1,
+        ).flatten()
+        _run_batch_index_select_backward(output, inputs, grad_output, run_backward)
 
 
 ############################ pooled regroup configs ###################################
@@ -1014,10 +1133,14 @@ class RegroupConfig(TritonOpConfig):
         permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
             values[0], keys, lengths, groups
         )
-        grad_outputs = [
-            torch.randn(self.batch_size, length, device=device, dtype=dtype)
-            for length in out_lengths
-        ]
+        grad_outputs = (
+            [
+                torch.randn(self.batch_size, length, device=device, dtype=dtype)
+                for length in out_lengths
+            ]
+            if self.run_backward
+            else None
+        )
         return {
             "values": values,
             "permutes": permutes,
@@ -1031,19 +1154,15 @@ class RegroupConfig(TritonOpConfig):
 def _run_backward(
     outputs: List[torch.Tensor],
     values: List[torch.Tensor],
-    grad_outputs: List[torch.Tensor],
+    grad_outputs: Optional[List[torch.Tensor]],
     run_backward: bool,
 ) -> None:
     if run_backward:
+        assert grad_outputs is not None
         torch.autograd.grad(outputs, values, grad_outputs)
 
 
-@dataclass
-class RegroupTritonConfig(RegroupConfig):
-    """Benchmark the Triton multi-tensor pooled-embedding regroup."""
-
-
-@register_benchmark(RegroupTritonConfig)
+@register_benchmark(RegroupConfig)
 def regroup_triton(
     _batch_inputs: List[Dict[str, Any]],
     values: List[torch.Tensor],
@@ -1051,7 +1170,7 @@ def regroup_triton(
     in_shapes: torch.Tensor,
     out_shapes: torch.Tensor,
     out_lengths: List[int],
-    grad_outputs: List[torch.Tensor],
+    grad_outputs: Optional[List[torch.Tensor]],
     run_backward: bool = False,
     **_kwargs: Dict[str, Any],
 ) -> None:
@@ -1062,12 +1181,7 @@ def regroup_triton(
         _run_backward(outputs, values, grad_outputs, run_backward)
 
 
-@dataclass
-class RegroupFbgemmConfig(RegroupConfig):
-    """Benchmark the FBGEMM multi-tensor pooled-embedding regroup."""
-
-
-@register_benchmark(RegroupFbgemmConfig)
+@register_benchmark(RegroupConfig)
 def regroup_fbgemm(
     _batch_inputs: List[Dict[str, Any]],
     values: List[torch.Tensor],
@@ -1075,7 +1189,7 @@ def regroup_fbgemm(
     in_shapes: torch.Tensor,
     out_shapes: torch.Tensor,
     out_lengths: List[int],
-    grad_outputs: List[torch.Tensor],
+    grad_outputs: Optional[List[torch.Tensor]],
     run_backward: bool = False,
     **_kwargs: Dict[str, Any],
 ) -> None:

--- a/torchrec/sparse/tests/test_triton_batch_index_select.py
+++ b/torchrec/sparse/tests/test_triton_batch_index_select.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+import unittest
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import torch
+
+_TESTS_SUPPORTED = torch.cuda.is_available() and sys.version_info < (3, 15)
+
+if TYPE_CHECKING or _TESTS_SUPPORTED:
+    import torchrec.sparse.triton_batch_index_select as triton_batch_index_select_module
+    from torchrec.sparse.triton_batch_index_select import triton_batch_index_select_dim0
+
+
+def _reference(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: int,
+    input_rows: list[int],
+    input_columns: list[int],
+) -> torch.Tensor:
+    input_splits = inputs.split(
+        [rows * columns for rows, columns in zip(input_rows, input_columns)]
+    )
+    index_splits = indices.split(batch_size)
+    outputs = [
+        input_part.view(rows, columns).index_select(0, index_part)
+        for input_part, index_part, rows, columns in zip(
+            input_splits, index_splits, input_rows, input_columns
+        )
+    ]
+    return torch.cat(outputs, dim=1).flatten()
+
+
+@unittest.skipUnless(_TESTS_SUPPORTED, "CUDA and Python below 3.15 are required")
+class TritonBatchIndexSelectTest(unittest.TestCase):
+    def _inputs(
+        self, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor, int, list[int], list[int]]:
+        batch_size = 13
+        input_rows = [17, 23, 31, 37, 41]
+        input_columns = [12, 16, 48, 112, 160]
+        inputs = torch.cat(
+            [
+                torch.randn(rows, columns, device="cuda", dtype=dtype).flatten()
+                for rows, columns in zip(input_rows, input_columns)
+            ]
+        ).requires_grad_(True)
+        index_parts = []
+        for rows in input_rows:
+            index_part = torch.randint(0, rows, (batch_size,), device="cuda")
+            index_part[1] = index_part[0]
+            index_parts.append(index_part)
+        indices = torch.cat(index_parts)
+        return inputs, indices, batch_size, input_rows, input_columns
+
+    def test_forward_and_backward(self) -> None:
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                inputs, indices, batch_size, input_rows, input_columns = self._inputs(
+                    dtype
+                )
+                reference_inputs = inputs.detach().clone().requires_grad_()
+                output = triton_batch_index_select_dim0(
+                    inputs, indices, batch_size, input_rows, input_columns
+                )
+                expected = _reference(
+                    reference_inputs,
+                    indices,
+                    batch_size,
+                    input_rows,
+                    input_columns,
+                )
+                torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+                grad_output = torch.randn_like(output)
+                actual_grad = torch.autograd.grad(output, inputs, grad_output)[0]
+                expected_grad = torch.autograd.grad(
+                    expected, reference_inputs, grad_output
+                )[0]
+                # Duplicate indices make the atomic accumulation order nondeterministic.
+                tolerance = 16 * torch.finfo(dtype).eps
+                torch.testing.assert_close(
+                    actual_grad, expected_grad, rtol=0, atol=tolerance
+                )
+
+    def test_compile_forward_and_backward(self) -> None:
+        inputs, indices, batch_size, input_rows, input_columns = self._inputs(
+            torch.float32
+        )
+        reference_inputs = inputs.detach().clone().requires_grad_()
+        compiled = torch.compile(
+            triton_batch_index_select_dim0,
+            backend="aot_eager",
+            fullgraph=True,
+        )
+        output = compiled(inputs, indices, batch_size, input_rows, input_columns)
+        expected = _reference(
+            reference_inputs, indices, batch_size, input_rows, input_columns
+        )
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+        grad_output = torch.randn_like(output)
+        actual_grad = torch.autograd.grad(output, inputs, grad_output)[0]
+        expected_grad = torch.autograd.grad(expected, reference_inputs, grad_output)[0]
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=1e-5)
+
+    def test_large_batch_launch_grid(self) -> None:
+        batch_size = 65536
+        input_rows = [2]
+        input_columns = [160]
+        inputs = torch.randn(320, device="cuda")
+        indices = torch.randint(0, 2, (batch_size,), device="cuda")
+
+        output = triton_batch_index_select_dim0(
+            inputs, indices, batch_size, input_rows, input_columns
+        )
+        expected = _reference(inputs, indices, batch_size, input_rows, input_columns)
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+    def test_sorted_reduction_backward(self) -> None:
+        batch_size = 64
+        input_rows = [17, 23]
+        input_columns = [512, 512]
+        inputs = torch.randn(
+            sum(rows * columns for rows, columns in zip(input_rows, input_columns)),
+            device="cuda",
+            dtype=torch.float16,
+            requires_grad=True,
+        )
+        indices = torch.cat(
+            [
+                torch.zeros(batch_size, device="cuda", dtype=torch.int64),
+                torch.arange(batch_size, device="cuda") % input_rows[1],
+            ]
+        )
+        reference_inputs = inputs.detach().clone().requires_grad_()
+
+        with mock.patch.object(
+            triton_batch_index_select_module,
+            "_SORTED_REDUCTION_MIN_OUTPUT_ELEMENTS",
+            0,
+        ):
+            output = triton_batch_index_select_dim0(
+                inputs, indices, batch_size, input_rows, input_columns
+            )
+            grad_output = torch.randn_like(output)
+            actual_grad = torch.autograd.grad(output, inputs, grad_output)[0]
+
+        expected = _reference(
+            reference_inputs,
+            indices,
+            batch_size,
+            input_rows,
+            input_columns,
+        )
+        expected_grad = torch.autograd.grad(expected, reference_inputs, grad_output)[0]
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            actual_grad,
+            expected_grad,
+            rtol=0,
+            atol=batch_size * torch.finfo(inputs.dtype).eps,
+        )
+
+    def test_specialized_backward_paths(self) -> None:
+        cases = (
+            ("high_duplication", 1024, [64] * 32, [128] * 32, False),
+            ("mostly_unique", 4096, [3072] * 4, [256] * 4, True),
+        )
+        for name, batch_size, input_rows, input_columns, cover_all_rows in cases:
+            with self.subTest(name=name):
+                inputs = torch.randn(
+                    sum(
+                        rows * columns
+                        for rows, columns in zip(input_rows, input_columns)
+                    ),
+                    device="cuda",
+                    dtype=torch.float16,
+                    requires_grad=True,
+                )
+                index_parts = []
+                for rows in input_rows:
+                    if cover_all_rows:
+                        index_part = torch.cat(
+                            [
+                                torch.arange(rows, device="cuda"),
+                                torch.randint(
+                                    0,
+                                    rows,
+                                    (batch_size - rows,),
+                                    device="cuda",
+                                ),
+                            ]
+                        )[torch.randperm(batch_size, device="cuda")]
+                    else:
+                        index_part = torch.randint(
+                            0, rows, (batch_size,), device="cuda"
+                        )
+                    index_parts.append(index_part)
+                indices = torch.cat(index_parts)
+                reference_inputs = inputs.detach().clone().requires_grad_()
+
+                output = triton_batch_index_select_dim0(
+                    inputs, indices, batch_size, input_rows, input_columns
+                )
+                expected = _reference(
+                    reference_inputs,
+                    indices,
+                    batch_size,
+                    input_rows,
+                    input_columns,
+                )
+                torch.testing.assert_close(output, expected, rtol=0, atol=0)
+                grad_output = torch.randn_like(output)
+                actual_grad = torch.autograd.grad(output, inputs, grad_output)[0]
+                expected_grad = torch.autograd.grad(
+                    expected, reference_inputs, grad_output
+                )[0]
+                torch.testing.assert_close(
+                    actual_grad,
+                    expected_grad,
+                    rtol=0,
+                    atol=max(16, 2 * batch_size // min(input_rows))
+                    * torch.finfo(inputs.dtype).eps,
+                )

--- a/torchrec/sparse/triton_batch_index_select.py
+++ b/torchrec/sparse/triton_batch_index_select.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import functools
+import itertools
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+
+_BUCKETING_MIN_OUTPUT_ELEMENTS = 4 * 1024 * 1024
+_COUNTED_SCATTER_MIN_ROW_FRACTION = 0.5
+_SORTED_REDUCTION_MIN_OUTPUT_ELEMENTS = 512 * 1024 * 1024
+
+
+@triton.jit
+# Triton TR001: the linearization pass uses one fixed streaming tile.
+def _linearize_indices_kernel(  # noqa: TR001
+    indices,
+    row_offsets,
+    linear_indices,
+    num_indices,
+    batch_size,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_indices
+    features = offsets // batch_size
+    rows = tl.load(indices + offsets, mask=mask, other=0)
+    feature_row_start = tl.load(row_offsets + features, mask=mask, other=0)
+    tl.store(linear_indices + offsets, feature_row_start + rows, mask=mask)
+
+
+@triton.jit
+# Triton TR001: the run-detection pass uses one fixed streaming tile.
+def _mark_sorted_runs_kernel(  # noqa: TR001
+    sorted_rows,
+    run_flags,
+    num_indices,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_indices
+    rows = tl.load(sorted_rows + offsets, mask=mask, other=0)
+    previous_rows = tl.load(
+        sorted_rows + offsets - 1,
+        mask=mask & (offsets > 0),
+        other=-1,
+    )
+    tl.store(run_flags + offsets, (offsets == 0) | (rows != previous_rows), mask=mask)
+
+
+@triton.jit
+# Triton TR001: the run-compaction pass uses one fixed streaming tile.
+def _compact_sorted_runs_kernel(  # noqa: TR001
+    sorted_rows,
+    run_flags,
+    run_ids,
+    unique_rows,
+    run_offsets,
+    num_indices,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_indices
+    flags = tl.load(run_flags + offsets, mask=mask, other=0)
+    ids = tl.load(run_ids + offsets, mask=mask, other=0)
+    rows = tl.load(sorted_rows + offsets, mask=mask, other=0)
+    starts = mask & (flags != 0)
+    tl.store(unique_rows + ids - 1, rows, mask=starts)
+    tl.store(run_offsets + ids - 1, offsets, mask=starts)
+
+
+@triton.jit
+def _finish_sorted_runs_kernel(
+    run_ids,
+    run_offsets,
+    num_runs,
+    num_indices,
+) -> None:
+    runs = tl.load(run_ids + num_indices - 1)
+    tl.store(num_runs, runs)
+    tl.store(run_offsets + runs, num_indices)
+
+
+@triton.jit
+# Triton TR001: the heavy uniform-row reduction uses one fixed row/vector tile.
+def _sorted_index_backward_kernel(  # noqa: TR001
+    grad_output,
+    sorted_positions,
+    unique_rows,
+    run_offsets,
+    num_runs,
+    grad_inputs,
+    batch_size,
+    total_columns,
+    COLUMNS: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+) -> None:
+    rows = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)[:, None]
+    columns = tl.arange(0, COLUMNS)[None, :]
+    runs = tl.load(num_runs)
+    row_mask = rows < runs
+    input_rows = tl.load(unique_rows + rows, mask=row_mask, other=0)
+    starts = tl.load(run_offsets + rows, mask=row_mask, other=0)
+    ends = tl.load(run_offsets + rows + 1, mask=row_mask, other=0)
+    positions_in_run = tl.zeros((BLOCK_ROWS, 1), dtype=tl.int64)
+    accumulator = tl.zeros((BLOCK_ROWS, COLUMNS), dtype=tl.float32)
+    active = row_mask & (starts + positions_in_run < ends)
+    while tl.max(active).to(tl.int1):
+        positions = tl.load(
+            sorted_positions + starts + positions_in_run,
+            mask=active,
+            other=0,
+        )
+        features = positions // batch_size
+        batches = positions % batch_size
+        output_offsets = batches * total_columns + features * COLUMNS + columns
+        accumulator += tl.load(
+            grad_output + output_offsets,
+            mask=active & (columns < COLUMNS),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        positions_in_run += 1
+        active = row_mask & (starts + positions_in_run < ends)
+    tl.store(
+        grad_inputs + input_rows * COLUMNS + columns,
+        accumulator,
+        mask=row_mask & (columns < COLUMNS),
+    )
+
+
+@triton.jit
+# Triton TR001: keep the auxiliary count pass on one fixed, bandwidth-sized tile.
+def _count_index_occurrences_kernel(  # noqa: TR001
+    indices,
+    row_offsets,
+    counts,
+    num_indices,
+    batch_size,
+    RELAXED_ATOMICS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    # Triton int64 pointer-cast guard: widen the scalar before large products.
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_indices
+    features = offsets // batch_size
+    selected_rows = tl.load(indices + offsets, mask=mask, other=0).to(tl.int64)
+    row_starts = tl.load(row_offsets + features, mask=mask, other=0)
+    if RELAXED_ATOMICS:
+        tl.atomic_add(
+            counts + row_starts + selected_rows,
+            1,
+            mask=mask,
+            sem="relaxed",
+        )
+    else:
+        tl.atomic_add(counts + row_starts + selected_rows, 1, mask=mask)
+
+
+@triton.jit
+# Triton TR001: cached shape buckets select launch parameters without autotuning.
+def _batch_index_select_dim0_kernel(  # noqa: TR001
+    inputs,
+    indices,
+    input_offsets,
+    column_offsets,
+    feature_ids,
+    output,
+    batch_size,
+    total_columns,
+    NUM_FEATURES: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_COLUMNS: tl.constexpr,
+) -> None:
+    batch_feature = tl.program_id(0)
+    feature = tl.load(
+        feature_ids + batch_feature % NUM_FEATURES, eviction_policy="evict_last"
+    )
+    batch_tile = batch_feature // NUM_FEATURES
+    batch_offsets = tl.arange(0, BLOCK_BATCH)[:, None]
+    batches = batch_tile * BLOCK_BATCH + batch_offsets
+    # Triton int64 pointer-cast guard: widen the scalar before the output stride.
+    output_batches = batch_tile.to(tl.int64) * BLOCK_BATCH + batch_offsets
+    columns = tl.program_id(1) * BLOCK_COLUMNS + tl.arange(0, BLOCK_COLUMNS)[None, :]
+
+    column_start = tl.load(column_offsets + feature, eviction_policy="evict_last")
+    columns_count = (
+        tl.load(column_offsets + feature + 1, eviction_policy="evict_last")
+        - column_start
+    )
+    input_start = tl.load(input_offsets + feature, eviction_policy="evict_last")
+
+    batch_mask = batches < batch_size
+    column_mask = columns < columns_count
+    mask = batch_mask & column_mask
+    selected_rows = tl.load(
+        indices + feature * batch_size + batches,
+        mask=batch_mask,
+        other=0,
+        eviction_policy="evict_last",
+    ).to(tl.int64)
+
+    input_indices = input_start + selected_rows * columns_count + columns
+    output_indices = output_batches * total_columns + column_start + columns
+    values = tl.load(
+        inputs + input_indices,
+        mask=mask,
+        eviction_policy="evict_first",
+    )
+    tl.store(output + output_indices, values, mask=mask)
+
+
+@triton.jit
+# Triton TR001: backward reuses the forward bucket's measured launch parameters.
+def _batch_index_select_dim0_backward_kernel(  # noqa: TR001
+    grad_output,
+    indices,
+    input_offsets,
+    row_offsets,
+    column_offsets,
+    feature_ids,
+    counts,
+    grad_inputs,
+    batch_size,
+    total_columns,
+    NUM_FEATURES: tl.constexpr,
+    USE_COUNTS: tl.constexpr,
+    RELAXED_ATOMICS: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_COLUMNS: tl.constexpr,
+) -> None:
+    batch_feature = tl.program_id(0)
+    feature = tl.load(
+        feature_ids + batch_feature % NUM_FEATURES, eviction_policy="evict_last"
+    )
+    batch_tile = batch_feature // NUM_FEATURES
+    batch_offsets = tl.arange(0, BLOCK_BATCH)[:, None]
+    batches = batch_tile * BLOCK_BATCH + batch_offsets
+    # Triton int64 pointer-cast guard: widen the scalar before the output stride.
+    output_batches = batch_tile.to(tl.int64) * BLOCK_BATCH + batch_offsets
+    columns = tl.program_id(1) * BLOCK_COLUMNS + tl.arange(0, BLOCK_COLUMNS)[None, :]
+
+    column_start = tl.load(column_offsets + feature, eviction_policy="evict_last")
+    columns_count = (
+        tl.load(column_offsets + feature + 1, eviction_policy="evict_last")
+        - column_start
+    )
+    input_start = tl.load(input_offsets + feature, eviction_policy="evict_last")
+
+    batch_mask = batches < batch_size
+    column_mask = columns < columns_count
+    mask = batch_mask & column_mask
+    selected_rows = tl.load(
+        indices + feature * batch_size + batches,
+        mask=batch_mask,
+        other=0,
+        eviction_policy="evict_last",
+    ).to(tl.int64)
+
+    output_indices = output_batches * total_columns + column_start + columns
+    gradients = tl.load(
+        grad_output + output_indices,
+        mask=mask,
+        eviction_policy="evict_first",
+    )
+    input_indices = input_start + selected_rows * columns_count + columns
+    atomic_mask = mask
+    if USE_COUNTS:
+        row_start = tl.load(row_offsets + feature, eviction_policy="evict_last")
+        occurrences = tl.load(
+            counts + row_start + selected_rows,
+            mask=batch_mask,
+            other=0,
+            eviction_policy="evict_last",
+        )
+        unique_mask = mask & (occurrences == 1)
+        tl.store(grad_inputs + input_indices, gradients, mask=unique_mask)
+        atomic_mask = mask & (occurrences > 1)
+    if RELAXED_ATOMICS:
+        tl.atomic_add(
+            grad_inputs + input_indices,
+            gradients,
+            mask=atomic_mask,
+            sem="relaxed",
+        )
+    else:
+        tl.atomic_add(grad_inputs + input_indices, gradients, mask=atomic_mask)
+
+
+@dataclass(frozen=True)
+class _LaunchBucket:
+    feature_ids: torch.Tensor
+    max_columns: int
+
+
+@dataclass(frozen=True)
+class _Metadata:
+    input_offsets: torch.Tensor
+    row_offsets: torch.Tensor
+    column_offsets: torch.Tensor
+    buckets: tuple[_LaunchBucket, ...]
+    combined_bucket: _LaunchBucket
+    total_columns: int
+    total_rows: int
+    supports_relaxed_atomics: bool
+    num_sms: int
+
+
+def _prefix_sum(values: Sequence[int]) -> tuple[int, ...]:
+    return tuple(itertools.accumulate(values, initial=0))
+
+
+def _launch_parameters(max_columns: int) -> tuple[int, int, int]:
+    if max_columns <= 64:
+        block_columns = 1 << (max_columns - 1).bit_length()
+        return 256 // block_columns, block_columns, 2
+    if max_columns <= 128:
+        return 4, 128, 4
+    block_columns = min(512, 1 << (max_columns - 1).bit_length())
+    return 1, block_columns, 2 if block_columns == 256 else 4
+
+
+@functools.lru_cache(maxsize=32)
+def _cached_metadata(
+    input_rows: tuple[int, ...],
+    input_columns: tuple[int, ...],
+    device: torch.device,
+) -> _Metadata:
+    input_offsets = _prefix_sum(
+        tuple(rows * columns for rows, columns in zip(input_rows, input_columns))
+    )
+    row_offsets = _prefix_sum(input_rows)
+    column_offsets = _prefix_sum(input_columns)
+
+    feature_buckets: dict[int, list[int]] = {}
+    for feature, columns in enumerate(input_columns):
+        limit = 1 << (columns - 1).bit_length()
+        feature_buckets.setdefault(limit, []).append(feature)
+
+    buckets = []
+    for feature_list in feature_buckets.values():
+        buckets.append(
+            _LaunchBucket(
+                feature_ids=torch.tensor(
+                    feature_list, dtype=torch.int32, device=device
+                ),
+                max_columns=max(input_columns[i] for i in feature_list),
+            )
+        )
+
+    tensor_kwargs = {"dtype": torch.int64, "device": device}
+    device_properties = torch.cuda.get_device_properties(device)
+    return _Metadata(
+        input_offsets=torch.tensor(input_offsets, **tensor_kwargs),
+        row_offsets=torch.tensor(row_offsets, **tensor_kwargs),
+        column_offsets=torch.tensor(column_offsets, **tensor_kwargs),
+        buckets=tuple(buckets),
+        combined_bucket=_LaunchBucket(
+            feature_ids=torch.arange(
+                len(input_columns), dtype=torch.int32, device=device
+            ),
+            max_columns=max(input_columns),
+        ),
+        total_columns=column_offsets[-1],
+        total_rows=row_offsets[-1],
+        supports_relaxed_atomics=device_properties.major >= 8,
+        num_sms=device_properties.multi_processor_count,
+    )
+
+
+def _launch_buckets(metadata: _Metadata, batch_size: int) -> tuple[_LaunchBucket, ...]:
+    if (
+        len(metadata.buckets) > 1
+        and batch_size * metadata.total_columns >= _BUCKETING_MIN_OUTPUT_ELEMENTS
+    ):
+        return metadata.buckets
+    return (metadata.combined_bucket,)
+
+
+def _use_counted_scatter(metadata: _Metadata, batch_size: int) -> bool:
+    num_features = metadata.combined_bucket.feature_ids.numel()
+    return (
+        batch_size * metadata.total_columns >= _BUCKETING_MIN_OUTPUT_ELEMENTS
+        and metadata.total_rows
+        >= _COUNTED_SCATTER_MIN_ROW_FRACTION * batch_size * num_features
+    )
+
+
+def _use_fp32_accumulator(
+    metadata: _Metadata, batch_size: int, dtype: torch.dtype
+) -> bool:
+    num_features = metadata.combined_bucket.feature_ids.numel()
+    return (
+        dtype != torch.float32
+        and batch_size * metadata.total_columns >= _BUCKETING_MIN_OUTPUT_ELEMENTS
+        and 4 * metadata.total_rows <= batch_size * num_features
+    )
+
+
+def _use_sorted_reduction(
+    metadata: _Metadata,
+    batch_size: int,
+    input_columns: tuple[int, ...],
+) -> bool:
+    return (
+        len(set(input_columns)) == 1
+        and input_columns[0] > 256
+        and batch_size * metadata.total_columns >= _SORTED_REDUCTION_MIN_OUTPUT_ELEMENTS
+    )
+
+
+def _sorted_backward_impl(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    input_numel: int,
+    batch_size: int,
+    input_columns: tuple[int, ...],
+    metadata: _Metadata,
+) -> torch.Tensor:
+    num_indices = indices.numel()
+    linear_indices = torch.empty_like(indices)
+    linear_grid = (triton.cdiv(num_indices, 256),)
+    _linearize_indices_kernel[linear_grid](
+        indices,
+        metadata.row_offsets,
+        linear_indices,
+        num_indices,
+        batch_size,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_SIZE=256,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=4,
+    )
+    sorted_rows, sorted_positions = torch.sort(linear_indices)
+    run_flags = torch.empty_like(indices, dtype=torch.int32)
+    run_grid = (triton.cdiv(num_indices, 256),)
+    _mark_sorted_runs_kernel[run_grid](
+        sorted_rows,
+        run_flags,
+        num_indices,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_SIZE=256,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=4,
+    )
+    run_ids = torch.cumsum(run_flags, dim=0, dtype=torch.int32)
+    unique_rows = torch.empty_like(indices)
+    run_offsets = torch.empty(num_indices + 1, dtype=torch.int64, device=indices.device)
+    num_runs = torch.empty(1, dtype=torch.int32, device=indices.device)
+    _compact_sorted_runs_kernel[run_grid](
+        sorted_rows,
+        run_flags,
+        run_ids,
+        unique_rows,
+        run_offsets,
+        num_indices,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_SIZE=256,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=4,
+    )
+    _finish_sorted_runs_kernel[(1,)](
+        run_ids,
+        run_offsets,
+        num_runs,
+        num_indices,
+    )
+    grad_inputs = torch.zeros(
+        input_numel,
+        dtype=grad_output.dtype,
+        device=grad_output.device,
+    )
+    grid = (triton.cdiv(num_indices, 4),)
+    _sorted_index_backward_kernel[grid](
+        grad_output,
+        sorted_positions,
+        unique_rows,
+        run_offsets,
+        num_runs,
+        grad_inputs,
+        batch_size,
+        metadata.total_columns,
+        # pyrefly: ignore[bad-argument-type]
+        COLUMNS=input_columns[0],
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_ROWS=4,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=2,
+    )
+    return grad_inputs
+
+
+def _validate_inputs(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: int,
+    input_rows: tuple[int, ...],
+    input_columns: tuple[int, ...],
+) -> None:
+    if len(input_rows) != len(input_columns):
+        raise ValueError("input_rows and input_columns must have equal length")
+    if inputs.device.type != "cuda" or indices.device != inputs.device:
+        raise ValueError("inputs and indices must be CUDA tensors on the same device")
+    if not inputs.is_contiguous() or not indices.is_contiguous():
+        raise ValueError("inputs and indices must be contiguous")
+    if inputs.numel() != sum(
+        rows * columns for rows, columns in zip(input_rows, input_columns)
+    ):
+        raise ValueError("inputs size does not match input_rows and input_columns")
+    if indices.numel() != batch_size * len(input_columns):
+        raise ValueError("indices size does not match batch_size and input_columns")
+    if any(rows <= 0 for rows in input_rows):
+        raise ValueError("all input row counts must be positive")
+    if any(columns <= 0 for columns in input_columns):
+        raise ValueError("all input column counts must be positive")
+
+
+def _forward_impl(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: int,
+    input_rows: tuple[int, ...],
+    input_columns: tuple[int, ...],
+) -> torch.Tensor:
+    _validate_inputs(inputs, indices, batch_size, input_rows, input_columns)
+    if not input_columns:
+        return inputs.new_empty(0)
+    metadata = _cached_metadata(input_rows, input_columns, inputs.device)
+    output = inputs.new_empty(batch_size * metadata.total_columns)
+    launch_buckets = _launch_buckets(metadata, batch_size)
+    for bucket in launch_buckets:
+        block_batch, block_columns, num_warps = _launch_parameters(bucket.max_columns)
+        if len(launch_buckets) == 1 and bucket.max_columns == 128:
+            # Triton TR001: uniform D128 benefits from a wider batch tile.
+            block_batch, block_columns, num_warps = 8, 64, 2
+        if (
+            len(launch_buckets) == 1
+            and bucket.max_columns == 1024
+            and batch_size * metadata.total_columns
+            >= _SORTED_REDUCTION_MIN_OUTPUT_ELEMENTS
+        ):
+            block_batch, block_columns, num_warps = 1, 1024, 4
+        num_features = bucket.feature_ids.numel()
+        num_batch_tiles = triton.cdiv(batch_size, block_batch)
+        grid = (
+            num_features * num_batch_tiles,
+            triton.cdiv(bucket.max_columns, block_columns),
+        )
+        _batch_index_select_dim0_kernel[grid](
+            inputs,
+            indices,
+            metadata.input_offsets,
+            metadata.column_offsets,
+            bucket.feature_ids,
+            output,
+            batch_size,
+            metadata.total_columns,
+            # pyrefly: ignore[bad-argument-type]
+            NUM_FEATURES=num_features,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_BATCH=block_batch,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_COLUMNS=block_columns,
+            # pyrefly: ignore[unexpected-keyword]
+            num_warps=num_warps,
+        )
+    return output
+
+
+def _backward_impl(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    input_numel: int,
+    batch_size: int,
+    input_rows: tuple[int, ...],
+    input_columns: tuple[int, ...],
+) -> torch.Tensor:
+    metadata = _cached_metadata(input_rows, input_columns, grad_output.device)
+    if _use_sorted_reduction(metadata, batch_size, input_columns):
+        return _sorted_backward_impl(
+            grad_output,
+            indices,
+            input_numel,
+            batch_size,
+            input_columns,
+            metadata,
+        )
+    use_fp32_accumulator = _use_fp32_accumulator(
+        metadata, batch_size, grad_output.dtype
+    )
+    grad_inputs = torch.zeros(
+        input_numel,
+        dtype=torch.float32 if use_fp32_accumulator else grad_output.dtype,
+        device=grad_output.device,
+    )
+    use_counts = _use_counted_scatter(metadata, batch_size)
+    counts = metadata.row_offsets
+    if use_counts:
+        counts = torch.zeros(
+            metadata.total_rows,
+            dtype=torch.int32,
+            device=grad_output.device,
+        )
+        num_indices = indices.numel()
+        count_num_programs = triton.cdiv(num_indices, 256)
+        count_grid = (count_num_programs,)
+        # Triton atomic-add membar amortization uses relaxed ordering at 16+ waves.
+        relaxed_atomics: Any = (
+            metadata.supports_relaxed_atomics
+            and count_num_programs >= 16 * metadata.num_sms
+        )
+        _count_index_occurrences_kernel[count_grid](
+            indices,
+            metadata.row_offsets,
+            counts,
+            num_indices,
+            batch_size,
+            RELAXED_ATOMICS=relaxed_atomics,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_SIZE=256,
+            # pyrefly: ignore[unexpected-keyword]
+            num_warps=4,
+        )
+    for bucket in _launch_buckets(metadata, batch_size):
+        block_batch, block_columns, num_warps = _launch_parameters(bucket.max_columns)
+        if use_fp32_accumulator and bucket.max_columns <= 128:
+            # Triton TR001: high-contention atomics benefit from a wider batch tile.
+            block_batch, block_columns, num_warps = 8, 64, 2
+        num_features = bucket.feature_ids.numel()
+        num_batch_tiles = triton.cdiv(batch_size, block_batch)
+        num_column_tiles = triton.cdiv(bucket.max_columns, block_columns)
+        num_programs = num_features * num_batch_tiles * num_column_tiles
+        grid = (
+            num_features * num_batch_tiles,
+            num_column_tiles,
+        )
+        # Triton atomic-add membar amortization: terminal sums with at least
+        # 16 waves do not need release ordering within the kernel.
+        relaxed_atomics: Any = (
+            metadata.supports_relaxed_atomics and num_programs >= 16 * metadata.num_sms
+        )
+        counted_scatter: Any = use_counts
+        _batch_index_select_dim0_backward_kernel[grid](
+            grad_output,
+            indices,
+            metadata.input_offsets,
+            metadata.row_offsets,
+            metadata.column_offsets,
+            bucket.feature_ids,
+            counts,
+            grad_inputs,
+            batch_size,
+            metadata.total_columns,
+            # pyrefly: ignore[bad-argument-type]
+            NUM_FEATURES=num_features,
+            USE_COUNTS=counted_scatter,
+            RELAXED_ATOMICS=relaxed_atomics,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_BATCH=block_batch,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_COLUMNS=block_columns,
+            # pyrefly: ignore[unexpected-keyword]
+            num_warps=num_warps,
+        )
+    return (
+        grad_inputs.to(dtype=grad_output.dtype) if use_fp32_accumulator else grad_inputs
+    )
+
+
+@torch.library.custom_op(
+    "torchrec::triton_batch_index_select_dim0",
+    mutates_args=(),
+    schema="(Tensor inputs, Tensor indices, SymInt batch_size, SymInt[] input_rows, SymInt[] input_columns) -> Tensor",
+)
+def triton_batch_index_select_dim0(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: int,
+    input_rows: list[int],
+    input_columns: list[int],
+) -> torch.Tensor:
+    return _forward_impl(
+        inputs,
+        indices,
+        batch_size,
+        tuple(input_rows),
+        tuple(input_columns),
+    )
+
+
+@triton_batch_index_select_dim0.register_fake
+def _fake_triton_batch_index_select_dim0(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: int,
+    input_rows: list[int],
+    input_columns: list[int],
+) -> torch.Tensor:
+    return inputs.new_empty(batch_size * sum(input_columns))
+
+
+@torch.library.custom_op(
+    "torchrec::triton_batch_index_select_dim0_backward",
+    mutates_args=(),
+    schema="(Tensor grad_output, Tensor indices, SymInt input_numel, SymInt batch_size, SymInt[] input_rows, SymInt[] input_columns) -> Tensor",
+)
+def _triton_batch_index_select_dim0_backward(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    input_numel: int,
+    batch_size: int,
+    input_rows: list[int],
+    input_columns: list[int],
+) -> torch.Tensor:
+    return _backward_impl(
+        grad_output.contiguous(),
+        indices,
+        input_numel,
+        batch_size,
+        tuple(input_rows),
+        tuple(input_columns),
+    )
+
+
+@_triton_batch_index_select_dim0_backward.register_fake
+def _fake_triton_batch_index_select_dim0_backward(
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    input_numel: int,
+    batch_size: int,
+    input_rows: list[int],
+    input_columns: list[int],
+) -> torch.Tensor:
+    return grad_output.new_empty(input_numel)
+
+
+def _setup_context(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
+    input_values, indices, batch_size, input_rows, input_columns = inputs
+    ctx.save_for_backward(indices)
+    ctx.input_numel = input_values.numel()
+    ctx.batch_size = batch_size
+    ctx.input_rows = input_rows
+    ctx.input_columns = input_columns
+
+
+def _backward(
+    ctx: Any, grad_output: torch.Tensor
+) -> tuple[torch.Tensor, None, None, None, None]:
+    (indices,) = ctx.saved_tensors
+    return (
+        _triton_batch_index_select_dim0_backward(
+            grad_output,
+            indices,
+            ctx.input_numel,
+            ctx.batch_size,
+            ctx.input_rows,
+            ctx.input_columns,
+        ),
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+triton_batch_index_select_dim0.register_autograd(
+    _backward,
+    setup_context=_setup_context,
+)


### PR DESCRIPTION
Summary:

This diff adds a standalone TorchRec Triton implementation and benchmark for batch_index_select_dim0. It intentionally does not change embeddingbag.py yet; the goal is to establish correctness and performance before integration.

Kernel design

- Cache input offsets, row offsets, column offsets, and feature groups by shape and device.
- Derive launch parameters from embedding width instead of maintaining a table of per-width presets. Small dimensions use width-scaled batching, wide dimensions use capped column tiles, and measured exceptions are limited to uniform D128, heavy uniform D1024, and high-contention accumulation.
- Group features by power-of-two embedding width only for workloads large enough to benefit; lightweight workloads use one combined launch.
- Flatten feature and batch tiles into one launch axis. This preserves feature-fast wave scheduling and supports reconstructed batch sizes of 65,536 and above without exceeding CUDA's Y-grid limit.
- Use counted scatter when input rows are broadly covered: unique destinations use stores and only duplicate destinations use atomics.
- Accumulate high-duplication FP16/BF16 gradients in FP32 before one final cast, improving both performance and numerical stability.
- For heavy uniform wide workloads, sort linearized destination rows, compact runs entirely on the GPU, and reduce each destination once. This avoids contended atomics without a host synchronization.
- Mark streamed payload loads as evict-first, use relaxed atomic ordering for sufficiently large terminal reductions, and widen output-pointer products to int64 before they can overflow.
- Register custom-op fake and autograd implementations for torch.compile compatibility.

Correctness

- CUDA tests compare forward output and input gradients with native PyTorch for FP32, FP16, and BF16.
- Every tested feature has a repeated row index, covering duplicate-index gradient accumulation.
- Dedicated tests cover counted scatter, FP32 accumulation, and the sorted heavy-volume backward path.
- A fullgraph torch.compile test validates fake and autograd registration.
- A 65,536-row test covers the flattened launch geometry that avoids the CUDA grid-dimension limit.

Workload and benchmark method

The production call in VariableBatchEmbeddingBagCollectionAwaitable operates on post-all-to-all pooled activations, not directly on the embedding-table weights. The benchmark models VBE inverse indices: each deduplicated input row appears at least once, repeated rows reconstruct the output batch, and indices are shuffled.

Performance work is concentrated above approximately 10 MB of useful traffic, with multi-GB cases as the primary target. Lightweight cases remain covered for correctness and catastrophic-regression detection but are not independently tuned.

Results use 100 timed iterations on an idle NVIDIA H100 PCIe with 96 GB HBM2e, 132 SMs, 2.40 TB/s theoretical aggregate HBM bandwidth, and 18.18 GB/s/SM theoretical average bandwidth. A 20 ms GPU backlog keeps the measured launch sequence queued. Each uploaded trace contains ten separately marked profile iterations. The reported numbers, bandwidth percentages, launch thresholds, and measured exceptions are H100-specific; correctness is device-generic, but performance has not yet been validated on A100 or B200.

Each backend cell reports linked GPU P50 latency, effective useful bandwidth, and percentage of the 2.40 TB/s HBM peak. Forward useful bytes count one selected-input read plus one output write. Forward plus backward counts those two selected-payload transfers in each direction. This excludes indices, metadata, zero initialization, casts, and atomic transaction amplification, so it is an algorithm-independent roofline indicator rather than an NCU DRAM-counter measurement.

Results and bandwidth

| Shape | Dtype | Mode | Useful bytes | Triton | FBGEMM | Native PyTorch | Triton vs FBGEMM |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Mixed VBE: T165, R1024-4096, B4096 | FP16 | Forward | 175.374 MB | [0.1434 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.223 TB/s; 51.0% | [0.2283 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.768 TB/s; 32.0% | [0.9719 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.180 TB/s; 7.5% | 1.59x |
| Mixed VBE: T165, R1024-4096, B4096 | FP16 | Forward + backward | 350.749 MB | [0.3909 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.897 TB/s; 37.4% | [0.5913 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.593 TB/s; 24.7% | [2.0654 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.170 TB/s; 7.1% | 1.51x |
| Mixed VBE: T165, R1024-4096, B4096 | FP32 | Forward | 350.749 MB | [0.1958 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.791 TB/s; 74.6% | [0.2693 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.302 TB/s; 54.3% | [1.0779 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.325 TB/s; 13.6% | 1.38x |
| Mixed VBE: T165, R1024-4096, B4096 | FP32 | Forward + backward | 701.497 MB | [0.4482 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.565 TB/s; 65.2% | [0.6887 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.019 TB/s; 42.4% | [2.4475 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.287 TB/s; 11.9% | 1.54x |
| Mixed VBE: T165, R1024-4096, B4096 | BF16 | Forward | 175.374 MB | [0.1438 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_bf16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.220 TB/s; 50.8% | Not supported | [0.9622 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_bf16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.182 TB/s; 7.6% | N/A |
| Mixed VBE: T165, R1024-4096, B4096 | BF16 | Forward + backward | 350.749 MB | [0.3907 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_mixed_bf16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.898 TB/s; 37.4% | Not supported | [2.0725 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_mixed_bf16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.169 TB/s; 7.1% | N/A |
| Small mixed: T16, R128-256, B256 | FP16 | Forward | 0.918 MB | [0.0080 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_small_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.115 TB/s; 4.8% | [0.0140 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_small_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.066 TB/s; 2.7% | [0.0422 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_small_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.022 TB/s; 0.9% | 1.75x |
| Small mixed: T16, R128-256, B256 | FP16 | Forward + backward | 1.835 MB | [0.0168 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_small_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.109 TB/s; 4.6% | [0.0832 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_small_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.022 TB/s; 0.9% | [0.1260 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_small_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.015 TB/s; 0.6% | 4.95x |
| Uniform: T1024, R100, B2048, D128 | FP16 | Forward | 1.074 GB | [0.5514 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.947 TB/s; 81.1% | [0.6277 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.711 TB/s; 71.3% | [4.6704 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.230 TB/s; 9.6% | 1.14x |
| Uniform: T1024, R100, B2048, D128 | FP16 | Forward + backward | 2.147 GB | [1.1852 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.812 TB/s; 75.5% | [1.2918 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.662 TB/s; 69.3% | [16.8271 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.128 TB/s; 5.3% | 1.09x |
| Wide: T16, R4096, B4096, D1024 | FP16 | Forward | 268.435 MB | [0.1318 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 2.037 TB/s; 84.9% | [0.1479 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.815 TB/s; 75.6% | [0.3022 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.888 TB/s; 37.0% | 1.12x |
| Wide: T16, R4096, B4096, D1024 | FP16 | Forward + backward | 536.871 MB | [0.3266 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.644 TB/s; 68.5% | [0.4218 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.273 TB/s; 53.0% | [0.6613 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.812 TB/s; 33.8% | 1.29x |
| Large VBE: T165, R32768-65536, B65536 | FP16 | Forward | 2.806 GB | [2.3225 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_large_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.208 TB/s; 50.3% | [3.4726 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_large_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.808 TB/s; 33.7% | [8.5167 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_large_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.329 TB/s; 13.7% | 1.50x |
| Large VBE: T165, R32768-65536, B65536 | FP16 | Forward + backward | 5.612 GB | [6.1976 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_large_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.906 TB/s; 37.7% | [8.4273 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_large_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.666 TB/s; 27.7% | [13.7870 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_large_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.407 TB/s; 17.0% | 1.36x |
| XL mixed VBE: T165, R131072-262144, B262144 | FP16 | Forward | 11.223 GB | [9.2971 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.207 TB/s; 50.3% | [14.4237 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.778 TB/s; 32.4% | [37.3026 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_mixed_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.301 TB/s; 12.5% | 1.55x |
| XL mixed VBE: T165, R131072-262144, B262144 | FP16 | Forward + backward | 22.447 GB | [25.7902 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.870 TB/s; 36.3% | [34.6855 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.647 TB/s; 27.0% | [60.8025 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_mixed_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.369 TB/s; 15.4% | 1.34x |
| XL mixed VBE: T165, R65536-131072, B131072 | FP32 | Forward | 11.223 GB | [6.1232 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.833 TB/s; 76.4% | [8.9319 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.257 TB/s; 52.4% | [19.5564 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_mixed_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.574 TB/s; 23.9% | 1.46x |
| XL mixed VBE: T165, R65536-131072, B131072 | FP32 | Forward + backward | 22.447 GB | [16.2107 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.385 TB/s; 57.7% | [20.3534 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.103 TB/s; 46.0% | [37.8636 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_mixed_fp32_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.593 TB/s; 24.7% | 1.26x |
| XL uniform: T1024, R100, B20480, D128 | FP16 | Forward | 10.737 GB | [5.3967 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.990 TB/s; 82.9% | [5.2816 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 2.033 TB/s; 84.7% | [38.6430 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_uniform_d128_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.278 TB/s; 11.6% | 0.98x |
| XL uniform: T1024, R100, B20480, D128 | FP16 | Forward + backward | 21.475 GB | [10.6580 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 2.015 TB/s; 84.0% | [13.0595 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.644 TB/s; 68.5% | [60.8753 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_uniform_d128_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.353 TB/s; 14.7% | 1.23x |
| XL wide: T16, R81920-163840, B163840, D1024 | FP16 | Forward | 10.737 GB | [5.2600 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 2.041 TB/s; 85.0% | [5.4275 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.978 TB/s; 82.4% | [12.0673 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_wide_d1024_fp16-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.890 TB/s; 37.1% | 1.03x |
| XL wide: T16, R81920-163840, B163840, D1024 | FP16 | Forward + backward | 21.475 GB | [11.8200 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_triton_xl_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.817 TB/s; 75.7% | [12.0380 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_fbgemm_xl_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 1.784 TB/s; 74.3% | [25.7718 ms](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118914624/trace-batch_index_select_dim0_torch_xl_wide_d1024_fp16_backward-rank0.json.gz&bucket=torchrec_benchmark_traces); 0.833 TB/s; 34.7% | 1.02x |

The Triton-to-FBGEMM column is FBGEMM latency divided by Triton latency, so values above 1 mean Triton is faster. Triton wins all 12 original supported comparisons and all comparisons against native PyTorch. Across the new approximately 10 GB cases, Triton wins 7 of 8 FBGEMM comparisons, including both XL wide modes after the heavy-volume optimization. The only remaining loss is XL uniform D128 forward at 0.98x, where both implementations sustain more than 82% of theoretical HBM bandwidth.

All traces: https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D118914624

Reviewed By: xywang9334

Differential Revision: D118914624


