### PR TITLE
[Triton][ops] Add fused 8-bit rowwise quantization (#4690)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_ops.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_ops.py
@@ -60,6 +60,10 @@ from torchrec.sparse.triton_permute_2d import (
 from torchrec.sparse.triton_permute_multi_embedding import (
     triton_permute_multi_embedding,
 )
+from torchrec.sparse.triton_quantized_comm import (
+    triton_float_to_fused8bitrowwise_quantized,
+    triton_fused8bitrowwise_quantized_to_float,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -1068,6 +1072,92 @@ def batch_index_select_dim0_torch(
             dim=1,
         ).flatten()
         _run_batch_index_select_backward(output, inputs, grad_output, run_backward)
+
+
+######################## fused 8-bit rowwise configs ################################
+@dataclass
+class Fused8BitRowwiseConfig(TritonOpConfig):
+    """FP32 communication tensors quantized independently by their last dimension."""
+
+    num_rows: int = 65536
+    num_columns: int = 32
+    gpu_backlog_ms: float = 20.0
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        if self.num_rows < 0 or self.num_columns <= 0:
+            raise ValueError("num_rows must be nonnegative and num_columns positive")
+        input = torch.randn(
+            self.num_rows,
+            self.num_columns,
+            dtype=torch.float32,
+            device=device,
+        )
+        quantized = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input)
+        return {"input": input, "quantized": quantized}
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_quantize_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    input: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_float_to_fused8bitrowwise_quantized ##"):
+        triton_float_to_fused8bitrowwise_quantized(input)
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_quantize_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    input: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## fbgemm_float_to_fused8bitrowwise_quantized ##"):
+        torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input)
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_dequantize_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    quantized: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_fused8bitrowwise_quantized_to_float ##"):
+        triton_fused8bitrowwise_quantized_to_float(quantized)
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_dequantize_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    quantized: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## fbgemm_fused8bitrowwise_quantized_to_float ##"):
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(quantized)
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_roundtrip_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    input: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_fused8bitrowwise_roundtrip ##"):
+        triton_fused8bitrowwise_quantized_to_float(
+            triton_float_to_fused8bitrowwise_quantized(input)
+        )
+
+
+@register_benchmark(Fused8BitRowwiseConfig)
+def fused_8bit_rowwise_roundtrip_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    input: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## fbgemm_fused8bitrowwise_roundtrip ##"):
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
+            torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input)
+        )
 
 
 ############################ pooled regroup configs ###################################

