### PR TITLE
Make stash/restore trunk sizes independently configurable (#4689)

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -37,10 +37,13 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# Trunk size for the bulk stash (D2H) / restore (H2D) copies. ~32 MiB trunks
-# keep the copy engine yielding often enough for the main stream's small copies
-# to interleave, at a negligible bandwidth cost (see chunked copy design).
-_STASH_CHUNK_SIZE_BYTES: int = 32 * 1024**2
+# Default trunk size for the bulk stash (D2H) / restore (H2D) copies. ~32 MiB
+# trunks keep the copy engine yielding often enough for the main stream's small
+# copies to interleave, at a negligible bandwidth cost (see chunked copy
+# design). Each use case (embedding / optimizer) and each direction (stash /
+# restore) overrides this independently -- see ``set_embedding_trunk_size`` /
+# ``set_optimizer_trunk_size``, driven from ``MemoryBouncerConfig``.
+_DEFAULT_CHUNK_SIZE_BYTES: int = 32 * 1024**2
 
 
 @runtime_checkable
@@ -179,10 +182,17 @@ class MemoryStashingManager:
     # sites run on every batch; without this guard they would flood the event
     # logger. Intentionally NOT cleared in reset() to avoid re-flooding.
     _logged_event_keys: set[str] = set()
-    # Trunk size (bytes) for the bulk D2H stash / H2D restore copies, used as
-    # ``chunked_copy_``'s ``chunk_size_bytes``. Defaults to
-    # ``_STASH_CHUNK_SIZE_BYTES``; override via ``set_trunk_size``.
-    _stash_chunk_size_bytes: int = _STASH_CHUNK_SIZE_BYTES
+    # Trunk sizes (bytes) for the bulk copies, used as ``chunked_copy_``'s
+    # ``chunk_size_bytes``. Embedding and optimizer stashing each get their own
+    # pair, and within a use case the D2H stash and H2D restore are independent:
+    # the two directions contend with different main-stream traffic (stash
+    # overlaps forward, restore overlaps backward), so their optimal trunk sizes
+    # differ. All default to ``_DEFAULT_CHUNK_SIZE_BYTES``; override via
+    # ``set_embedding_trunk_size`` / ``set_optimizer_trunk_size``.
+    _embedding_stash_chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES
+    _embedding_restore_chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES
+    _optimizer_stash_chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES
+    _optimizer_restore_chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES
     _stashed_tables: Optional[Set[str]] = None
 
     @classmethod
@@ -291,7 +301,52 @@ class MemoryStashingManager:
         to the main stream's small copies more often, at a small bandwidth cost;
         values <= 0 disable chunking and fall back to a single ``copy_``.
         """
-        cls._stash_chunk_size_bytes = size_bytes
+        cls.set_embedding_trunk_size(size_bytes, size_bytes)
+        cls.set_optimizer_trunk_size(size_bytes, size_bytes)
+
+    @classmethod
+    def set_embedding_trunk_size(
+        cls,
+        stash_size_bytes: Optional[int] = None,
+        restore_size_bytes: Optional[int] = None,
+    ) -> None:
+        """Set the embedding-weight trunk sizes (in bytes).
+
+        Only the arguments that are not ``None`` are applied, so a caller can
+        tune one direction without disturbing the other. Values <= 0 disable
+        chunking for that direction and fall back to a single ``copy_``.
+
+        Args:
+            stash_size_bytes: Trunk size for the D2H stash (forward pass).
+            restore_size_bytes: Trunk size for the H2D restore (backward pass).
+        """
+        if stash_size_bytes is not None:
+            cls._embedding_stash_chunk_size_bytes = stash_size_bytes
+        if restore_size_bytes is not None:
+            cls._embedding_restore_chunk_size_bytes = restore_size_bytes
+
+    @classmethod
+    def set_optimizer_trunk_size(
+        cls,
+        stash_size_bytes: Optional[int] = None,
+        restore_size_bytes: Optional[int] = None,
+    ) -> None:
+        """Set the optimizer-state trunk sizes (in bytes).
+
+        Only the arguments that are not ``None`` are applied, so a caller can
+        tune one direction without disturbing the other. Values <= 0 disable
+        chunking for that direction and fall back to a single ``copy_``. When
+        the state is stashed in slices (``num_slices > 1``) every slice uses
+        these same sizes.
+
+        Args:
+            stash_size_bytes: Trunk size for the D2H stash (after the step).
+            restore_size_bytes: Trunk size for the H2D restore (backward pass).
+        """
+        if stash_size_bytes is not None:
+            cls._optimizer_stash_chunk_size_bytes = stash_size_bytes
+        if restore_size_bytes is not None:
+            cls._optimizer_restore_chunk_size_bytes = restore_size_bytes
 
     @classmethod
     def set_delay_stash(cls, delay: bool) -> None:
@@ -328,7 +383,10 @@ class MemoryStashingManager:
         cls._optimizer_scratch_buffer_restore_callbacks.clear()
         cls._emo_cache_restore_callbacks.clear()
         cls._delay_stash = False
-        cls._stash_chunk_size_bytes = _STASH_CHUNK_SIZE_BYTES
+        cls._embedding_stash_chunk_size_bytes = _DEFAULT_CHUNK_SIZE_BYTES
+        cls._embedding_restore_chunk_size_bytes = _DEFAULT_CHUNK_SIZE_BYTES
+        cls._optimizer_stash_chunk_size_bytes = _DEFAULT_CHUNK_SIZE_BYTES
+        cls._optimizer_restore_chunk_size_bytes = _DEFAULT_CHUNK_SIZE_BYTES
         cls._pending_stash_callbacks.clear()
         cls._staged_storage_buffers.clear()
         cls._stashed_tables = None
@@ -459,6 +517,8 @@ class MemoryStashingManager:
         label: str = "tensor",
         sync_event: Optional[torch.cuda.Event] = None,
         delay: bool = False,
+        stash_chunk_size_bytes: Optional[int] = None,
+        restore_chunk_size_bytes: Optional[int] = None,
     ) -> Tuple[
         Callable[[Optional[torch.Tensor]], None],
         Callable[..., None],
@@ -488,6 +548,12 @@ class MemoryStashingManager:
                 to perform the actual D2H copy and free HBM.  A sync event
                 is recorded automatically so that the deferred execution
                 waits for the correct GPU work.
+            stash_chunk_size_bytes: Trunk size for the D2H copy, passed to
+                ``chunked_copy_``.  ``None`` falls back to
+                ``_DEFAULT_CHUNK_SIZE_BYTES``; the public ``stash_*`` entry
+                points always pass their use case's configured value.
+            restore_chunk_size_bytes: Trunk size for the H2D copy in the
+                returned ``restore`` callback.  Same fallback as above.
 
         Returns:
             A tuple of three callback functions:
@@ -498,6 +564,21 @@ class MemoryStashingManager:
               hook.  In non-delayed mode it has already been called and is
               safe to call again (no-op on empty tensor list).
         """
+        # Resolve the trunk sizes once, up front, so a stash and the ``restore``
+        # it hands back always use a matched pair -- a later
+        # ``set_*_trunk_size`` or ``reset`` cannot re-point an in-flight cycle's
+        # restore at a different trunk size than its stash.
+        stash_chunk_bytes: int = (
+            _DEFAULT_CHUNK_SIZE_BYTES
+            if stash_chunk_size_bytes is None
+            else stash_chunk_size_bytes
+        )
+        restore_chunk_bytes: int = (
+            _DEFAULT_CHUNK_SIZE_BYTES
+            if restore_chunk_size_bytes is None
+            else restore_chunk_size_bytes
+        )
+
         # (hbm_tensor ref, cpu_buffer, original_storage_size)
         stash_data: List[Tuple[torch.Tensor, torch.Tensor, int]] = []
         # Original CUDA storages saved before .data= so restore can
@@ -558,7 +639,7 @@ class MemoryStashingManager:
                         chunked_copy_(
                             cpu_buffer,
                             tensor,
-                            chunk_size_bytes=cls._stash_chunk_size_bytes,
+                            chunk_size_bytes=stash_chunk_bytes,
                         )
                         # Tell the caching allocator this tensor is in use on
                         # d2h_stream so the bytes are not reused by default-
@@ -707,7 +788,7 @@ class MemoryStashingManager:
                             chunked_copy_(
                                 tmp,
                                 cpu_buf,
-                                chunk_size_bytes=cls._stash_chunk_size_bytes,
+                                chunk_size_bytes=restore_chunk_bytes,
                             )
                         # Tell the caching allocator this storage is in use on
                         # h2d_stream so the bytes cannot be reused by main-stream
@@ -839,7 +920,11 @@ class MemoryStashingManager:
 
         if cls._delay_stash:
             await_restore, restore, execute_stash = cls._stash_tensors(
-                tensors, label="embedding", delay=True
+                tensors,
+                label="embedding",
+                delay=True,
+                stash_chunk_size_bytes=cls._embedding_stash_chunk_size_bytes,
+                restore_chunk_size_bytes=cls._embedding_restore_chunk_size_bytes,
             )
 
             # Wrap execute_stash to also register the restore callback,
@@ -852,7 +937,10 @@ class MemoryStashingManager:
             return await_restore, restore, _deferred_stash
 
         await_restore, restore, execute_stash = cls._stash_tensors(
-            tensors, label="embedding"
+            tensors,
+            label="embedding",
+            stash_chunk_size_bytes=cls._embedding_stash_chunk_size_bytes,
+            restore_chunk_size_bytes=cls._embedding_restore_chunk_size_bytes,
         )
         cls._embedding_weight_restore_callbacks.append(restore)
         return await_restore, restore, execute_stash
@@ -1172,7 +1260,11 @@ class MemoryStashingManager:
 
         if num_slices <= 1:
             await_restore, tensor_restore, _execute_stash = cls._stash_tensors(
-                tensors, label="optimizer state", sync_event=sync_event
+                tensors,
+                label="optimizer state",
+                sync_event=sync_event,
+                stash_chunk_size_bytes=cls._optimizer_stash_chunk_size_bytes,
+                restore_chunk_size_bytes=cls._optimizer_restore_chunk_size_bytes,
             )
             cls._optimizer_state_restore_callbacks.append(tensor_restore)
             scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
@@ -1215,6 +1307,8 @@ class MemoryStashingManager:
                 slice_tensors,
                 label=f"optimizer state slice {k + 1}/{len(slices)}",
                 sync_event=sync_event,
+                stash_chunk_size_bytes=cls._optimizer_stash_chunk_size_bytes,
+                restore_chunk_size_bytes=cls._optimizer_restore_chunk_size_bytes,
             )
             slice_awaits.append(await_restore_k)
             slice_restores.append(restore_k)

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -28,6 +28,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.memory_stashing import (
     _collect_cuda_tensors_from_value,
+    _DEFAULT_CHUNK_SIZE_BYTES,
     _partition_tensors_into_slices,
     chunked_copy_,
     MemoryStashingManager,
@@ -1190,6 +1191,247 @@ class ChunkedCopyTest(unittest.TestCase):
         # A dummy op sits between consecutive chunks: one fewer than chunk count.
         self.assertEqual(len(add_calls), expected_chunks - 1)
         self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
+
+
+class TestTrunkSizeConfiguration(unittest.TestCase):
+    """Tests for the four independent trunk-size knobs (no GPU required)."""
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+
+    def test_defaults_are_the_shared_default(self) -> None:
+        """All four knobs start at _DEFAULT_CHUNK_SIZE_BYTES (32 MiB)."""
+        self.assertEqual(_DEFAULT_CHUNK_SIZE_BYTES, 32 * 1024**2)
+        self.assertEqual(
+            MemoryStashingManager._embedding_stash_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_restore_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_stash_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_restore_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+
+    def test_embedding_and_optimizer_are_independent(self) -> None:
+        """Setting one use case must not disturb the other."""
+        MemoryStashingManager.set_embedding_trunk_size(64 * 1024**2, 64 * 1024**2)
+        MemoryStashingManager.set_optimizer_trunk_size(128 * 1024**2, 128 * 1024**2)
+
+        self.assertEqual(
+            MemoryStashingManager._embedding_stash_chunk_size_bytes, 64 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_restore_chunk_size_bytes, 64 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_stash_chunk_size_bytes, 128 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_restore_chunk_size_bytes, 128 * 1024**2
+        )
+
+    def test_stash_and_restore_directions_are_independent(self) -> None:
+        """Within a use case, each direction is set separately."""
+        MemoryStashingManager.set_embedding_trunk_size(
+            stash_size_bytes=8 * 1024**2, restore_size_bytes=64 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_stash_chunk_size_bytes, 8 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_restore_chunk_size_bytes, 64 * 1024**2
+        )
+
+    def test_omitted_direction_is_left_untouched(self) -> None:
+        """``None`` means 'leave as is', so one direction can be tuned alone."""
+        MemoryStashingManager.set_optimizer_trunk_size(4 * 1024**2, 4 * 1024**2)
+        MemoryStashingManager.set_optimizer_trunk_size(stash_size_bytes=16 * 1024**2)
+
+        self.assertEqual(
+            MemoryStashingManager._optimizer_stash_chunk_size_bytes, 16 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_restore_chunk_size_bytes, 4 * 1024**2
+        )
+
+    def test_set_trunk_size_sets_every_knob(self) -> None:
+        """The set-both shortcut still applies to all four."""
+        MemoryStashingManager.set_trunk_size(7 * 1024**2)
+        self.assertEqual(
+            MemoryStashingManager._embedding_stash_chunk_size_bytes, 7 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_restore_chunk_size_bytes, 7 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_stash_chunk_size_bytes, 7 * 1024**2
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_restore_chunk_size_bytes, 7 * 1024**2
+        )
+
+    def test_reset_restores_all_defaults(self) -> None:
+        """reset() must clear every knob, not just one."""
+        MemoryStashingManager.set_embedding_trunk_size(1, 2)
+        MemoryStashingManager.set_optimizer_trunk_size(3, 4)
+
+        MemoryStashingManager.reset()
+
+        self.assertEqual(
+            MemoryStashingManager._embedding_stash_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._embedding_restore_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_stash_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+        self.assertEqual(
+            MemoryStashingManager._optimizer_restore_chunk_size_bytes,
+            _DEFAULT_CHUNK_SIZE_BYTES,
+        )
+
+
+class TestTrunkSizeWiring(unittest.TestCase):
+    """Each stash path must reach chunked_copy_ with its own trunk size.
+
+    Guards the wiring that makes the four knobs actually independent: embedding
+    and optimizer stashing share ``_stash_tensors``, so a regression there would
+    silently collapse all four back onto one value.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        self.device = torch.device("cuda:0")
+        MemoryStashingManager.set_streams(torch.cuda.Stream(device=self.device))
+        # Distinct, deliberately small values so each call is attributable and
+        # the chunk loop actually runs (rather than falling back to one copy_).
+        self.emb_stash_bytes = 64 * 1024
+        self.emb_restore_bytes = 16 * 1024
+        self.opt_stash_bytes = 128 * 1024
+        self.opt_restore_bytes = 8 * 1024
+        MemoryStashingManager.set_embedding_trunk_size(
+            stash_size_bytes=self.emb_stash_bytes,
+            restore_size_bytes=self.emb_restore_bytes,
+        )
+        MemoryStashingManager.set_optimizer_trunk_size(
+            stash_size_bytes=self.opt_stash_bytes,
+            restore_size_bytes=self.opt_restore_bytes,
+        )
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+
+    def _record_chunked_copy(self, calls: List[Tuple[str, int]]) -> Any:
+        """Patch chunked_copy_ to record (direction, chunk_size) and call through.
+
+        Direction is read off the destination: a CPU dst is the D2H stash, a
+        CUDA dst is the H2D restore.
+        """
+        real = chunked_copy_
+
+        def recording(
+            dst: torch.Tensor,
+            src: torch.Tensor,
+            chunk_size_bytes: int = 512 * 1024**2,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            calls.append(("h2d" if dst.is_cuda else "d2h", chunk_size_bytes))
+            real(dst, src, chunk_size_bytes, *args, **kwargs)
+
+        return patch(
+            "torchrec.distributed.memory_stashing.chunked_copy_", new=recording
+        )
+
+    def test_embedding_stash_and_restore_use_the_embedding_sizes(self) -> None:
+        weights = torch.randn(512, 512, device=self.device)  # 1 MiB
+        original = weights.clone()
+        inner = Mock()
+        inner.weights_dev = weights
+        emb_module = Mock()
+        emb_module._emb_module = inner
+        lookup = Mock(spec=["_emb_modules"])
+        lookup._emb_modules = [emb_module]
+
+        calls: List[Tuple[str, int]] = []
+        with self._record_chunked_copy(calls):
+            result = MemoryStashingManager.stash_embedding_weights(lookup)
+            self.assertIsNotNone(result)
+            assert result is not None
+            await_restore, restore, _execute_stash = result
+            restore(None)
+            await_restore(None)
+        torch.cuda.synchronize()
+
+        self.assertEqual(
+            calls, [("d2h", self.emb_stash_bytes), ("h2d", self.emb_restore_bytes)]
+        )
+        torch.testing.assert_close(weights, original, rtol=1e-05, atol=1e-08)
+
+    def test_optimizer_stash_and_restore_use_the_optimizer_sizes(self) -> None:
+        model = nn.Linear(4, 4).to(self.device)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, foreach=True)
+        param = next(model.parameters())
+        state = torch.randn(512, 512, device=self.device)  # 1 MiB, over the threshold
+        original = state.clone()
+        optimizer.state[param] = {"exp_avg": state}
+
+        calls: List[Tuple[str, int]] = []
+        with self._record_chunked_copy(calls):
+            await_restore, restore = MemoryStashingManager.stash_optimizer_state(
+                optimizer
+            )
+            restore(None)
+            await_restore(None)
+        torch.cuda.synchronize()
+
+        self.assertEqual(
+            calls, [("d2h", self.opt_stash_bytes), ("h2d", self.opt_restore_bytes)]
+        )
+        torch.testing.assert_close(state, original, rtol=1e-05, atol=1e-08)
+
+    def test_optimizer_slices_all_use_the_optimizer_sizes(self) -> None:
+        """A multi-slice restore must not fall back to the shared default."""
+        model = nn.Linear(4, 4).to(self.device)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, foreach=True)
+        params = list(model.parameters())
+        for param in params[:2]:
+            optimizer.state[param] = {
+                "exp_avg": torch.randn(512, 512, device=self.device)
+            }
+
+        calls: List[Tuple[str, int]] = []
+        with self._record_chunked_copy(calls):
+            await_restore, restore = MemoryStashingManager.stash_optimizer_state(
+                optimizer, num_slices=2
+            )
+            restore(None)
+            await_restore(None)
+        torch.cuda.synchronize()
+
+        self.assertEqual(
+            sorted(calls),
+            sorted(
+                [
+                    ("d2h", self.opt_stash_bytes),
+                    ("d2h", self.opt_stash_bytes),
+                    ("h2d", self.opt_restore_bytes),
+                    ("h2d", self.opt_restore_bytes),
+                ]
+            ),
+        )
 
 
 class TestCollectCudaTensorsSharded(unittest.TestCase):


### PR DESCRIPTION
Summary:

The bulk host-to-device and device-to-host copies behind memory stashing are split into fixed 32 MiB chunks so the copy engine yields between them and lets the main stream's smaller copies interleave. That size was hard-coded, and 32 MiB is a guess rather than a measured optimum - the right value depends on how much other copy traffic the transfer is competing with, which differs by use case and by direction.

This replaces the single hard-coded value with four independent knobs: embedding and optimizer stashing each get their own pair, and within each the eviction and the restore are set separately. The two directions overlap different phases - embedding eviction overlaps forward, optimizer eviction overlaps the post-step, and both restores overlap backward - so each contends with different main-stream traffic and tunes differently.

Sizes are resolved once when a stash begins and captured for the restore it hands back, so changing a knob mid-run cannot leave an in-flight cycle restoring at a different chunk size than it evicted at. The set-everything shortcut is kept and now fans out to all four.

All four default to the previous hard-coded value, so this changes nothing until a caller sets one. Non-positive values disable chunking and fall back to a single copy.

Reviewed By: Fiery

Differential Revision: D118754228