--- a/torchrec/sparse/tests/test_triton_quantized_comm.py
+++ b/torchrec/sparse/tests/test_triton_quantized_comm.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+import unittest
+from typing import TYPE_CHECKING
+
+import torch
+from parameterized import parameterized
+
+_TESTS_SUPPORTED = torch.cuda.is_available() and sys.version_info < (3, 15)
+
+if TYPE_CHECKING or _TESTS_SUPPORTED:
+    from torchrec.sparse.triton_quantized_comm import (
+        triton_float_to_fused8bitrowwise_quantized,
+        triton_fused8bitrowwise_quantized_to_float,
+    )
+
+if _TESTS_SUPPORTED:
+    try:
+        torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    except OSError:
+        pass
+
+
+def _make_invalid_quantize_input(case: str) -> tuple[torch.Tensor, str]:
+    if case == "cpu":
+        return torch.empty(2, 4), "CUDA tensor"
+    if case == "non_contiguous":
+        return torch.empty(4, 2, device="cuda").t(), "contiguous"
+    if case == "wrong_dtype":
+        return torch.empty(2, 4, dtype=torch.float16, device="cuda"), "torch.float32"
+    if case == "scalar":
+        return torch.empty((), device="cuda"), "at least one dimension"
+    return torch.empty(1, 4097, device="cuda"), "cannot exceed 4096"
+
+
+def _make_invalid_dequantize_input(case: str) -> tuple[torch.Tensor, str]:
+    if case == "cpu":
+        return torch.empty(2, 12, dtype=torch.uint8), "CUDA tensor"
+    if case == "non_contiguous":
+        return torch.empty(12, 2, dtype=torch.uint8, device="cuda").t(), "contiguous"
+    if case == "wrong_dtype":
+        return torch.empty(2, 12, device="cuda"), "torch.uint8"
+    if case == "scalar":
+        return (
+            torch.empty((), dtype=torch.uint8, device="cuda"),
+            "at least one dimension",
+        )
+    columns = 4 if case == "too_narrow" else 10
+    return (
+        torch.empty(2, columns, dtype=torch.uint8, device="cuda"),
+        "multiple of four and at least eight",
+    )
+
+
+@unittest.skipUnless(_TESTS_SUPPORTED, "CUDA and Python below 3.15 are required")
+class TritonQuantizedCommTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            ("single_row", 1, 32),
+            ("narrow_unaligned", 20, 31),
+            ("wide_unaligned", 21, 33),
+            ("many_rows", 4096, 32),
+            ("medium_width", 257, 128),
+            ("wide", 257, 1024),
+            ("one_column", 20, 1),
+            ("two_columns", 20, 2),
+        )
+    )
+    def test_matches_fbgemm(self, _name: str, num_rows: int, num_columns: int) -> None:
+        input = torch.randn(
+            num_rows,
+            num_columns,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        actual_quantized = triton_float_to_fused8bitrowwise_quantized(input)
+        expected_quantized = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input)
+        payload_columns = (num_columns + 3) // 4 * 4
+        torch.testing.assert_close(
+            actual_quantized[:, :num_columns],
+            expected_quantized[:, :num_columns],
+            rtol=0,
+            atol=1,
+        )
+        torch.testing.assert_close(
+            actual_quantized[:, payload_columns:].view(torch.float32),
+            expected_quantized[:, payload_columns:].view(torch.float32),
+            rtol=1e-6,
+            atol=1e-8,
+        )
+
+        actual = triton_fused8bitrowwise_quantized_to_float(expected_quantized)
+        expected = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(expected_quantized)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=1e-6)
+
+    def test_constant_rows(self) -> None:
+        input = torch.full((37, 32), 2.5, device="cuda")
+        quantized = triton_float_to_fused8bitrowwise_quantized(input)
+        output = triton_fused8bitrowwise_quantized_to_float(quantized)
+        torch.testing.assert_close(output, input, rtol=0, atol=0)
+
+    def test_empty_rows(self) -> None:
+        input = torch.empty(0, 32, device="cuda")
+        quantized = triton_float_to_fused8bitrowwise_quantized(input)
+        self.assertEqual(quantized.shape, (0, 40))
+        self.assertEqual(
+            triton_fused8bitrowwise_quantized_to_float(quantized).shape,
+            input.shape,
+        )
+
+    def test_empty_columns(self) -> None:
+        input = torch.empty(3, 0, device="cuda")
+        quantized = triton_float_to_fused8bitrowwise_quantized(input)
+        self.assertEqual(quantized.shape, (3, 8))
+        torch.testing.assert_close(quantized, torch.zeros_like(quantized))
+
+    @parameterized.expand(
+        (("cpu",), ("non_contiguous",), ("wrong_dtype",), ("scalar",), ("too_wide",))
+    )
+    def test_quantize_rejects_invalid_input(self, case: str) -> None:
+        input, message = _make_invalid_quantize_input(case)
+        with self.assertRaisesRegex(ValueError, message):
+            triton_float_to_fused8bitrowwise_quantized(input)
+
+    @parameterized.expand(
+        (
+            ("cpu",),
+            ("non_contiguous",),
+            ("wrong_dtype",),
+            ("scalar",),
+            ("too_narrow",),
+            ("unaligned",),
+        )
+    )
+    def test_dequantize_rejects_invalid_input(self, case: str) -> None:
+        input, message = _make_invalid_dequantize_input(case)
+        with self.assertRaisesRegex(ValueError, message):
+            triton_fused8bitrowwise_quantized_to_float(input)
+
+    def test_compile(self) -> None:
+        input = torch.randn(64, 32, device="cuda")
+        quantize = torch.compile(
+            triton_float_to_fused8bitrowwise_quantized,
+            backend="aot_eager",
+            fullgraph=True,
+        )
+        dequantize = torch.compile(
+            triton_fused8bitrowwise_quantized_to_float,
+            backend="aot_eager",
+            fullgraph=True,
+        )
+        quantized = quantize(input)
+        actual = dequantize(quantized)
+        expected = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
+            torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input)
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=1e-6)

--- a/torchrec/sparse/triton_quantized_comm.py
+++ b/torchrec/sparse/triton_quantized_comm.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+_MAX_COLUMNS = 4096
+
+
+@triton.jit
+# Triton TR001: row width determines the reduction tile and launch shape.
+def _float_to_fused8bitrowwise_kernel(  # noqa: TR001
+    input,
+    output,
+    output_qparams,
+    num_rows,
+    num_columns,
+    output_columns,
+    qparam_columns,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_COLUMNS: tl.constexpr,
+) -> None:
+    row_ids = tl.program_id(0).to(tl.int64) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    rows = row_ids[:, None]
+    columns = tl.arange(0, BLOCK_COLUMNS)[None, :]
+    row_mask = rows < num_rows
+    value_mask = row_mask & (columns < num_columns)
+    values = tl.load(
+        input + rows * num_columns + columns,
+        mask=value_mask,
+        other=0.0,
+    ).to(tl.float32)
+    minimum = tl.min(tl.where(value_mask, values, float("inf")), axis=1)
+    maximum = tl.max(tl.where(value_mask, values, -float("inf")), axis=1)
+    value_range = maximum - minimum
+    inverse_scale = 255.0 / (value_range + 1.0e-20)
+    quantized = tl.floor((values - minimum[:, None]) * inverse_scale[:, None] + 0.5)
+    payload_mask = row_mask & (columns < output_columns - 8)
+    tl.store(
+        output + rows * output_columns + columns,
+        tl.where(value_mask, quantized, 0).to(tl.uint8),
+        mask=payload_mask,
+    )
+    qparam_offsets = row_ids * qparam_columns + (output_columns - 8) // 4
+    tl.store(
+        output_qparams + qparam_offsets,
+        value_range / 255.0,
+        mask=row_ids < num_rows,
+    )
+    tl.store(
+        output_qparams + qparam_offsets + 1,
+        minimum,
+        mask=row_ids < num_rows,
+    )
+
+
+@triton.jit
+# Triton TR001: dequantization is a single fixed streaming tile.
+def _fused8bitrowwise_to_float_kernel(  # noqa: TR001
+    input,
+    input_qparams,
+    output,
+    numel,
+    input_columns,
+    output_columns,
+    qparam_columns,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    rows = offsets // output_columns
+    columns = offsets % output_columns
+    qparam_offsets = rows * qparam_columns + output_columns // 4
+    scale = tl.load(input_qparams + qparam_offsets, mask=mask)
+    bias = tl.load(input_qparams + qparam_offsets + 1, mask=mask)
+    quantized = tl.load(
+        input + rows * input_columns + columns,
+        mask=mask,
+        other=0,
+    ).to(tl.float32)
+    tl.store(output + offsets, quantized * scale + bias, mask=mask)
+
+
+def _validate_quantize_input(input: torch.Tensor) -> None:
+    if not input.is_cuda:
+        raise ValueError("input must be a CUDA tensor")
+    if not input.is_contiguous():
+        raise ValueError("input must be contiguous")
+    if input.dtype != torch.float32:
+        raise ValueError("input must have dtype torch.float32")
+    if input.ndim == 0:
+        raise ValueError("input must have at least one dimension")
+    if input.shape[-1] > _MAX_COLUMNS:
+        raise ValueError(f"input row width cannot exceed {_MAX_COLUMNS}")
+
+
+def _validate_dequantize_input(input: torch.Tensor) -> None:
+    if not input.is_cuda:
+        raise ValueError("input must be a CUDA tensor")
+    if not input.is_contiguous():
+        raise ValueError("input must be contiguous")
+    if input.dtype != torch.uint8:
+        raise ValueError("input must have dtype torch.uint8")
+    if input.ndim == 0:
+        raise ValueError("input must have at least one dimension")
+    if input.shape[-1] < 8 or input.shape[-1] % 4 != 0:
+        raise ValueError(
+            "input row width must be a multiple of four and at least eight"
+        )
+
+
+@torch.library.custom_op(
+    "torchrec::triton_float_to_fused8bitrowwise_quantized",
+    mutates_args=(),
+)
+def triton_float_to_fused8bitrowwise_quantized(
+    input: torch.Tensor,
+) -> torch.Tensor:
+    _validate_quantize_input(input)
+    num_columns = input.shape[-1]
+    payload_columns = (num_columns + 3) // 4 * 4
+    output_columns = payload_columns + 8
+    output = torch.empty(
+        (*input.shape[:-1], output_columns),
+        dtype=torch.uint8,
+        device=input.device,
+    )
+    num_rows = output.numel() // output_columns
+    if num_rows == 0:
+        return output
+    if num_columns == 0:
+        return output.zero_()
+
+    block_columns = max(4, triton.next_power_of_2(num_columns))
+    block_rows = max(1, min(8, 256 // block_columns))
+    _float_to_fused8bitrowwise_kernel[(triton.cdiv(num_rows, block_rows),)](
+        input,
+        output,
+        output.view(torch.float32),
+        num_rows,
+        num_columns,
+        output_columns,
+        output_columns // 4,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_ROWS=block_rows,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_COLUMNS=block_columns,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=min(8, max(1, block_columns // 32)),
+    )
+    return output
+
+
+@triton_float_to_fused8bitrowwise_quantized.register_fake
+def _fake_float_to_fused8bitrowwise_quantized(
+    input: torch.Tensor,
+) -> torch.Tensor:
+    output_columns = (input.shape[-1] + 3) // 4 * 4 + 8
+    return input.new_empty((*input.shape[:-1], output_columns), dtype=torch.uint8)
+
+
+@torch.library.custom_op(
+    "torchrec::triton_fused8bitrowwise_quantized_to_float",
+    mutates_args=(),
+)
+def triton_fused8bitrowwise_quantized_to_float(
+    input: torch.Tensor,
+) -> torch.Tensor:
+    _validate_dequantize_input(input)
+    input_columns = input.shape[-1]
+    output_columns = input_columns - 8
+    output = torch.empty(
+        (*input.shape[:-1], output_columns),
+        dtype=torch.float32,
+        device=input.device,
+    )
+    if output.numel() == 0:
+        return output
+
+    _fused8bitrowwise_to_float_kernel[(triton.cdiv(output.numel(), 512),)](
+        input,
+        input.view(torch.float32),
+        output,
+        output.numel(),
+        input_columns,
+        output_columns,
+        input_columns // 4,
+        # pyrefly: ignore[bad-argument-type]
+        BLOCK_SIZE=512,
+        # pyrefly: ignore[unexpected-keyword]
+        num_warps=8,
+    )
+    return output
+
+
+@triton_fused8bitrowwise_quantized_to_float.register_fake
+def _fake_fused8bitrowwise_quantized_to_float(
+    input: torch.Tensor,
+) -> torch.Tensor:
+    return input.new_empty(
+        (*input.shape[:-1], input.shape[-1] - 8), dtype=torch.float32
+    )


### PR DESCRIPTION
Summary:

- Add standalone Triton implementations for FloatToFused8BitRowwiseQuantized and Fused8BitRowwiseQuantizedToFloat.
- Register fake implementations for compile support and add CUDA correctness coverage against FBGEMM.
- Extend the shared TorchRec Triton benchmark with quantize, dequantize, and round-trip modes.
- Leave the production qcomm codec unchanged; this diff establishes correctness and performance first.

The quantizer fuses row reduction, qparam generation, portable nearest-integer conversion, payload writes, and qparam writes into one launch. FBGEMM quantization uses two GPU kernels for these row counts. The dequantizer uses a flat streaming kernel. Launch geometry is derived from row width rather than selected by autotune.

Benchmark setup:
- NVIDIA H100; bandwidth percentages use 2.40 TB/s peak.
- Stable Triton 3.5.0+fb, opt build, 100 timed iterations, p50 reported.
- 10 profiler iterations per linked trace.
- Ideal traffic counts input and final output bytes; FBGEMM quantization additionally rereads input and writes/reads a temporary range tensor, so its actual traffic is higher.
- [All uploaded traces](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D118954986)

| Shape | Operation | Ideal traffic | Triton p50 | FBGEMM p50 | Speedup | Triton bandwidth | FBGEMM bandwidth |
| --- | --- | --- | --- | --- | --- | --- | --- |
| R=1,048,576; D=32 | Quantize | 0.176 GB | [0.08 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_triton_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.33 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_fbgemm_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 4.13x | 2.202 TB/s; 91.8% | 0.534 TB/s; 22.2% |
| R=1,048,576; D=32 | Dequantize | 0.176 GB | [0.09 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_triton_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.11 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_fbgemm_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.22x | 1.957 TB/s; 81.6% | 1.601 TB/s; 66.7% |
| R=1,048,576; D=32 | Round trip | 0.352 GB | [0.18 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_triton_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.43 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_fbgemm_d32_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.39x | 1.957 TB/s; 81.6% | 0.819 TB/s; 34.1% |
| R=1,048,576; D=128 | Quantize | 0.679 GB | [0.43 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_triton_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.94 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_fbgemm_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.19x | 1.580 TB/s; 65.8% | 0.723 TB/s; 30.1% |
| R=1,048,576; D=128 | Dequantize | 0.679 GB | [0.35 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_triton_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.39 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_fbgemm_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.11x | 1.941 TB/s; 80.9% | 1.742 TB/s; 72.6% |
| R=1,048,576; D=128 | Round trip | 1.359 GB | [0.78 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_triton_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | [1.33 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_fbgemm_d128_r1048576-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.71x | 1.742 TB/s; 72.6% | 1.022 TB/s; 42.6% |
| R=262,144; D=1024 | Quantize | 1.344 GB | [0.63 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_triton_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | [1.67 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_fbgemm_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.65x | 2.134 TB/s; 88.9% | 0.805 TB/s; 33.5% |
| R=262,144; D=1024 | Dequantize | 1.344 GB | [0.70 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_triton_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | [0.79 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_fbgemm_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.13x | 1.920 TB/s; 80.0% | 1.702 TB/s; 70.9% |
| R=262,144; D=1024 | Round trip | 2.689 GB | [1.34 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_triton_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | [2.47 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_fbgemm_d1024_r262144-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.84x | 2.006 TB/s; 83.6% | 1.088 TB/s; 45.4% |
| R=40,000,000; D=32 | Quantize | 6.720 GB | [3.02 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_triton_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [12.23 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_fbgemm_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 4.05x | 2.225 TB/s; 92.7% | 0.549 TB/s; 22.9% |
| R=40,000,000; D=32 | Dequantize | 6.720 GB | [3.45 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_triton_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [4.12 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_fbgemm_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.19x | 1.948 TB/s; 81.2% | 1.631 TB/s; 68.0% |
| R=40,000,000; D=32 | Round trip | 13.440 GB | [6.48 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_triton_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [16.35 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_fbgemm_d32_r40000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.52x | 2.074 TB/s; 86.4% | 0.822 TB/s; 34.3% |
| R=2,000,000; D=1024 | Quantize | 10.256 GB | [4.87 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_triton_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [11.83 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_quantize_fbgemm_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 2.43x | 2.106 TB/s; 87.7% | 0.867 TB/s; 36.1% |
| R=2,000,000; D=1024 | Dequantize | 10.256 GB | [5.34 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_triton_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [5.92 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_dequantize_fbgemm_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.11x | 1.921 TB/s; 80.0% | 1.732 TB/s; 72.2% |
| R=2,000,000; D=1024 | Round trip | 20.512 GB | [10.23 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_triton_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | [17.75 ms](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118954986/trace-fused_8bit_rowwise_roundtrip_fbgemm_d1024_r2000000-rank0.json.gz&bucket=torchrec_benchmark_traces) | 1.74x | 2.005 TB/s; 83.5% | 1.156 TB/s; 48.2% |

All selected meaningful-volume comparisons improve over FBGEMM: quantization by 2.19–4.13x, dequantization by 1.11–1.22x, and round trip by 1.71–2.52x. The largest cases sustain 80.0–92.7% of the stated H100 peak.

The D32 comparison is capped at R=40,000,000 because the current FBGEMM setup overflows signed 32-bit indexing near a 10 GB FP32 input. The D1024 case provides a valid 10.256 GB per-operation and 20.512 GB round-trip comparison. Results and launch choices are H100-specific measurements; A100 and B200 validation should precede production integration.

Reviewed By: xywang9334

Differential Revision: D118954986


