### PR TITLE
Extend gradient accumulation to multi-micro-batch windows + bucket-view accumulation

### DIFF
--- a/torchrec/distributed/train_pipeline/gradient_accumulation.py
+++ b/torchrec/distributed/train_pipeline/gradient_accumulation.py
@@ -16,8 +16,20 @@ This module provides:
 """
 
 import contextlib
+import logging
 from dataclasses import dataclass
-from typing import Any, ContextManager, Generic, Iterator, Optional, TYPE_CHECKING
+from enum import Enum
+from typing import (
+    Any,
+    cast,
+    ContextManager,
+    Final,
+    Generic,
+    Iterator,
+    Optional,
+    Protocol,
+    TYPE_CHECKING,
+)
 
 import torch
 from torch.nn.parallel import DistributedDataParallel
@@ -25,6 +37,130 @@ from torchrec.distributed.train_pipeline.pipeline_context import In, Out
 
 if TYPE_CHECKING:
     from torchrec.distributed.train_pipeline.train_pipelines import TrainPipeline
+
+
+class GAWindowObserver(Protocol):
+    """Notified once per micro-batch, immediately before the inner ``progress()``.
+
+    For pipelines whose sparse/dense sub-steps or grad-clip bypass the GA-wrapped
+    optimizer and so must gate on the same boundary the wrapper uses. Supplied explicitly
+    at wrapper construction: the wrapper never writes state onto the pipeline it wraps.
+    Keyword-only so the two booleans cannot be transposed.
+
+    Not called when GA is disabled -- that path is a pure pass-through, and the observer's
+    owner keeps whatever default it initialised.
+    """
+
+    def __call__(self, *, should_step: bool, at_window_start: bool) -> None: ...
+
+
+class _GAPipelineHooks(Protocol):
+    """The surface the GA wrapper drives on the pipeline it wraps.
+
+    ``TrainPipeline`` does not declare ``attach``, so naming the surface lets the one call
+    site be a plain attribute access instead of ``getattr``.
+    """
+
+    def attach(
+        self, model: Optional[torch.nn.Module] = None, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
+
+# Capability marker for the APS config-time eval-GA guard
+# (aps_models/ads/common/train_pipeline.py), which fail-fasts when GA and scheduled
+# in-trainer eval are both on and this is False. Not a config knob: no torchrec reader,
+# never assigned at runtime. It records that _advance_state is gated on model.training, so
+# an eval interlude reusing the GA progress() path cannot desync the K-micro window.
+# If that gating is reverted set this False -- do NOT delete it, which breaks the APS
+# import instead of activating the guard.
+GA_EVAL_COUNTER_SAFE: Final[bool] = True
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _ga_abort_all_process_groups(reason: str) -> None:
+    """Tear down every process group before a rank-LOCAL raise on a collective-bearing
+    boundary.
+
+    The partial-window guards raise on the rank that detects the problem. At
+    ``world_size > 1`` its peers would otherwise block in the next collective until the
+    NCCL watchdog fires ~30 minutes later, with the timeout masking the real cause.
+
+    Best-effort, and effective only on NCCL: ``_abort_process_group`` is experimental,
+    documented NCCL-only, and expects ``TORCH_NCCL_ASYNC_ERROR_HANDLING=0``. On other
+    backends the abort may fail and peers are not torn down; the raise still stands.
+
+    Not gated on the backend: ``get_backend()`` reports only the default PG while
+    ``_abort_process_group(None)`` aborts all of them, and a composite
+    ``cpu:gloo,cuda:nccl`` config does not equal ``"nccl"`` -- a gate would skip the abort
+    on hybrid jobs that need it.
+
+    A no-op at ``world_size <= 1`` (no peers to strand), so call sites need no guard.
+    A failure to abort must never mask the raise that follows.
+    """
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return
+    if torch.distributed.get_world_size() <= 1:
+        return
+    logger.error(
+        f"[gradient_accumulation] aborting all process groups before raising: {reason}"
+    )
+    try:
+        torch.distributed.distributed_c10d._abort_process_group(None)
+    except Exception:
+        # `_abort_process_group(None)` resolves `pg = group or GroupMember.WORLD` and raises
+        # AssertionError when that is None. Log loudly rather than silently: at this point the
+        # peers were NOT torn down and the fail-closed guarantee does not hold. See the SPL
+        # boundary-hardening journal, NR-10.
+        logger.exception(
+            "[gradient_accumulation] _abort_process_group FAILED -- peers were NOT torn "
+            "down; the raise that follows is rank-local and may strand them"
+        )
+
+
+class PartialWindowPolicy(Enum):
+    """Caller policy for a partial (r < K) gradient-accumulation window.
+
+    A partial final window means the total micro-batch count was not a whole multiple of
+    ``num_steps`` (K).
+
+    ``STEP`` and ``RAISE`` ONLY select what happens at world_size <= 1, where the local
+    grads ARE the full window (no replicas to diverge). At world_size > 1 both of them
+    fail-closed (abort the process groups, then raise): stepping un-reduced rank-local
+    grads without a cross-rank reduce would diverge replicas.
+
+      - ``STEP`` (default; preserves the historical single-process behavior): take the
+        sanctioned in-band optimizer step + zero_grad on the partial window.
+      - ``RAISE``: fail-closed even at world_size <= 1 so a caller that requires K-divisible
+        data (e.g. APS) is told loudly instead of silently training on a smaller final batch.
+
+    ``DISCARD`` is different in kind: it applies at EVERY world size, and is the only
+    policy that makes a partial window a normal, non-fatal ending.
+
+      - ``DISCARD``: on ITERATOR EXHAUSTION, throw the partial window's accumulated
+        gradients away rank-locally -- no optimizer step, no collective, no process-group
+        abort -- and let the caller's ``StopIteration`` propagate. Correct ONLY for callers
+        that have established cross-rank agreement on exhaustion out of band (so every rank
+        discards together, keeping replicas identical) and that accept losing up to K-1
+        micro-batches at the end of a phase. This is what unlocks consume-all
+        (``num_batches < 0``) under GA.
+
+    SCOPE OF ``DISCARD`` -- exhaustion only, by design. An explicit ``is_last_batch=True``
+    partial window does NOT discard: it still commits IN-BAND via the forced step in
+    ``progress()``, exactly as under ``STEP``. That is deliberate and is the better outcome,
+    not an oversight -- ``is_last_batch`` forces ``should_sync``, so the backward runs
+    outside ``no_sync`` and the partial window's gradients ARE cross-rank reduced. The
+    result is replica-safe at any world size AND keeps the data, whereas discarding would
+    throw away up to K-1 micro-batches for no safety gain. ``DISCARD`` exists precisely for
+    the case where that information is NOT available (nobody knows which batch is last until
+    the iterator is already empty). ``RAISE`` is the one policy that also fences the explicit
+    path, because a RAISE caller is asserting K-divisibility rather than asking for a
+    best-effort ending.
+    """
+
+    STEP = "step"
+    RAISE = "raise"
+    DISCARD = "discard"
 
 
 @dataclass
@@ -35,12 +171,26 @@ class GradientAccumulationConfig:
     Attributes:
         is_enabled: Whether gradient accumulation is enabled.
         num_steps: Number of micro-batches to accumulate before optimizer step.
-        num_warmup_steps: Number of warmup steps where all iterations sync.
+        num_warmup_steps: Number of warmup MICRO-steps (NOT logical/optimizer
+            steps) during which every iteration syncs gradients. Counted against
+            the global micro counter (current_step), so with num_steps=K a value
+            of W means the first W micro-batches sync (~the first ceil(W/K)
+            logical windows). Default 1 (only the very first micro).
     """
 
     is_enabled: bool = False
     num_steps: int = 1
     num_warmup_steps: int = 1
+    # Zero dense grads in place at window-start instead of set_to_none=True, preserving
+    # the DDP gradient_as_bucket_view alias so autograd accumulates into the persistent
+    # reduction bucket rather than allocating a standalone dense .grad set held across
+    # the K-micro window (~1x dense-grad-size of extra HBM). Callers that construct this
+    # dataclass directly get OFF; the APS layer resolves it from a tri-state config (see
+    # aps_models.ads.common.gradient_accumulation.config.resolve_accumulate_into_buckets,
+    # which derives ON at K>1). Semantic delta vs OFF: a dense param holding a live
+    # bucket-view grad at window start but unused through the window keeps a present zero
+    # instead of None, so a dense optimizer sees participate-on-zero rather than skip.
+    accumulate_into_buckets: bool = False
 
     def __post_init__(self) -> None:
         if self.num_steps < 1:
@@ -74,11 +224,37 @@ class _GAOptimizerWrapper:
         self._optimizer = optimizer
         self._config = config
         self._current_step: int = 0
+        # Anchor of the CURRENT K-window within the global micro counter. The
+        # optimizer-step / grad-sync / window-start boundaries are all computed relative
+        # to this anchor (steps_in_window), not to _current_step, so that re-anchoring on
+        # an iterator exhaustion (realign_window) restarts the window without disturbing
+        # the counter's monotonic contract or replaying num_warmup_steps.
+        self._window_base: int = 0
         self._needs_zero_grad: bool = True
+        # One-shot: when True, step() fires even off the schedule boundary. Used to
+        # force an in-band optimizer step on an explicit final partial window (r<K).
+        self._force_step: bool = False
+        # Backref to the owning GradientAccumulationWrapper, set right after
+        # construction. When accumulate_into_buckets is on, zero_grad delegates the
+        # window-start zero to the outer wrapper's selective bucket-view-preserving
+        # protocol (it needs the model's DDP topology). None when this optimizer
+        # wrapper is used standalone (unit tests) -> plain None-path zero.
+        self._ga_wrapper: Optional["GradientAccumulationWrapper[Any, Any]"] = None
+
+    @property
+    def steps_in_window(self) -> int:
+        """Micro-batches consumed since the latest window anchor.
+
+        NOT bounded to ``[0, num_steps)``: the anchor moves only on ``realign_window()``
+        (iterator exhaustion / explicit last batch), ``set_step()`` and ``reset()``, so
+        within one continuous phase this grows without bound exactly like
+        ``_current_step``. Only its residue mod ``num_steps`` is meaningful.
+        """
+        return self._current_step - self._window_base
 
     def _should_step(self) -> bool:
         """Returns True if optimizer.step() should actually execute."""
-        return (self._current_step + 1) % self._config.num_steps == 0
+        return (self.steps_in_window + 1) % self._config.num_steps == 0
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         """
@@ -86,16 +262,35 @@ class _GAOptimizerWrapper:
 
         Uses the _needs_zero_grad flag to ensure proper timing regardless of
         when zero_grad is called in the pipeline execution order.
+
+        When ``accumulate_into_buckets`` is set (and the owning wrapper is present),
+        the window-start zero is delegated to
+        ``GradientAccumulationWrapper._window_start_zero_grad``, which preserves the
+        DDP ``gradient_as_bucket_view`` alias so autograd accumulates into the
+        persistent reduction bucket instead of allocating a standalone dense ``.grad``
+        set held across the K-micro no_sync window. Otherwise (feature off, or the
+        wrapper is used standalone) it delegates to the real optimizer's zero_grad.
         """
-        if self._needs_zero_grad:
+        if not self._needs_zero_grad:
+            return
+        if self._config.accumulate_into_buckets and self._ga_wrapper is not None:
+            # The incoming set_to_none is intentionally NOT forwarded: the selective
+            # protocol has fixed semantics -- the first-window / not-ready path and every
+            # non-target leaf use set_to_none=True (the real-optimizer tree-clear), while
+            # ready bucket-view targets are retained and zeroed in place (alias-preserving).
+            self._ga_wrapper._window_start_zero_grad()
+        else:
             self._optimizer.zero_grad(set_to_none=set_to_none)
-            self._needs_zero_grad = False
+        self._needs_zero_grad = False
 
     def step(self, *args: Any, **kwargs: Any) -> None:
         """
-        Intercepts step to execute only at accumulation boundaries.
+        Intercepts step to execute only at accumulation boundaries, or when a
+        one-shot forced step is requested (an explicit last batch whose partial
+        window is not on the schedule boundary -- see
+        GradientAccumulationWrapper.progress).
         """
-        if self._should_step():
+        if self._should_step() or self._force_step:
             self._optimizer.step(*args, **kwargs)
             self._needs_zero_grad = True
 
@@ -106,11 +301,36 @@ class _GAOptimizerWrapper:
     def reset(self) -> None:
         """Resets the internal step counter and zero_grad flag."""
         self._current_step = 0
+        self._window_base = 0
         self._needs_zero_grad = True
+        self._force_step = False
+
+    def realign_window(self) -> None:
+        """Re-anchor the K-window at the current micro counter.
+
+        Called when a data iterator is exhausted: a phase that consumed a non-multiple of
+        K micro-batches would otherwise leave the free-running counter off-modulo and
+        shift every SUBSEQUENT window's boundary off the trainer's logical step. Moving
+        the anchor (rather than zeroing ``_current_step``) keeps ``current_step``
+        monotonic for its public accessor AND keeps ``num_warmup_steps`` counted against
+        the global counter, so warmup is not replayed on each new iterator.
+        """
+        self._window_base = self._current_step
 
     def set_step(self, step: int) -> None:
-        """Sets the internal step counter. Use this instead of directly modifying _current_step."""
+        """Sets the internal step counter. Use this instead of directly modifying _current_step.
+
+        Also drops the window anchor back to 0: callers place the wrapper at a specific
+        point in the accumulation cycle and expect plain ``(step + 1) % K`` semantics on
+        the raw value. Without this, a preceding realign_window() would leave a stale base
+        and make steps_in_window disagree with the step the caller just set.
+
+        No validation is added here (this method's contract predates the anchor): a
+        negative ``step`` still yields a negative ``steps_in_window``, exactly as it
+        already yielded a negative ``current_step``.
+        """
         self._current_step = step
+        self._window_base = 0
 
     def __getattr__(self, name: str) -> Any:
         """Proxy all other attributes to the wrapped optimizer."""
@@ -139,16 +359,78 @@ class GradientAccumulationWrapper(Generic[In, Out]):
         optimizer: torch.optim.Optimizer,
         model: torch.nn.Module,
         config: GradientAccumulationConfig,
+        partial_window_policy: PartialWindowPolicy = PartialWindowPolicy.STEP,
+        window_observer: Optional[GAWindowObserver] = None,
     ) -> None:
         self._pipeline = pipeline
         self._model = model
         self._config = config
+        # Boundary signal for a pipeline whose sub-steps bypass the wrapped optimizer.
+        # Explicit rather than inferred: a pipeline that needs it opts in here, so a
+        # rename is a type error instead of a silent fall back to stepping every micro.
+        self._window_observer = window_observer
+        # Caller policy for a partial (r < K) final window at world_size <= 1 (read in
+        # _flush_accumulated_gradients). world_size > 1 ALWAYS fail-closes regardless.
+        self._partial_window_policy = partial_window_policy
         self._optimizer_wrapper = _GAOptimizerWrapper(optimizer, config)
+        # Backref so the optimizer wrapper's zero_grad can delegate the selective
+        # window-start zero (accumulate_into_buckets) back here, where the model's
+        # DDP topology is discoverable.
+        self._optimizer_wrapper._ga_wrapper = self
         self._cached_ddp_modules: list[Any] | None = None
+        # True after a non-boundary micro left accumulated-but-un-stepped gradients;
+        # gates the StopIteration flush so an in-band-committed window is not re-stepped.
+        self._pending_uncommitted: bool = False
+        # Component 2 (selective retain readiness). True once a synchronized training
+        # backward has established the DDP gradient_as_bucket_view aliases. Gates the
+        # selective window-start zero so the FIRST window -- before any views exist --
+        # uses a plain set_to_none clear (also clears APF dummy grads and avoids the
+        # detach-on-view crash that only exists post-alias). Intentionally survives
+        # reset() (same model + DDP instances remain alive; the module tree is static post
+        # construction -- see _get_ddp_modules). attach() rejects a model swap, so a live
+        # wrapper's DDP topology + readiness can never become stale.
+        self._bucket_views_ready: bool = False
+        # Warn-once keys for leaves excluded from the alias-preserving window-start zero.
+        # See _warn_bucket_view_skip.
+        self._warned_bucket_view_skips: set[str] = set()
 
         # Only replace optimizer in pipeline when GA is enabled
         # This avoids unintended side effects when GA is disabled
-        if config.is_enabled and hasattr(pipeline, "_optimizer"):
+        if config.is_enabled:
+            if not hasattr(pipeline, "_optimizer"):
+                # Fail-closed on exactly ONE hole: a pipeline that exposes no _optimizer
+                # at all. Previously the injection was silently skipped, so GA quietly
+                # provided no optimizer-step gating whatsoever while the caller believed
+                # gradients were accumulating over K.
+                #
+                # SCOPE: hasattr("_optimizer") is necessary, NOT sufficient. A pipeline can
+                # expose _optimizer, accept this replacement, and still step a separately
+                # captured optimizer reference. Closing that requires a GA capability /
+                # rebind contract on TrainPipeline; this guard does not attempt it. Nor does
+                # it claim to know what an _optimizer-less pipeline does instead -- only
+                # that this wrapper's gating injection point is absent.
+                raise RuntimeError(
+                    "Gradient accumulation is enabled but the wrapped pipeline "
+                    f"{type(pipeline).__name__} exposes no `_optimizer` attribute, so the "
+                    "GA optimizer wrapper cannot be injected and optimizer-step gating to "
+                    f"one step per {config.num_steps}-micro window cannot be guaranteed. "
+                    "Use a pipeline that exposes `_optimizer` (e.g. "
+                    "TrainPipelineSparseDist), or disable gradient accumulation."
+                )
+            if isinstance(getattr(pipeline, "_optimizer", None), _GAOptimizerWrapper):
+                # Already GA-wrapped. Replacing again would nest the gates: the outer
+                # wrapper's step() would reach the inner one, which gates again, so the
+                # real optimizer would step once per K**2 micro-batches instead of once
+                # per K -- silent under-stepping, not a crash. There is no unwrap path,
+                # so no legitimate caller reaches this.
+                raise RuntimeError(
+                    "Gradient accumulation is enabled but the wrapped pipeline "
+                    f"{type(pipeline).__name__} already has a GA-wrapped `_optimizer`, so "
+                    "this pipeline is being wrapped a second time. Nesting the wrappers "
+                    "would gate the optimizer to one step per "
+                    f"{config.num_steps}**2 micro-batches instead of per "
+                    f"{config.num_steps}. Wrap each pipeline exactly once."
+                )
             # pyrefly: ignore[missing-attribute]: pipeline may not have _optimizer
             pipeline._optimizer = self._optimizer_wrapper
 
@@ -176,8 +458,10 @@ class GradientAccumulationWrapper(Generic[In, Out]):
         if self.current_step < self._config.num_warmup_steps:
             return True
 
-        # Sync on the last step of each accumulation cycle
-        return (self.current_step + 1) % self._config.num_steps == 0
+        # Sync on the last step of each accumulation cycle. Window-relative (unlike the
+        # two job-lifetime guards above): an iterator exhaustion re-anchors the window, and
+        # the grad-sync boundary must move with it or DDP would sync on the wrong micro.
+        return (self.steps_in_window + 1) % self._config.num_steps == 0
 
     def _get_no_sync_context(self) -> ContextManager[None]:
         """
@@ -185,11 +469,16 @@ class GradientAccumulationWrapper(Generic[In, Out]):
         synchronization on **all** ``DistributedDataParallel`` modules in the
         model tree, not just the outermost one.
 
-        Some sharded submodules — notably ``ShardedVariableLengthEmbeddingArch``
-        — wrap their DATA_PARALLEL lookups in their own internal DDP instances.
-        If ``no_sync()`` is only called on the outer DDP, those inner DDP
-        modules will still all-reduce on every backward pass, breaking gradient
-        accumulation for those parameters.
+        Some sharded submodules wrap their DATA_PARALLEL lookups in their own internal
+        DDP instances. Inner DDPs that are REGISTERED submodules (in ``_modules``) are
+        discovered by the ``root.modules()`` walk in ``_get_ddp_modules`` and entered via
+        ``no_sync()`` here. NOTE: ``ShardedVariableLengthEmbeddingArch`` stores its lookup
+        DDPs in a PLAIN Python list (``self._lookups``), NOT an ``nn.ModuleList``, so those
+        DDPs are NOT in ``_modules`` and are NOT discovered -- they all-reduce EVERY micro
+        (numerically correct under GA: mean-all-reduce is linear + idempotent on an
+        already-reduced tensor; no standalone-grad duplication, but no no_sync comm saving
+        either). A plain-list -> ``nn.ModuleList`` migration would silently change this;
+        test_ga_bucket_view_alias guards the plain-list-not-discovered contract.
 
         This method uses a cached list of DDP modules (computed once on first
         call) and composes their ``no_sync()`` contexts with
@@ -243,10 +532,12 @@ class GradientAccumulationWrapper(Generic[In, Out]):
         if hasattr(root, "no_sync"):
             ddp_modules.append(root)
 
-        # Walk descendants for any inner DDP instances (e.g. VLE's
-        # internal DDP for DATA_PARALLEL lookups). Uses a strict
-        # isinstance check — only actual DDP modules are collected,
-        # not FSDP or other modules that happen to have no_sync.
+        # Walk descendants for any REGISTERED inner DDP instances (present in
+        # ``_modules``). Uses a strict isinstance check — only actual DDP modules are
+        # collected, not FSDP or other modules that happen to have no_sync. NOTE:
+        # ``ShardedVariableLengthEmbeddingArch`` keeps its lookup DDPs in a PLAIN list
+        # (not ``_modules``), so they are NOT collected here and reduce every micro
+        # (see the _get_no_sync_context docstring).
         # The hasattr guard is needed because root may not be an
         # nn.Module (e.g. when _dmp_wrapped_module is a non-Module
         # wrapper object and model itself lacks modules()).
@@ -278,6 +569,268 @@ class GradientAccumulationWrapper(Generic[In, Out]):
                 stack.enter_context(ddp.no_sync())
             yield
 
+    def _collect_bucket_view_targets(  # noqa: C901 — the branches ARE the eligibility contract for in-place bucket-view zeroing; splitting them would scatter a correctness gate
+        self,
+    ) -> list[tuple[torch.nn.Parameter, torch.Tensor]]:
+        """Params (+ their live bucket-view grad) eligible for in-place window-start zero.
+
+        A target is a parameter that:
+          (a) is managed by a real ``DistributedDataParallel`` that the GA wrapper
+              enters via ``no_sync()``;
+          (b) that DDP has ``gradient_as_bucket_view=True``;
+          (c) currently has a live grad (not None) that is a bucket-view alias
+              (``grad._base is not None``) with a strided (dense) layout;
+          (d) is owned by the wrapped optimizer (H1.1 ownership intersection below), so
+              the OFF-path ``optimizer.zero_grad`` would have cleared it -- ON must not
+              diverge from OFF for a DDP-reduced-but-not-optimizer-owned leaf.
+
+        NOTE (heuristic, H1.2): ``grad._base is not None`` is a CONSERVATIVE,
+        NON-AUTHORITATIVE check -- it confirms the grad is SOME view, NOT authoritatively
+        the reducer's live reduction-bucket view. The reducer's live bucket views are
+        C++-internal and not exposed to Python (``reducer.cpp``; ``init.cpp``), so a
+        reducer bucket-view cannot be distinguished from an arbitrary other view here.
+        Under ``gradient_as_bucket_view=True`` the managed dense grad IS the bucket-view
+        in the common case; we rely on that + the ownership + no_sync-DDP gating and do
+        NOT claim to reject an arbitrary non-bucket view.
+
+        Skipped (fall to the None path via the tree-clear):
+          - ``grad is None`` (permanently grad-less dense head -> MUST stay None so the
+            dense optimizer keeps skipping it: no None->zero state corruption);
+          - sparse / non-strided grad (not a dense bucket-view);
+          - params of a non-DDP root (DMP/custom/FSDP) or a non-bucket-view DDP;
+          - fp32-grad DP params (never in any ``DDP._module_parameters`` -> not seen).
+
+        DEGRADED (excluded from the target list + warn-once) on unsafe / unknown states,
+        rather than raised:
+          - a real DDP with no ``_module_parameters`` (no authoritative ownership list;
+            never broaden to ``module.parameters()``, which ignores the ignore-list);
+          - a param reduced by two DISTINCT DDP reducers (a grad can alias only one
+            reduction bucket, so an in-place zero could target the wrong one);
+          - a no_sync'd real DDP with ``find_unused_parameters=True`` (the per-iteration
+            used-parameter set is dynamic, so a dense grad zeroed in place one window may
+            be absent (None) the next -> None-vs-zero divergence for the dense optimizer
+            state);
+          - a live dense grad on an optimizer-owned bucket-view DDP param whose grad is
+            NOT a view (``grad._base is None``): unexpected standalone-grad state for a
+            ``gradient_as_bucket_view=True`` DDP (heuristic per the NOTE above; catches
+            the common "bucket-view was dropped" case, not an authoritative assertion).
+
+        WHY EXCLUSION AND NOT A RAISE. A non-target is not hidden below, so it takes the
+        real ``optimizer.zero_grad(set_to_none=True)`` tree-clear -- byte-identical to the
+        flag-OFF path. The cost of degrading is forgone HBM reclaim for those params,
+        which is precisely the default-off behaviour, i.e. strictly no worse. Two sibling
+        branches in this same loop (non-bucket-view, find_unused_parameters) already do
+        exactly this, and an empty target list short-circuits to the same clear. Raising
+        instead would convert a working GA run into a hard crash the moment
+        ``accumulate_into_buckets`` becomes the K>1 default -- trading a memory
+        optimisation for an availability regression. The skip is WARNED rather than
+        silent, because someone must not believe they are getting reclaim they are not.
+        """
+        real_ddps: list[DistributedDataParallel] = [
+            m for m in self._get_ddp_modules() if isinstance(m, DistributedDataParallel)
+        ]
+
+        # Pass 1 (ownership): map param-identity -> owning DDP across ALL real DDPs.
+        # A grad can alias only one reducer bucket, so a param
+        # reduced by two DISTINCT DDP reducers is an unsupported double-owner config ->
+        # exclude that param. _module_parameters (excludes DDP-ignored MP/FSDP params) is
+        # the authoritative ownership list; its absence on a real DDP is an unknown state
+        # -> exclude that whole DDP (never broaden to module.parameters(), which ignores
+        # the ignore-list). Both exclusions leave the affected leaves on the plain
+        # set_to_none path -- see the docstring for why that is inert.
+        owner_of: dict[int, DistributedDataParallel] = {}
+        skipped_ddp_ids: set[int] = set()
+        excluded_param_ids: set[int] = set()
+        for ddp in real_ddps:
+            module_params = getattr(ddp, "_module_parameters", None)
+            if module_params is None:
+                skipped_ddp_ids.add(id(ddp))
+                self._warn_bucket_view_skip(
+                    "missing_module_parameters",
+                    f"{type(ddp).__name__} exposes no authoritative _module_parameters "
+                    "ownership list",
+                )
+                continue
+            for p in module_params:
+                if not p.requires_grad:
+                    continue
+                prev = owner_of.get(id(p))
+                if prev is not None and prev is not ddp:
+                    excluded_param_ids.add(id(p))
+                    self._warn_bucket_view_skip(
+                        "double_ddp_ownership",
+                        f"a parameter of shape {tuple(p.shape)} is reduced by two "
+                        "distinct DistributedDataParallel reducers",
+                    )
+                    continue
+                owner_of[id(p)] = ddp
+
+        # H1.1 ownership intersection: the wrapped optimizer's owned param id-set. The
+        # OFF path clears ONLY optimizer-owned param_groups (optimizer.zero_grad), so an
+        # in-place window-start zero must touch ONLY params the optimizer owns -- a
+        # DDP-reduced-but-not-optimizer-owned param must fall to the plain path (left
+        # accumulating), else ON would zero a grad OFF leaves present -> a None-vs-present
+        # divergence for that leaf. Duck-typed on ``param_groups`` (torchrec must NOT
+        # import the apf/aps CombinedOptimizer -- layering; the apf CombinedOptimizer
+        # aggregates its sub-optimizers' param_groups). Empty owned-set -> no targets ->
+        # plain path everywhere (inert, identical to OFF).
+        owned_param_ids: set[int] = set()
+        wrapped_optimizer = self._optimizer_wrapper._optimizer
+        for group in getattr(wrapped_optimizer, "param_groups", None) or []:
+            if isinstance(group, dict):
+                for p in group.get("params", []):
+                    owned_param_ids.add(id(p))
+
+        # Pass 2: select in-place-zero targets from the no_sync'd bucket-view DDPs.
+        targets: list[tuple[torch.nn.Parameter, torch.Tensor]] = []
+        for ddp in real_ddps:
+            if id(ddp) in skipped_ddp_ids:
+                # Excluded in pass 1 (no ownership list). Already warned.
+                continue
+            if not getattr(ddp, "gradient_as_bucket_view", False):
+                # Grads are not reduction-bucket aliases -> the None path is correct, and
+                # there is no standalone duplicate to reclaim. Checked BEFORE the
+                # find_unused_parameters warn: otherwise a DDP with nothing to reclaim still
+                # logs "their HBM is NOT reclaimed", which is alarming and untrue. Not
+                # reachable on APS (it hardcodes gradient_as_bucket_view=True) but generic
+                # torchrec callers do hit it.
+                continue
+            if getattr(ddp, "find_unused_parameters", False):
+                self._warn_bucket_view_skip(
+                    "find_unused_parameters",
+                    f"{type(ddp).__name__} uses find_unused_parameters=True, so its "
+                    "used-parameter set is dynamic per micro-batch",
+                )
+                continue
+            # _module_parameters guaranteed present (pass 1).
+            for p in ddp._module_parameters:
+                if not p.requires_grad:
+                    continue
+                if id(p) in excluded_param_ids:
+                    # Double-owned (pass 1). Already warned.
+                    continue
+                if id(p) not in owned_param_ids:
+                    # DDP-reduced but NOT wrapped-optimizer-owned (H1.1): OFF never clears
+                    # it, so ON must not zero it either -> plain path (leave accumulating).
+                    continue
+                grad = p.grad
+                if grad is None:
+                    # Grad-less dense head: stays None (dense optimizer skips it).
+                    continue
+                if grad.is_sparse or grad.layout != torch.strided:
+                    # Not a dense bucket-view alias.
+                    continue
+                if getattr(grad, "_base", None) is None:
+                    self._warn_bucket_view_skip(
+                        "standalone_grad",
+                        f"a parameter of shape {tuple(p.shape)} on a "
+                        "gradient_as_bucket_view=True DDP holds a STANDALONE grad "
+                        "(grad._base is None) -- the bucket-view alias was dropped",
+                    )
+                    continue
+                targets.append((p, grad))
+        return targets
+
+    def _warn_bucket_view_skip(self, reason: str, detail: str) -> None:
+        """Warn once per REASON that something was excluded from the in-place window-start
+        zero, and therefore keeps the flag-OFF ``set_to_none`` path.
+
+        Keyed per reason rather than per param so a model with hundreds of affected
+        leaves logs once, not hundreds of times -- and rank 0 only, because every reason
+        here is a property of the DDP topology, which is rank-uniform by construction.
+
+        Not silent: the exclusion is correct and inert, but it means the forgone HBM
+        reclaim for those leaves is real, and someone reading only the config would
+        otherwise believe they were getting it.
+        """
+        if reason in self._warned_bucket_view_skips:
+            return
+        self._warned_bucket_view_skips.add(reason)
+        if (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_rank() != 0
+        ):
+            return
+        logger.warning(
+            "[accumulate_into_buckets] excluding leaves from the alias-preserving "
+            "window-start zero (%s): %s. They fall back to "
+            "optimizer.zero_grad(set_to_none=True) -- numerically identical to "
+            "accumulate_into_buckets=False, but their dense-gradient HBM is NOT "
+            "reclaimed across the K-micro window.",
+            reason,
+            detail,
+        )
+
+    def _window_start_zero_grad(self) -> None:
+        """Window-start zero for ``accumulate_into_buckets`` (Component 1).
+
+        Selective retain/hide/tree-clear/restore so the DDP ``gradient_as_bucket_view``
+        alias survives the window-start zero (autograd then accumulates into the
+        persistent reduction bucket instead of allocating a standalone dense ``.grad``
+        set across the K-micro no_sync window) WITHOUT bypassing the real optimizer
+        tree's ``zero_grad`` (which propagates fused-embedding LR and applies correct
+        None semantics to Shampoo dense / fp32-grad DP / every non-target leaf).
+
+          1. Until bucket-views are established (first window), plain set_to_none clear.
+          2. Collect targets = live bucket-view grads owned by a GA-no_sync'd real DDP.
+          3. Hide: ``p.grad = None`` for targets only (so tree-clear no-ops on them).
+          4. Tree-clear: ``self._optimizer.zero_grad(set_to_none=True)`` -- fused-LR
+             propagation + None semantics for every non-target leaf.
+          5. Restore + in-place zero: reinstate the saved bucket-view and ``grad.zero_()``
+             (view-safe: no ``detach_()`` on a view).
+        """
+        optimizer = self._optimizer_wrapper._optimizer
+        if not self._bucket_views_ready:
+            # First window / views not yet established: plain None clear (also clears
+            # APF dummy grads; avoids the detach-on-view crash that only exists
+            # post-alias). Numerically identical to the None path.
+            optimizer.zero_grad(set_to_none=True)
+            return
+        targets = self._collect_bucket_view_targets()
+        if not targets:
+            # No live bucket-view DDP targets (e.g. default AFOC, where promoted tables
+            # use the fp32-grad manual reducer; or a custom/FSDP root; or grads not yet
+            # present): plain None path -- inert, identical to accumulate_into_buckets off.
+            optimizer.zero_grad(set_to_none=True)
+            return
+        # Hide the target grads so the real optimizer tree-clear cannot touch them, then
+        # ALWAYS restore the saved bucket-view aliases (finally) even if the tree-clear
+        # raises -- otherwise an exception would leave targets at None and drop their
+        # aliases (HBM reclaim would silently stop and the next backward would allocate a
+        # fresh standalone grad). Zero in place only on the success path (after restore).
+        for p, _grad in targets:
+            p.grad = None
+        try:
+            # Tree-clear the real optimizer: fused-embedding LR propagation + None
+            # semantics for Shampoo dense / fp32-grad DP / all non-target leaves (targets
+            # are None -> no-op on them).
+            optimizer.zero_grad(set_to_none=True)
+        finally:
+            # Restore the bucket-view alias (preserves it so the next no_sync backward
+            # accumulates into the persistent reduction bucket).
+            for p, grad in targets:
+                p.grad = grad
+        # Zero the restored aliases in place (view-safe; only reached on success).
+        # H4.1 (Phase-P2 conditional): coalesce the per-target ``grad.zero_()`` memsets
+        # into one ``torch._foreach_zero_`` per ``(device, dtype)`` group -- Phase P found
+        # a MATERIAL ~2% per-window QPS cost (CMF -2.32%) from launching N separate memset
+        # kernels (one per dense param) each window. Grouped writes are storage-safe: DDP
+        # reduction-bucket slices share storage but do NOT overlap
+        # (reducer.cpp:1170-1193,1293-1349). Rebuild the group lists from the FRESH
+        # ``targets`` every window -- never cache the live tensor list (a static_graph
+        # bucket rebuild repoints grads to new views). NOTE: ``_foreach_zero_`` does not
+        # bump per-tensor version counters (unlike ``Tensor.zero_()``, ForeachUnaryOp.cu);
+        # these grads are DDP reduction-bucket views WRITTEN by the reducer, not tensors
+        # autograd READS for backward, so the version counter is immaterial here -- the
+        # alias-preservation + next-window freshness is covered by the bucket-view
+        # state-machine + foreach coalescing tests.
+        zero_groups: dict[tuple[torch.device, torch.dtype], list[torch.Tensor]] = {}
+        for _p, grad in targets:
+            zero_groups.setdefault((grad.device, grad.dtype), []).append(grad)
+        for grad_list in zero_groups.values():
+            torch._foreach_zero_(grad_list)
+
     def _flush_accumulated_gradients(self, steps_accumulated: int) -> bool:
         """
         Force a gradient sync and optimizer step for any remaining gradients.
@@ -288,11 +841,110 @@ class GradientAccumulationWrapper(Generic[In, Out]):
                 of when flush is called (before or after _advance_state).
 
         Returns:
-            True if gradients were flushed, False if no flush was needed.
+            True if a partial window was committed with an optimizer step.
+            False if no flush was needed (complete window) OR the partial window was
+            discarded under ``PartialWindowPolicy.DISCARD`` (no step is taken, so nothing
+            is flushed). The sole caller ignores this value.
         """
         remaining = steps_accumulated % self._config.num_steps
         if remaining > 0:
-            # Step, zero gradients to prevent stale state, and reset flag
+            if self._partial_window_policy is PartialWindowPolicy.DISCARD:
+                # DISCARD: drop the partial window rank-locally. No optimizer step, no
+                # collective, and deliberately NOT _ga_abort_all_process_groups -- under
+                # this policy an exhaustion-time partial window is the NORMAL ending of a
+                # consume-all phase, not a fault, and every rank reaches it together
+                # (the caller established cross-rank exhaustion agreement out of band).
+                #
+                # Placed AHEAD of the world-size block on purpose, and this placement is
+                # load-bearing: every policy check below is written as `is RAISE / else
+                # STEP` with no exhaustive match, so a DISCARD that fell through would
+                # take a silent local un-reduced optimizer step -- corruption, not a
+                # crash. Early-returning here also leaves the deliberately-unconditional
+                # abort in the world_size > 1 block byte-identical for STEP and RAISE.
+                #
+                # Re-arm BEFORE zeroing. zero_grad() early-returns when _needs_zero_grad
+                # is False, which is exactly the mid-window state we are in, so calling it
+                # bare is a guaranteed no-op and the discarded gradients would survive
+                # into the next window. Same idiom the boundary-commit path uses. Go
+                # through the wrapper (not the raw optimizer) so the
+                # accumulate_into_buckets bucket-view alias routing is preserved.
+                self._optimizer_wrapper._needs_zero_grad = True
+                self._optimizer_wrapper.zero_grad(set_to_none=True)
+                logger.warning(
+                    "Gradient accumulation discarded a partial final window "
+                    "(steps_accumulated=%d, num_steps=%d, remaining=%d) under "
+                    "PartialWindowPolicy.DISCARD: %d micro-batch(es) of accumulated "
+                    "gradients were zeroed without an optimizer step. Expected at the end "
+                    "of a consume-all phase. If a downstream collective later times out, "
+                    "suspect an ASYMMETRIC exhaustion (one rank's reader errored) rather "
+                    "than a clean end-of-data.",
+                    steps_accumulated,
+                    self._config.num_steps,
+                    remaining,
+                    remaining,
+                )
+                # Deliberately no reset() (it zeroes _current_step/_window_base and would
+                # replay GA/DDP warmup on every new iterator) and no realign_window()
+                # (the caller already does that right after this returns).
+                return False
+            # A raw flush steps the RANK-LOCAL accumulated grads of an incomplete window
+            # WITHOUT a cross-rank reduce. In a distributed (world_size > 1) run that
+            # diverges replicas, so FAIL-CLOSED (raise) rather than silently corrupt. The
+            # supported divisible-N path never reaches here (full windows -> remaining==0),
+            # and the APS config-time guards (train_pipeline.py) block a statically-partial
+            # N; but a CHECKPOINT RESUME can still produce a runtime-partial remaining
+            # window (the data loader subtracts a logical-step count from a reader-micro
+            # total with no xK conversion), which the static guards do not catch -- this
+            # runtime guard closes that hole. (An explicit is_last_batch partial window
+            # commits IN-BAND under a synchronized step and never sets _pending_uncommitted,
+            # so it never reaches this flush.)
+            if (
+                torch.distributed.is_available()
+                and torch.distributed.is_initialized()
+                and torch.distributed.get_world_size() > 1
+            ):
+                # A3: fires BEFORE policy evaluation and is deliberately unconditional, so
+                # the abort must apply under BOTH PartialWindowPolicy values -- gating it on
+                # RAISE would preserve the hang for STEP callers.
+                _ga_abort_all_process_groups(
+                    f"partial final window at world_size>1 "
+                    f"(steps_accumulated={steps_accumulated}, remaining={remaining})"
+                )
+                raise RuntimeError(
+                    "Gradient accumulation reached a partial final window "
+                    f"(steps_accumulated={steps_accumulated}, num_steps="
+                    f"{self._config.num_steps}, remaining={remaining}) that was never "
+                    "committed in-band. Flushing would step un-reduced rank-local "
+                    "gradients (replica divergence). This usually means a checkpoint "
+                    "resume left a reader-batch count that is not a whole multiple of "
+                    "num_micro_batches_per_step. Make the total reader batches a whole "
+                    "multiple of K, and when warm-starting from a seed set "
+                    "++checkpoint.skip_loading_training_progress_checkpoint_on_start=true "
+                    "so training restarts at step 0."
+                )
+            # Single-process (world_size <= 1): the local grads ARE the full window (no
+            # replicas to diverge), so an in-band step is numerically correct. Whether a
+            # partial world_size <= 1 window is TOLERATED is a caller policy
+            # (PartialWindowPolicy, selected at wrapper construction):
+            #   - RAISE: fail-closed even here, so a caller that requires K-divisible data
+            #     (e.g. APS, which already fail-closes a static N % K != 0 at config time)
+            #     is told loudly rather than silently stepping a smaller final batch -- e.g.
+            #     a checkpoint-resume remainder the static guards cannot catch.
+            #   - STEP (default): take the sanctioned local step + reset (historical W<=1
+            #     behavior).
+            if self._partial_window_policy is PartialWindowPolicy.RAISE:
+                raise RuntimeError(
+                    "Gradient accumulation reached a partial final window "
+                    f"(steps_accumulated={steps_accumulated}, num_steps="
+                    f"{self._config.num_steps}, remaining={remaining}) at world_size <= 1 "
+                    "and the caller selected PartialWindowPolicy.RAISE. The local grads "
+                    "would be a correct single-process step, but this caller requires the "
+                    "total reader batch count to be a whole multiple of "
+                    "num_micro_batches_per_step. Make it a whole multiple of K, or select "
+                    "PartialWindowPolicy.STEP to take the sanctioned local step."
+                )
+            # PartialWindowPolicy.STEP: sanctioned in-band step + reset. Plain set_to_none
+            # (post-step boundary; no bucket-view alias to preserve after a real step).
             self._optimizer_wrapper._optimizer.step()
             self._optimizer_wrapper._optimizer.zero_grad(set_to_none=True)
             self._optimizer_wrapper._needs_zero_grad = False
@@ -323,9 +975,82 @@ class GradientAccumulationWrapper(Generic[In, Out]):
                 remaining accumulated gradients before raising.
         """
         if not self._config.is_enabled:
+            # Pass-through: no window, so no boundary to signal.
             return self._pipeline.progress(dataloader_iter)
 
         should_sync = self._should_sync_grad(is_last_batch=is_last_batch or False)
+        # VETO fix (policy-contract completeness): is_last_batch commits an OFF-BOUNDARY
+        # partial (r < K) window in-band via the SYNCHRONIZED force-step armed below
+        # (should_sync is True for is_last_batch, so the backward runs under nullcontext and
+        # the partial window's grads ARE cross-rank reduced -> replica-safe at any
+        # world_size). But that in-band commit BYPASSES _flush_accumulated_gradients and thus
+        # PartialWindowPolicy: a caller that selected RAISE (e.g. APS) could otherwise
+        # silently force-step a partial window here instead of raising. Fail-closed on a
+        # partial window BEFORE arming the force-step / publishing the boundary / calling
+        # pipeline.progress() so no partial step occurs (mirrors the flush path). Gated on
+        # model.training (like the flush guard and the boundary-commit block below) so an
+        # eval interlude never spuriously raises. A FULL window via is_last_batch (already on
+        # the schedule boundary => _should_step() True) is NOT partial and is unaffected;
+        # PartialWindowPolicy.STEP keeps the synchronized force-step unchanged.
+        #
+        # DISCARD deliberately does NOT fence here, and this asymmetry with RAISE is the
+        # point: is_last_batch makes should_sync True, so the partial window's grads are
+        # cross-rank REDUCED and the in-band step is replica-safe at any world_size. Taking
+        # it keeps up to K-1 micro-batches that a discard would throw away, for no safety
+        # gain. DISCARD governs the EXHAUSTION path, where that information does not exist.
+        # (No non-test caller in aps_models/, apf/ or torchrec/ passes is_last_batch=True
+        # today, so this is a contract statement, not a live behavior difference.)
+        if (
+            is_last_batch
+            and self._partial_window_policy is PartialWindowPolicy.RAISE
+            and getattr(self._model, "training", True)
+            and not self._optimizer_wrapper._should_step()
+        ):
+            steps_accumulated = self.steps_in_window + 1
+            remaining = steps_accumulated % self._config.num_steps
+            # A3: this branch only exists under RAISE, so the abort is gated with it. At
+            # world_size <= 1 the helper is a no-op, which is the correct behavior -- there
+            # are no peers to strand.
+            _ga_abort_all_process_groups(
+                f"partial final window via is_last_batch under PartialWindowPolicy.RAISE "
+                f"(steps_accumulated={steps_accumulated}, remaining={remaining})"
+            )
+            raise RuntimeError(
+                "Gradient accumulation reached a partial final window "
+                f"(steps_accumulated={steps_accumulated}, num_steps="
+                f"{self._config.num_steps}, remaining={remaining}) via an explicit "
+                "is_last_batch commit and the caller selected PartialWindowPolicy.RAISE. "
+                "The in-band step would be synchronized (replica-safe), but this caller "
+                "requires the total reader batch count to be a whole multiple of "
+                "num_micro_batches_per_step. Make it a whole multiple of K, or select "
+                "PartialWindowPolicy.STEP to take the sanctioned synchronized final-window "
+                "step."
+            )
+        # Publish the GA CONSUME BOUNDARY onto the inner pipeline BEFORE progress()
+        # so split-optimizer sub-steps (sparse/dense) + grad-clip that BYPASS the
+        # GA-wrapped optimizer gate on the SAME boundary the wrapped optimizer uses.
+        # NOTE: the consume boundary is _should_step() (the optimizer-step boundary),
+        # NOT _should_sync_grad() which force-True's on step-0/warmup where the
+        # optimizer does NOT step (that predicate drives DDP no_sync only).
+        should_step = self._optimizer_wrapper._should_step() or bool(is_last_batch)
+        # Partial-window support (one-shot): on an explicit last batch, force the wrapped
+        # optimizer to step in-band even when the schedule boundary (_should_step) is not
+        # reached (a final r<K window). Split modes already step via the observer below;
+        # this makes DEFAULT mode's wrapper.step() also fire.
+        # Assigned every progress() so it never leaks into a later window.
+        self._optimizer_wrapper._force_step = bool(is_last_batch)
+        # steps_in_window is the micro counter relative to the current window's anchor
+        # (not yet advanced), so == 0 marks the first micro of each window -- and stays
+        # correct after an iterator exhaustion re-anchors it. The FP-param own-grad-bucket
+        # path zeroes its coalesced buffer there, so the K micro grads accumulate before
+        # the boundary all-reduce.
+        at_window_start = (self.steps_in_window % self._config.num_steps) == 0
+        # Signal BEFORE progress() so sub-steps that bypass the wrapped optimizer gate on
+        # the same boundary it uses.
+        if self._window_observer is not None:
+            self._window_observer(
+                should_step=should_step, at_window_start=at_window_start
+            )
         ctx: ContextManager[None] = (
             contextlib.nullcontext() if should_sync else self._get_no_sync_context()
         )
@@ -339,25 +1064,174 @@ class GradientAccumulationWrapper(Generic[In, Out]):
             # this call. In TrainPipelineSparseDist, StopIteration is raised at
             # the top of progress() when self.batches is empty (all prefetched
             # batches were already fully processed in prior calls). Therefore
-            # current_step accurately reflects the number of completed batches
-            # and we should NOT add +1.
-            self._flush_accumulated_gradients(self.current_step)
+            # current_step reflects completed batches (do NOT add +1). Flush only if
+            # this rank has un-stepped accumulated gradients (a partial window not
+            # committed in-band). Partial windows are now FAIL-CLOSED at APS config time:
+            # train_pipeline.py hard-fails GA with a non-divisible bounded num_batches
+            # (N%K!=0) AND with consume-all num_batches=-1 (R1-lite frontier fail-fasts),
+            # so under the supported divisible-N path only full windows reach here ->
+            # _pending_uncommitted is False -> this no-ops. (A raw flush of a partial
+            # window would step un-reduced rank-local grads = replica divergence,
+            # distributed only; that frontier stays blocked at config time.)
+            # Gate on model.training: an eval interlude must never raw-flush / step the
+            # optimizer. _pending_uncommitted is only set inside the training-mode block
+            # below, so at a clean window boundary it is already False; the guard also
+            # closes the mid-window-eval edge (pending grads from an incomplete training
+            # window followed by an eval whose iterator is exhausted).
+            if getattr(self._model, "training", True):
+                if self._pending_uncommitted:
+                    self._flush_accumulated_gradients(self.steps_in_window)
+                    # The flush committed the partial window (single-process step + zero) or
+                    # raised (distributed). On the committed path clear the pending flag so a
+                    # subsequent reset() at the epoch/sample boundary sees a clean state (S2
+                    # guard) rather than raising on an already-handled window -- e.g. the
+                    # benchmark harness that calls reset() once per sample after a non-K-
+                    # divisible iter count.
+                    self._pending_uncommitted = False
+                # Re-anchor the K-window at the exhaustion point. A phase that consumed a
+                # non-multiple of K micros leaves the free-running counter off-modulo, which
+                # would shift EVERY subsequent window's boundary off the trainer's logical
+                # step once a new iterator starts. Runs on a clean-boundary exhaustion too
+                # (cheap, and keeps the anchor equal to the counter). Inside the training
+                # gate on purpose: an eval interlude must not touch GA state
+                # (test_eval_stop_iteration_does_not_flush), and a mid-window training
+                # window must survive an eval whose iterator exhausts.
+                self._optimizer_wrapper.realign_window()
             raise
 
-        self._advance_state()
-
-        # If user explicitly marked this as last batch, flush remaining gradients
-        # Use current_step which now includes this batch after _advance_state()
-        if is_last_batch:
-            self._flush_accumulated_gradients(self.current_step)
+        # Boundary-commit (cross-window grad-zeroing fix). The APS split-optimizer
+        # pipeline modes step their child optimizers DIRECTLY (train_pipeline.py
+        # dispatch to _step_optimizer_embedding_lookup_fwd / _step_optimizer_fp_allreduce)
+        # and NEVER call _GAOptimizerWrapper.step() — the only other place that resets
+        # _needs_zero_grad back to True. The sole grad zeroer is the wrapped
+        # self._optimizer.zero_grad() at the top of the next progress(), gated by
+        # _needs_zero_grad. Without this reset that zero_grad() no-ops from window 2
+        # onward and the dense (DDP) + DP-promoted Mechanism-B dense gradients LEAK
+        # across logical windows. Reset on the consume boundary for BOTH split and
+        # default modes (idempotent in default mode, where wrapper.step() already set
+        # it). Keyed on should_step (the optimizer-step boundary), NOT should_sync
+        # (which is True on warmup / step 0 without an optimizer step).
+        #
+        # Gated on model.training: the APS optimizer-step + zero_grad paths are all
+        # training-only (train_pipeline.py step dispatch ~1465-1470 + zero_grad ~1392),
+        # so in eval no step/zero happens and there is no grad state to manage. This also
+        # ensures should_step (an INTENT flag) only commits the boundary when a real
+        # optimizer step could actually have occurred.
+        if getattr(self._model, "training", True):
+            if should_step:
+                self._optimizer_wrapper._needs_zero_grad = True
+            # Track whether this micro left un-stepped accumulated gradients so a later
+            # StopIteration knows whether a flush is actually needed -- AND an explicit
+            # is_last_batch boundary (committed in-band above via the forced step) is NOT
+            # double-stepped by a raw flush. should_step True => committed this micro.
+            self._pending_uncommitted = not should_step
+            # Advance the GA micro-step counter ONLY during training. Eval reuses the same
+            # train_step -> progress() dispatch (ads_rec_train_factory keys the dispatch on
+            # _ga_config, NOT train/eval), so advancing _current_step during an eval
+            # interlude would desync the K-micro window boundaries (should_step /
+            # should_sync / at_window_start all key on current_step) for the resumed
+            # training step. Eval sets module.eval() (TrainLoopScheduler.set_eval_mode),
+            # so gating the advance on model.training freezes the counter across eval.
+            self._advance_state()
+            # An explicit last batch closes the phase, so re-anchor the K-window here for
+            # the same reason the StopIteration path does: the next iterator must start a
+            # fresh window even though this one ended off-modulo. APS never passes
+            # is_last_batch (_train_step_with_local_ga calls progress(data_iter) bare);
+            # this is for generic torchrec callers. Ordering: after _advance_state(), so
+            # the committed micro is counted before the anchor moves.
+            if is_last_batch:
+                self._optimizer_wrapper.realign_window()
+            # Component 2: mark the DDP gradient_as_bucket_view aliases established once a
+            # synchronized training backward has completed. should_sync True => the
+            # pipeline.progress() above ran under nullcontext (not no_sync), so DDP's
+            # reducer finalized and (re)aliased each managed dense grad to its
+            # reduction-bucket view. The selective in-place window-start zero then engages
+            # only from the NEXT window start (>= window 1, whose first micro is no_sync);
+            # window 0's start zero already used set_to_none (views not yet ready). The
+            # one-time static_graph bucket rebuild re-points each grad view exactly once and
+            # may fire during a later window's forward (not necessarily at the window-0
+            # boundary); the reducer COPIES the current (zeroed) grad into the new
+            # bucket-view and repoints p.grad, so the alias survives the rebuild regardless
+            # of timing. Targets are collected fresh every window and stay bucket-views
+            # (empirically verified in test_ga_bucket_view_alias: grad._base is set at
+            # every micro under the flag).
+            if should_sync and self._config.accumulate_into_buckets:
+                self._bucket_views_ready = True
 
         return result
 
-    def reset(self) -> None:
-        """Resets the wrapper and underlying pipeline state."""
+    def reset(self, drop_partial: bool = False) -> None:
+        """Resets the wrapper and underlying pipeline state.
+
+        ``_bucket_views_ready`` is intentionally NOT cleared: reset() runs at
+        epoch/dataloader boundaries where the SAME model and DDP instances (and their
+        established reduction-bucket views) remain alive, so readiness carries over. The
+        model/DDP topology cannot change under a live wrapper -- ``attach()`` rejects a
+        model swap -- so preserved readiness can never become stale.
+        """
+        # Clean-boundary guard (S2): a reset() with an OPEN partial window
+        # (_pending_uncommitted True -- a non-boundary micro left accumulated,
+        # un-stepped, un-reduced gradients) would silently DROP those gradients (the
+        # optimizer step never happens) and desync the K-micro window. Test semantic
+        # dirtiness, not current_step % K: an explicit is_last_batch can commit a clean
+        # partial window off the modulo boundary. APF checkpoints after a full logical
+        # step, so a normal epoch/dataloader-boundary reset has no pending window.
+        if self._pending_uncommitted and not drop_partial:
+            # @lint-ignore FIXIT AllRaisesAreAIExceptions AllRaisesAreAPSExceptions
+            raise RuntimeError(
+                "GradientAccumulationWrapper.reset() called with an open partial window "
+                "(accumulated, un-stepped gradients left by a non-boundary micro; "
+                f"current_step={self.current_step}, num_steps={self._config.num_steps}). "
+                "Resetting now would silently drop those gradients and desync the K-micro "
+                "window. Complete the window (reach the K-th micro) before reset, or pass "
+                "drop_partial=True to intentionally discard the partial window."
+            )
         self._optimizer_wrapper.reset()
+        self._pending_uncommitted = False
         if hasattr(self._pipeline, "reset"):
             self._pipeline.reset()
+
+    def attach(
+        self, model: Optional[torch.nn.Module] = None, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Reject a model swap; otherwise delegate.
+
+        This class is not a ``TrainPipeline`` subclass, so ``__getattr__`` would forward
+        ``attach(new_model)`` to the inner pipeline while the wrapper's optimizer stayed
+        bound to the original model's parameters and the window-start zero targeted a
+        stale DDP set. A swap therefore needs a fresh wrapper; same-model re-attach and
+        ``attach(None)`` delegate unchanged.
+
+        ``*args`` is forwarded because ``TrainPipelineSparseDist.attach`` takes
+        ``sparse_dist`` positionally.
+        """
+        if model is not None and model is not self._model:
+            raise RuntimeError(
+                "GradientAccumulationWrapper does not support swapping the model via "
+                "attach(): the wrapped optimizer stays bound to the original model's "
+                "parameters and the selective bucket-view zero caches the original DDP "
+                "topology. Construct a new GradientAccumulationWrapper with the new model "
+                "and its optimizer instead."
+            )
+        if not hasattr(  # @lint-ignore FIXIT [AvoidHasattrEverywhere] the wrapped pipeline is an unconstrained TrainPipeline; attach() is optional on it
+            self._pipeline, "attach"
+        ):
+            raise RuntimeError(
+                "GradientAccumulationWrapper requires the wrapped pipeline to provide "
+                f"attach(); {type(self._pipeline).__name__} does not. Wrap a pipeline "
+                "that implements the TrainPipeline attach protocol."
+            )
+        return self._ga_hooks.attach(model, *args, **kwargs)
+
+    @property
+    def _ga_hooks(self) -> _GAPipelineHooks:
+        """The wrapped pipeline seen through the GA hook surface.
+
+        ``TrainPipeline`` does not declare ``attach``, so the cast is what lets the one
+        call site be a plain attribute access. Pure view, no check: availability is
+        enforced at that call site.
+        """
+        return cast(_GAPipelineHooks, self._pipeline)
 
     @property
     def optimizer_wrapper(self) -> _GAOptimizerWrapper:
@@ -368,6 +1242,33 @@ class GradientAccumulationWrapper(Generic[In, Out]):
     def current_step(self) -> int:
         """Returns the current step count (single source of truth from optimizer wrapper)."""
         return self._optimizer_wrapper._current_step
+
+    @property
+    def steps_in_window(self) -> int:
+        """Micro-batches consumed since the latest window anchor.
+
+        This -- not ``current_step`` -- is what the optimizer-step, grad-sync and
+        window-start boundaries key on, so it is the value a Layer-1 trainer loop must
+        check when asserting that a logical step begins on a window boundary.
+        ``current_step`` stays globally monotonic and can legitimately be off-modulo
+        after an iterator exhaustion re-anchors the window.
+
+        NOT bounded to ``[0, num_micro_batches_per_step)`` -- see
+        ``_GAOptimizerWrapper.steps_in_window``; only its residue mod K is meaningful. In
+        particular ``_GAOptimizerWrapper.set_step(n)`` drops the anchor back to 0, so this
+        then reads ``n`` verbatim -- including a negative value for a negative ``n``,
+        exactly as ``current_step`` already did.
+        """
+        return self._optimizer_wrapper.steps_in_window
+
+    @property
+    def num_micro_batches_per_step(self) -> int:
+        """Number of micro-batches (K) accumulated per optimizer step.
+
+        Public accessor for the wrapper's configured K so a Layer-1 trainer loop can
+        assert its own K matches the wrapper's without reaching into private config.
+        """
+        return self._config.num_steps
 
     def set_step(self, step: int) -> None:
         """

--- a/torchrec/distributed/train_pipeline/tests/test_ga_bucket_view_alias.py
+++ b/torchrec/distributed/train_pipeline/tests/test_ga_bucket_view_alias.py
@@ -1,0 +1,965 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# Citrine missing_for_each_optimizer is suppressed file-wide below. These are CPU unit
+# tests whose whole purpose is to pin the optimizer's INTERACTION with DDP bucket views
+# (gradient_as_bucket_view aliasing, the selective window-start zero, and zero_grad
+# interception). `foreach=True` swaps SGD's internal implementation to the multi-tensor
+# kernels, which is exactly the behaviour under test, and the perf benefit the rule is
+# chasing is nil on a CPU unit test.
+# @lint-ignore-every CITRINE
+
+"""Real-DDP bucket-view alias state-machine + degradation tests for the
+``accumulate_into_buckets`` selective window-start zero (gradient_accumulation.py C1/C2).
+
+Builds a REAL ``DistributedDataParallel`` with ``gradient_as_bucket_view=True`` over a
+single-process gloo group so the ACTUAL bucket-view alias lifecycle is exercised (the
+mocked-DDP tests in test_gradient_accumulation.py cannot). Uses a bias-free ``Linear`` fed
+constant ones with ``lr=0`` so every micro contributes an identical all-ones grad -> the
+per-micro accumulation COUNT is ``grad.max()``, which lets us assert both (a) the alias
+invariant (bucket-view vs standalone) and (b) grad freshness (each window restarts at 1x,
+not K+1x -- i.e. ``grad.zero_()`` actually zeroed).
+
+Core invariant: across a K-micro window whose first micro runs under ``no_sync()``, the ON
+path keeps the dense grad a BUCKET-VIEW (``grad._base is not None``) every micro (no
+standalone HBM duplication), while the OFF path allocates a STANDALONE grad at each
+window-start no_sync micro. A permanently grad-less head stays ``None`` on both paths.
+
+NOTE on identity: DDP performs a ONE-TIME static_graph bucket rebuild that re-points each
+grad to a new bucket-view object exactly once; the invariant is "still a bucket-view", not
+"same object across windows".
+"""
+
+import inspect
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from typing import Any, cast, Iterator, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from pyre_extensions import none_throws
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+from torchrec.distributed.train_pipeline.gradient_accumulation import (
+    GradientAccumulationConfig,
+    GradientAccumulationWrapper,
+)
+from torchrec.distributed.train_pipeline.train_pipelines import TrainPipeline
+
+
+class _ConstGradModel(nn.Module):
+    """bias-free ``Linear`` (grad_W == outer(d_out, x)); with x=ones and lr=0 every micro
+    contributes an identical all-ones grad, so ``active.weight.grad.max()`` == the number of
+    micro-grads accumulated since the last zero. ``unused`` is forward-reachable but its
+    output is discarded (not in the loss) -> permanently grad-less (mirrors AFOC task heads
+    that static_graph=True tolerates)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.active = nn.Linear(4, 4, bias=False)
+        self.unused = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _ = self.unused(x)  # forward-reachable, discarded -> grad-less
+        return self.active(x)
+
+
+class _DDPForwardPipeline(TrainPipeline[Any, torch.Tensor]):
+    """zero_grad -> forward -> backward -> step through the (GA-wrapper-replaced) optimizer.
+    The GA wrapper supplies the no_sync context and gates the actual step/zero at window
+    boundaries."""
+
+    def __init__(self, model: nn.Module, optimizer: torch.optim.Optimizer) -> None:
+        super().__init__()
+        self._model = model
+        self._optimizer = optimizer
+
+    def progress(self, dataloader_iter: Iterator[torch.Tensor]) -> torch.Tensor:
+        batch = next(dataloader_iter)
+        self._optimizer.zero_grad()
+        out = self._model(batch)
+        loss = out.sum()
+        loss.backward()
+        self._optimizer.step()
+        return loss
+
+    def attach(
+        self, model: Optional[nn.Module] = None, sparse_dist: bool = True, **kwargs: Any
+    ) -> None:
+        # Mirrors TrainPipelineSparseDist.attach, which takes `sparse_dist` POSITIONALLY.
+        if model is not None:
+            self._model = model
+        self.last_sparse_dist: bool = sparse_dist
+
+
+def _init_single_process_group() -> str:
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_WORLD_SIZE", "1")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    dist.init_process_group(
+        backend="gloo", init_method=f"file://{tmp.name}", world_size=1, rank=0
+    )
+    return tmp.name
+
+
+def _probe(p: nn.Parameter) -> Tuple[bool, bool, Optional[int], int]:
+    """(has_grad, is_bucket_view, base_data_ptr, accumulation_count). Holds NO tensor
+    reference beyond this call (avoids perturbing AccumulateGrad)."""
+    g = p.grad
+    if g is None:
+        return (False, False, None, 0)
+    base = getattr(g, "_base", None)
+    return (
+        True,
+        base is not None,
+        base.data_ptr() if base is not None else None,
+        int(round(float(g.detach().max()))),
+    )
+
+
+@dataclass
+class _Trace:
+    active: List[Tuple[bool, bool, Optional[int], int]] = field(default_factory=list)
+    unused_has_grad: List[bool] = field(default_factory=list)
+    ready_initial: bool = False
+    ready_after_first: bool = False
+    ready_after_reset: bool = False
+    tree_clears: int = 0
+
+
+class _PGTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        torch.manual_seed(0)
+        self._init_file: str = _init_single_process_group()
+
+    def tearDown(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        try:
+            os.unlink(self._init_file)
+        except OSError:
+            pass
+
+    def _make_ddp(self, model: nn.Module, **kwargs: Any) -> DistributedDataParallel:
+        return DistributedDataParallel(model, process_group=dist.group.WORLD, **kwargs)
+
+
+class BucketViewAliasStateMachineTest(_PGTestBase):
+    def _drive(self, k: int, accumulate_into_buckets: bool, num_micros: int) -> _Trace:
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        optimizer = torch.optim.SGD(ddp.parameters(), lr=0.0)  # lr=0 -> grads constant
+
+        tree_clear_true = [0]
+        orig_zero_grad = optimizer.zero_grad
+
+        def _spy_zero_grad(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("set_to_none") is True:
+                tree_clear_true[0] += 1
+            return orig_zero_grad(*args, **kwargs)
+
+        optimizer.zero_grad = _spy_zero_grad
+
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=k,
+            num_warmup_steps=1,
+            accumulate_into_buckets=accumulate_into_buckets,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+
+        tr = _Trace()
+        tr.ready_initial = ga._bucket_views_ready
+        # Pre-seed an APF-style dummy grad on the active param: micro 0's first-window
+        # set_to_none must drop it, so micro 0's count is 1 (not 2).
+        model.active.weight.grad = torch.ones_like(model.active.weight)
+
+        batch = torch.ones(1, 4)
+        for i in range(num_micros):
+            ga.progress(iter([batch]))
+            if i == 0:
+                tr.ready_after_first = ga._bucket_views_ready
+            tr.active.append(_probe(cast(nn.Parameter, model.active.weight)))
+            tr.unused_has_grad.append(model.unused.weight.grad is not None)
+        ga.reset()
+        tr.ready_after_reset = ga._bucket_views_ready
+        tr.tree_clears = tree_clear_true[0]
+        return tr
+
+    def _assert_state_machine(self, k: int) -> None:
+        num_micros = 3 * k  # 3 windows
+        num_windows = 3
+        on = self._drive(k, True, num_micros)
+        off = self._drive(k, False, num_micros)
+        # Per-micro accumulation count restarts each window: 1..k repeating.
+        expected_counts = [(i % k) + 1 for i in range(num_micros)]
+
+        # --- ON: every micro is a bucket-view (no standalone) with FRESH grad values.
+        for i in range(num_micros):
+            has, view, _base, count = on.active[i]
+            self.assertTrue(
+                has and view, f"[K={k}] ON micro {i} not a bucket-view: {on.active[i]}"
+            )
+            self.assertEqual(
+                count,
+                expected_counts[i],
+                f"[K={k}] ON micro {i} accumulation count {count} != {expected_counts[i]} "
+                "(grad.zero_() freshness broken -> would leak across windows)",
+            )
+        # ON: base_ptr changes EXACTLY ONCE (the one-time static_graph rebuild), then stable.
+        on_bases = [b for (_h, _v, b, _c) in on.active]
+        transitions = sum(1 for a, b in zip(on_bases, on_bases[1:]) if a != b)
+        self.assertEqual(
+            transitions,
+            1,
+            f"[K={k}] expected exactly one bucket rebuild re-point: {on_bases}",
+        )
+
+        # --- OFF (bug reproduction): steady-state (window >= 1) no_sync window-start micros
+        # allocate a STANDALONE grad; the synced boundary re-aliases to a bucket-view.
+        for i in range(k, num_micros):
+            has, view, _base, count = off.active[i]
+            is_boundary = (i % k) == (k - 1)
+            if is_boundary:
+                self.assertTrue(
+                    view,
+                    f"[K={k}] OFF boundary micro {i} should re-alias: {off.active[i]}",
+                )
+            else:
+                self.assertTrue(
+                    has and not view,
+                    f"[K={k}] OFF non-boundary micro {i} should be STANDALONE (the bug): "
+                    f"{off.active[i]}",
+                )
+            self.assertEqual(
+                count, expected_counts[i], f"[K={k}] OFF micro {i} count off"
+            )
+
+        # --- Grad-less head stays None on BOTH paths (Distributed-Shampoo-safe).
+        self.assertFalse(
+            any(on.unused_has_grad), f"[K={k}] ON: grad-less head got a grad"
+        )
+        self.assertFalse(
+            any(off.unused_has_grad), f"[K={k}] OFF: grad-less head got a grad"
+        )
+
+        # --- Readiness lifecycle.
+        self.assertFalse(
+            on.ready_initial, "readiness should be False before any progress"
+        )
+        self.assertTrue(
+            on.ready_after_first, "readiness should be True after first synced backward"
+        )
+        self.assertTrue(
+            on.ready_after_reset, "readiness should survive reset() (same DDP)"
+        )
+
+        # --- Exactly one real-optimizer tree-clear per window (fused-LR carrier; the real
+        # KeyedOptimizer.zero_grad propagates fused-embedding LR recursively).
+        self.assertEqual(
+            on.tree_clears, num_windows, f"[K={k}] expected one tree-clear per window"
+        )
+
+    def test_alias_state_machine_k2(self) -> None:
+        self._assert_state_machine(k=2)
+
+    def test_alias_state_machine_k4(self) -> None:
+        self._assert_state_machine(k=4)
+
+
+class BucketViewDegradationTest(_PGTestBase):
+    """The four unsafe/unknown states DEGRADE (exclude + warn once), they do not raise.
+
+    Raising here would be the wrong trade: ``accumulate_into_buckets`` is derived from
+    ``K > 1``, so every GA job reaches this code, and a raise on any of these four states
+    would convert a working run into a hard crash to protect a memory optimisation.
+
+    Exclusion is provably inert, and that is what these tests assert. A param that is not
+    a target is not hidden, so it takes the real ``optimizer.zero_grad(set_to_none=True)``
+    tree-clear -- i.e. its grad ends up ``None``, byte-identical to the flag-OFF path.
+    Asserting merely "did not raise" would not distinguish that from silently zeroing a
+    grad the OFF path would have cleared, which is the divergence being guarded against.
+    So every case asserts ``grad is None`` afterwards, and that the skip was WARNED rather
+    than silent (a silent skip would let an operator believe they were getting reclaim
+    they are not).
+    """
+
+    def _wrap_ready(
+        self, ddp_owner: nn.Module
+    ) -> GradientAccumulationWrapper[Any, torch.Tensor]:
+        optimizer = torch.optim.SGD(ddp_owner.parameters(), lr=0.1)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp_owner, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp_owner, config)
+        ga._bucket_views_ready = True  # force reaching target collection
+        return ga
+
+    def _zero_and_capture_warning(
+        self, ga: GradientAccumulationWrapper[Any, torch.Tensor], reason: str
+    ) -> None:
+        """Run the window-start zero; assert it did not raise and warned once, by reason."""
+        with self.assertLogs(
+            "torchrec.distributed.train_pipeline.gradient_accumulation", level="WARNING"
+        ) as logs:
+            ga._window_start_zero_grad()
+        self.assertIn(reason, "".join(logs.output))
+
+    def test_find_unused_parameters_degrades(self) -> None:
+        model = _ConstGradModel()
+        ddp = self._make_ddp(
+            model,
+            gradient_as_bucket_view=True,
+            static_graph=False,
+            find_unused_parameters=True,
+        )
+        ga = self._wrap_ready(ddp)
+        model.active.weight.grad = torch.ones_like(model.active.weight)
+        self._zero_and_capture_warning(ga, "find_unused_parameters")
+        self.assertIsNone(
+            model.active.weight.grad,
+            "the excluded DDP's params must take the OFF (set_to_none) path",
+        )
+
+    def test_shared_param_two_ddps_degrades(self) -> None:
+        # A single Parameter reduced by TWO distinct DDP reducers (double ownership).
+        shared = nn.Linear(4, 4, bias=False)
+
+        class _Leaf(nn.Module):
+            def __init__(self, s: nn.Module) -> None:
+                super().__init__()
+                self.s = s
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.s(x)
+
+        ddp_a = self._make_ddp(
+            _Leaf(shared), gradient_as_bucket_view=True, static_graph=True
+        )
+        ddp_b = self._make_ddp(
+            _Leaf(shared), gradient_as_bucket_view=True, static_graph=True
+        )
+
+        class _Root(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.a: nn.Module = ddp_a
+                self.b: nn.Module = ddp_b
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.a(x) + self.b(x)
+
+        root = _Root()
+        ga = self._wrap_ready(root)
+        shared.weight.grad = torch.ones_like(shared.weight)
+        self._zero_and_capture_warning(ga, "double_ddp_ownership")
+        self.assertIsNone(
+            shared.weight.grad,
+            "the double-owned param must take the OFF (set_to_none) path",
+        )
+
+    def test_missing_module_parameters_degrades(self) -> None:
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        ga = self._wrap_ready(ddp)
+        model.active.weight.grad = torch.ones_like(model.active.weight)
+        # Simulate an unknown DDP variant lacking the authoritative ownership list.
+        del ddp._module_parameters
+        self._zero_and_capture_warning(ga, "missing_module_parameters")
+        self.assertIsNone(
+            model.active.weight.grad,
+            "the whole DDP is excluded, so its params take the OFF path",
+        )
+
+    def test_owned_bucket_view_param_with_standalone_grad_degrades(self) -> None:
+        # An optimizer-owned param of a gradient_as_bucket_view DDP whose grad is
+        # STANDALONE (grad._base is None) is an unknown alias state (the bucket-view
+        # was dropped) -> exclude it rather than zero a non-bucket-view in place.
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        ga = self._wrap_ready(ddp)  # optimizer over ddp.parameters(); ready forced True
+        model.active.weight.grad = torch.ones_like(model.active.weight)  # standalone
+        self.assertIsNone(
+            getattr(model.active.weight.grad, "_base", None),
+            "precondition: the injected grad must be standalone (_base is None)",
+        )
+        self._zero_and_capture_warning(ga, "standalone_grad")
+        self.assertIsNone(
+            model.active.weight.grad,
+            "the standalone-grad param must take the OFF (set_to_none) path",
+        )
+
+    def test_warning_is_emitted_once_per_reason(self) -> None:
+        """A model with the condition on every window must not log on every window."""
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        ga = self._wrap_ready(ddp)
+        model.active.weight.grad = torch.ones_like(model.active.weight)
+        self._zero_and_capture_warning(ga, "standalone_grad")
+        model.active.weight.grad = torch.ones_like(model.active.weight)
+        with self.assertNoLogs(
+            "torchrec.distributed.train_pipeline.gradient_accumulation", level="WARNING"
+        ):
+            ga._window_start_zero_grad()
+
+
+class AttachRejectTest(_PGTestBase):
+    def _wrap(self, model: nn.Module) -> GradientAccumulationWrapper[Any, torch.Tensor]:
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        optimizer = torch.optim.SGD(ddp.parameters(), lr=0.1)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        return GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+
+    def test_attach_distinct_model_rejected(self) -> None:
+        ga = self._wrap(_ConstGradModel())
+        with self.assertRaisesRegex(
+            RuntimeError, "does not support swapping the model"
+        ):
+            ga.attach(_ConstGradModel())
+
+    def test_attach_same_model_and_none_delegate(self) -> None:
+        model = _ConstGradModel()
+        ga = self._wrap(model)
+        calls: List[Any] = []
+        # `attach` is not on the TrainPipeline ABC; the concrete pipelines
+        # under test provide it.
+        orig = cast(Any, ga._pipeline).attach
+
+        def _spy(m: Optional[nn.Module] = None, **kw: Any) -> None:
+            calls.append(m)
+            return orig(m, **kw)
+
+        # pyre-ignore[8]: instance spy
+        ga._pipeline.attach = _spy
+        # Same model + None must NOT raise AND must DELEGATE to the inner pipeline.
+        ga.attach(ga._model)
+        ga.attach(None)
+        self.assertEqual(
+            len(calls),
+            2,
+            "attach() did not delegate same-model / None calls to the inner pipeline",
+        )
+
+    def test_attach_forwards_positional_sparse_dist(self) -> None:
+        """``TrainPipelineSparseDist.attach`` takes ``sparse_dist`` positionally, so a
+        ``(model, **kwargs)`` wrapper signature would raise TypeError and narrow the
+        public protocol."""
+        model = _ConstGradModel()
+        ga = self._wrap(model)
+        ga.attach(ga._model, False)
+        self.assertIs(cast(Any, ga._pipeline).last_sparse_dist, False)
+        ga.attach(ga._model, True)
+        self.assertIs(cast(Any, ga._pipeline).last_sparse_dist, True)
+
+
+class PlainListDDPDiscoveryContractTest(_PGTestBase):
+    """Locks the VLE reduction-cadence contract: a DDP stored in a PLAIN Python list is NOT
+    discovered by ``_get_ddp_modules`` (so it never enters no_sync -> reduces every micro),
+    while a REGISTERED inner DDP IS. Also a source tripwire tied to the REAL VLE class so a
+    future ``_lookups`` -> ``nn.ModuleList`` migration is caught."""
+
+    def test_registered_vs_plain_list_ddp_discovery(self) -> None:
+        reg_ddp = self._make_ddp(
+            nn.Linear(4, 4), gradient_as_bucket_view=True, static_graph=True
+        )
+        list_ddp = self._make_ddp(
+            nn.Linear(4, 4), gradient_as_bucket_view=True, static_graph=True
+        )
+
+        class _Root(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.dense = nn.Linear(4, 4)
+                self.registered_ddp: nn.Module = reg_ddp  # registered submodule
+                self._lookups: List[nn.Module] = [list_ddp]  # plain list (VLE pattern)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.dense(x)
+
+        root = _Root()
+        optimizer = torch.optim.SGD(root.dense.parameters(), lr=0.1)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(root, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, root, config)
+        discovered = ga._get_ddp_modules()
+        self.assertIn(reg_ddp, discovered, "registered inner DDP should be discovered")
+        self.assertNotIn(
+            list_ddp,
+            discovered,
+            "plain-list DDP (VLE _lookups pattern) must NOT be discovered (reduces every "
+            "micro; a ModuleList migration would silently change this)",
+        )
+
+    def test_real_vle_uses_plain_list_not_modulelist(self) -> None:
+        """Source tripwire on the ACTUAL ShardedVariableLengthEmbeddingArch: its ``_lookups``
+        must remain a plain ``list`` (undiscovered by no_sync). If this fails, VLE was
+        migrated to a registered container and now enters no_sync -- the every-micro-reduction
+        docs (gradient_accumulation._get_no_sync_context) + the VLE path-coverage scope MUST
+        be revisited."""
+        try:
+            from torchrec.fb.ads.distributed.variable_length_embedding_arch import (
+                ShardedVariableLengthEmbeddingArch,
+            )
+        except Exception as e:  # pragma: no cover - dep availability guard
+            self.skipTest(f"VLE class not importable in this target: {e}")
+        src = inspect.getsource(ShardedVariableLengthEmbeddingArch.__init__)
+        self.assertIn(
+            "self._lookups: List[nn.Module] = []",
+            src,
+            "VLE._lookups is no longer a plain list -- revisit no_sync discovery + docs",
+        )
+        self.assertNotIn(
+            "self._lookups: nn.ModuleList",
+            src,
+            "VLE._lookups migrated to nn.ModuleList -> now discoverable by no_sync; revisit",
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RISK #1 (report §3 D11d): the None-vs-present-zero Shampoo divergence surface.
+#
+# ``set_to_none`` (OFF) leaves a grad-less param's grad None -> Distributed Shampoo's
+# ``is_invalid_grad = grad is None or grad.numel()==0`` SKIPS it. ``accumulate_into_
+# buckets`` (ON) zeros the reduction-bucket-view IN PLACE -> a param that was active
+# last window keeps a PRESENT-ZERO grad -> Shampoo PARTICIPATES (present-zero). The
+# divergence is possible IFF a dense param is ACTIVE in one window and INACTIVE in a
+# later one. AFOC cannot exercise it (static_graph=True + find_unused=False => every
+# dense param is always used), which is WHY the Phase-B per-window instrumentation
+# reporting NO active->inactive transition is the load-bearing inertness proof. This
+# test constructs the counterfactual EXPLICITLY (a param present-then-inactive) and,
+# MULTI-PROCESS (world_size=2, so the present-zero grad is really all-reduced), shows
+# the OFF-vs-ON participation divergence + that an always-active param does NOT diverge.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class _ParticipateOnPresentZeroOptimizer(torch.optim.Optimizer):
+    """Mirrors Distributed Shampoo's participation rule
+    (``is_invalid_grad = grad is None or grad.numel()==0``): a present-zero grad
+    PARTICIPATES (state updated), a None/empty grad is SKIPPED. Records per-param
+    participation so the test can observe the OFF-vs-ON divergence."""
+
+    def __init__(self, params: Any) -> None:
+        super().__init__(params, {"lr": 0.0})
+        self.participated: dict[str, int] = {}
+        self.skipped: dict[str, int] = {}
+        self._names: dict[int, str] = {}
+
+    def name_params(self, named: List[Tuple[str, nn.Parameter]]) -> None:
+        for n, p in named:
+            self._names[id(p)] = n
+
+    # pyre-ignore[14]: matches torch.optim.Optimizer.step signature loosely.
+    def step(self, closure: Any = None) -> None:
+        _ = closure
+        for group in self.param_groups:
+            for p in group["params"]:
+                nm = self._names.get(id(p), f"id{id(p)}")
+                g = p.grad
+                invalid = g is None or g.numel() == 0
+                if invalid:
+                    self.skipped[nm] = self.skipped.get(nm, 0) + 1
+                else:
+                    self.participated[nm] = self.participated.get(nm, 0) + 1
+                    st = self.state[p]
+                    st["updates"] = st.get("updates", 0) + 1
+
+
+class _TwoParamModel(nn.Module):
+    """``active`` (always in the loss) + ``intermittent`` (in the loss only when the
+    forward flag is set) — both bias-free Linears fed constant ones."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.active = nn.Linear(4, 4, bias=False)
+        self.intermittent = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.active(x) + self.intermittent(x)
+
+
+def _active_inactive_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    accumulate_into_buckets: bool,
+    out_dir: str,
+) -> None:
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        torch.manual_seed(0)
+        k = 2
+        model = _TwoParamModel()
+        ddp = DistributedDataParallel(
+            model,
+            process_group=dist.group.WORLD,
+            gradient_as_bucket_view=True,
+            static_graph=True,
+        )
+        optimizer = _ParticipateOnPresentZeroOptimizer(ddp.parameters())
+        optimizer.name_params(list(ddp.module.named_parameters()))
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=k,
+            num_warmup_steps=1,
+            accumulate_into_buckets=accumulate_into_buckets,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+
+        # --- Window 1: BOTH params active (real fwd/bwd/step through the GA flow),
+        # establishing present bucket-view grads + readiness. ---
+        batch = torch.ones(2, 4)
+        for _ in range(k):
+            ga.progress(iter([batch]))
+
+        # Isolate the WINDOW-2 divergence: reset participation counters after window 1
+        # (both params were active in window 1 -> both participated on both paths).
+        optimizer.participated.clear()
+        optimizer.skipped.clear()
+
+        # --- Window 2 START zero via the GA-WRAPPER path (exactly what the pipeline
+        # calls each window start -- `pipeline._optimizer` is the _GAOptimizerWrapper):
+        # ON  -> _window_start_zero_grad -> intermittent.grad = present-zero (in place)
+        # OFF -> optimizer.zero_grad(set_to_none=True) -> intermittent.grad = None
+        pipeline._optimizer.zero_grad()
+
+        # --- Window 2 is INACTIVE for `intermittent` (no window-2 backward touches it);
+        # `active` STAYS active (a real window-2 grad). AFOC can't do this drop-out under
+        # static_graph=True/find_unused=False, so we construct it directly. ---
+        with torch.no_grad():
+            model.active.weight.grad = torch.ones_like(model.active.weight)
+
+        # --- Window 2 optimizer step: the participate-on-present-zero optimizer records
+        # each param as participated (present grad) or skipped (None). ---
+        optimizer.step()
+
+        blob = {
+            "aib": accumulate_into_buckets,
+            "participated": dict(optimizer.participated),
+            "skipped": dict(optimizer.skipped),
+        }
+        torch.save(blob, os.path.join(out_dir, f"rank_{rank}.pt"))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+class ActiveInactiveShampooDivergenceTest(unittest.TestCase):
+    """RISK #1: an active->inactive dense param yields DIVERGENT Shampoo participation
+    OFF (skip, grad None) vs ON (participate, grad present-zero); an always-active param
+    does NOT. Multi-process (world_size=2). Motivates the Phase-B per-window
+    active->inactive instrumentation as the load-bearing AFOC inertness proof."""
+
+    def _run(self, accumulate_into_buckets: bool) -> List[dict]:
+        world_size = 2
+        with tempfile.TemporaryDirectory() as out_dir:
+            init = tempfile.NamedTemporaryFile(delete=False)
+            init.close()
+            try:
+                mp.spawn(
+                    _active_inactive_worker,
+                    args=(world_size, init.name, accumulate_into_buckets, out_dir),
+                    nprocs=world_size,
+                    join=True,
+                )
+                return [
+                    torch.load(
+                        os.path.join(out_dir, f"rank_{r}.pt"), weights_only=False
+                    )
+                    for r in range(world_size)
+                ]
+            finally:
+                try:
+                    os.unlink(init.name)
+                except OSError:
+                    pass
+
+    def test_active_inactive_participation_divergence(self) -> None:
+        on_blobs = self._run(accumulate_into_buckets=True)
+        off_blobs = self._run(accumulate_into_buckets=False)
+        for rank, blob in enumerate(on_blobs):
+            # ON: intermittent kept a present-zero grad in window 2 -> PARTICIPATES.
+            self.assertGreaterEqual(
+                blob["participated"].get("intermittent.weight", 0),
+                1,
+                f"[ON rank{rank}] intermittent (active->inactive) should PARTICIPATE "
+                f"(present-zero grad): {blob}",
+            )
+            self.assertEqual(
+                blob["skipped"].get("intermittent.weight", 0),
+                0,
+                f"[ON rank{rank}] intermittent should NOT be skipped under ON: {blob}",
+            )
+        for rank, blob in enumerate(off_blobs):
+            # OFF: intermittent went None in window 2 -> SKIPPED (Shampoo drops it).
+            self.assertGreaterEqual(
+                blob["skipped"].get("intermittent.weight", 0),
+                1,
+                f"[OFF rank{rank}] intermittent (active->inactive) should be SKIPPED "
+                f"(grad None): {blob}",
+            )
+            self.assertEqual(
+                blob["participated"].get("intermittent.weight", 0),
+                0,
+                f"[OFF rank{rank}] intermittent should NOT participate under OFF: {blob}",
+            )
+        # --- The ALWAYS-active param participates on BOTH paths (NO divergence): this is
+        # the AFOC regime (every dense param always used) => the fix is inert there. ---
+        for blob in on_blobs + off_blobs:
+            self.assertGreaterEqual(
+                blob["participated"].get("active.weight", 0),
+                1,
+                f"always-active param must participate on both paths: {blob}",
+            )
+            self.assertEqual(
+                blob["skipped"].get("active.weight", 0),
+                0,
+                f"always-active param must never be skipped: {blob}",
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# H3 additions (session 9): coverage gaps not exercised above — the H1.1
+# optimizer-ownership intersection (the key pre-fail/post-pass), the
+# exception-restore (finally) alias preservation, and the fused-LR tree-clear on a
+# non-target owned leaf. (The non-view grad._base-is-None guard is in
+# BucketViewFailClosedTest; RISK#1, find_unused, double-owner + missing
+# _module_parameters are covered above.)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class _OwnedSubsetModel(nn.Module):
+    """``owned`` + ``unowned``, both bias-free Linears fed constant ones -> after a
+    synced DDP backward BOTH carry an all-ones bucket-view grad. The wrapped optimizer
+    is built over ``owned`` ONLY, so ``unowned`` is DDP-reduced but NOT
+    optimizer-owned."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.owned = nn.Linear(4, 4, bias=False)
+        self.unowned = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.owned(x) + self.unowned(x)
+
+
+class OwnershipIntersectionTest(_PGTestBase):
+    """H1.1: a param that is DDP-reduced (in ``_module_parameters``, requires_grad,
+    live bucket-view) but NOT in the wrapped optimizer's ``param_groups`` MUST be
+    EXCLUDED from ``_collect_bucket_view_targets`` so it falls to the plain path and ON
+    does not diverge from OFF (whose ``optimizer.zero_grad`` only clears
+    optimizer-owned param_groups). Pre-H1.1 ON zeroed EVERY selected bucket-view target
+    in place -> an un-owned DDP grad was zeroed under ON yet left accumulating under OFF
+    (a None-vs-present divergence for that leaf). This asserts the post-fix exclusion.
+    """
+
+    def test_ddp_reduced_but_not_optimizer_owned_is_excluded(self) -> None:
+        model = _OwnedSubsetModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        # Optimizer owns ONLY `owned` -> `unowned` is reduced-but-unowned.
+        optimizer = torch.optim.SGD(model.owned.parameters(), lr=0.0)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+
+        # One synced window establishes bucket-view aliases + readiness for BOTH params.
+        batch = torch.ones(2, 4)
+        ga.progress(iter([batch]))
+        self.assertTrue(ga._bucket_views_ready)
+        # Precondition: BOTH params carry a live bucket-view grad (so the ONLY reason
+        # `unowned` is excluded is the ownership intersection, not a missing grad).
+        self.assertIsNotNone(model.owned.weight.grad)
+        self.assertIsNotNone(model.unowned.weight.grad)
+        self.assertIsNotNone(getattr(model.unowned.weight.grad, "_base", None))
+
+        target_ids = {id(p) for p, _g in ga._collect_bucket_view_targets()}
+        self.assertIn(
+            id(model.owned.weight),
+            target_ids,
+            "optimizer-owned bucket-view param must be an in-place-zero target",
+        )
+        self.assertNotIn(
+            id(model.unowned.weight),
+            target_ids,
+            "DDP-reduced-but-NOT-optimizer-owned param must be EXCLUDED (H1.1) so ON "
+            "does not zero a grad OFF leaves accumulating",
+        )
+
+
+class BucketViewExceptionRestoreTest(_PGTestBase):
+    """If the real-optimizer tree-clear raises, the ``finally`` MUST restore the saved
+    bucket-view aliases (targets NOT left at None -> HBM reclaim keeps working and the
+    next backward accumulates into the persistent bucket) and MUST NOT zero them (the
+    in-place ``grad.zero_()`` runs only on the success path, after restore)."""
+
+    def test_tree_clear_exception_restores_and_does_not_zero_aliases(self) -> None:
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        optimizer = torch.optim.SGD(ddp.parameters(), lr=0.0)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+        ga.progress(iter([torch.ones(1, 4)]))  # establish aliases + readiness
+        self.assertTrue(ga._bucket_views_ready)
+        targets = ga._collect_bucket_view_targets()
+        self.assertTrue(targets, "need >=1 bucket-view target for the restore test")
+        saved = [
+            (p, p.grad, float(none_throws(p.grad).detach().max())) for p, _g in targets
+        ]
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("boom-tree-clear")
+
+        ga._optimizer_wrapper._optimizer.zero_grad = _boom
+        with self.assertRaisesRegex(RuntimeError, "boom-tree-clear"):
+            ga._window_start_zero_grad()
+
+        for p, saved_grad, val_before in saved:
+            self.assertIsNotNone(
+                p.grad,
+                "target grad left at None after a tree-clear exception (alias dropped)",
+            )
+            self.assertIs(
+                p.grad, saved_grad, "target grad not restored to the saved bucket-view"
+            )
+            self.assertIsNotNone(
+                getattr(p.grad, "_base", None), "restored grad is not a bucket-view"
+            )
+            self.assertEqual(
+                float(p.grad.detach().max()),
+                val_before,
+                "target grad was zeroed despite the exception (zero() must run only on "
+                "the success path, after restore)",
+            )
+
+
+class FusedLRTreeClearTest(_PGTestBase):
+    """The window-start zero HIDES only the bucket-view targets, then runs the REAL
+    optimizer tree-clear (the fused-embedding-LR carrier + correct None semantics) which
+    set_to_none-clears every NON-target owned leaf. Shows a non-target owned leaf's grad
+    IS cleared while the target's bucket-view alias is preserved + zeroed in place."""
+
+    def test_non_target_leaf_cleared_while_target_alias_preserved(self) -> None:
+        model = _ConstGradModel()
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        # A plain dense leaf OUTSIDE the DDP, owned by the optimizer -> a non-target.
+        extra = nn.Parameter(torch.zeros(4))
+        optimizer = torch.optim.SGD(list(ddp.parameters()) + [extra], lr=0.0)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+        ga.progress(iter([torch.ones(1, 4)]))  # establish target alias + readiness
+        self.assertTrue(ga._bucket_views_ready)
+        extra.grad = torch.ones(4)  # non-target owned leaf carries a standalone grad
+        target = model.active.weight
+        self.assertIsNotNone(target.grad)
+        self.assertIsNotNone(getattr(target.grad, "_base", None))
+
+        ga._window_start_zero_grad()
+
+        self.assertIsNone(
+            extra.grad,
+            "non-target owned leaf grad must be cleared by the real tree-clear",
+        )
+        self.assertIsNotNone(target.grad, "target bucket-view alias was dropped")
+        self.assertIsNotNone(
+            getattr(target.grad, "_base", None), "target is no longer a bucket-view"
+        )
+        self.assertEqual(
+            float(target.grad.detach().abs().max()),
+            0.0,
+            "target bucket-view grad was not zeroed in place",
+        )
+
+
+class ForeachZeroCoalescingTest(_PGTestBase):
+    """H4.1: the window-start in-place zero coalesces the per-target ``grad.zero_()``
+    into ``torch._foreach_zero_`` per (device,dtype). With MULTIPLE owned bucket-view
+    targets: every target is zeroed, aliases are preserved (still bucket-views), and a
+    subsequent synced window accumulates freshly (the foreach in-place zero took AND did
+    not break the next backward via the version-counter it skips). The multi-window
+    freshness/version behavior is also covered end-to-end by
+    BucketViewAliasStateMachineTest (which now exercises the foreach path)."""
+
+    def test_foreach_zero_multi_target_preserves_aliases(self) -> None:
+        model = _TwoParamModel()  # active + intermittent, both in the loss -> 2 grads
+        ddp = self._make_ddp(model, gradient_as_bucket_view=True, static_graph=True)
+        optimizer = torch.optim.SGD(ddp.parameters(), lr=0.0)  # own BOTH params
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=2,
+            num_warmup_steps=1,
+            accumulate_into_buckets=True,
+        )
+        pipeline = _DDPForwardPipeline(ddp, optimizer)
+        ga = GradientAccumulationWrapper(pipeline, optimizer, ddp, config)
+        ga.progress(iter([torch.ones(2, 4)]))  # synced window 0 -> bucket-views ready
+        self.assertTrue(ga._bucket_views_ready)
+        targets = ga._collect_bucket_view_targets()
+        self.assertGreaterEqual(
+            len(targets), 2, "need >=2 owned bucket-view targets to exercise grouping"
+        )
+
+        ga._window_start_zero_grad()  # foreach-coalesced in-place zero
+
+        for p, _g in targets:
+            self.assertIsNotNone(p.grad, "target alias dropped by the foreach path")
+            self.assertIsNotNone(
+                getattr(p.grad, "_base", None),
+                "target no longer a bucket-view after foreach zero",
+            )
+            self.assertEqual(
+                float(p.grad.detach().abs().max()),
+                0.0,
+                "target grad not zeroed by torch._foreach_zero_",
+            )

--- a/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
+++ b/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
@@ -7,9 +7,17 @@
 
 # pyre-strict
 
+# Citrine missing_for_each_optimizer is suppressed file-wide below. These are CPU unit
+# tests whose whole purpose is to pin the optimizer's INTERACTION with the GA wrapper
+# (zero_grad interception, the step/no-step boundary, and bucket-view accumulation).
+# `foreach=True` swaps SGD's internal implementation to the multi-tensor kernels, which is
+# exactly the behaviour under test, and the perf benefit the rule is chasing is nil on a
+# CPU unit test.
+# @lint-ignore-every CITRINE
+
 import contextlib
 import unittest
-from typing import Any, Iterator, List
+from typing import Any, cast, Iterator, List
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -18,6 +26,7 @@ from torchrec.distributed.train_pipeline.gradient_accumulation import (
     _GAOptimizerWrapper,
     GradientAccumulationConfig,
     GradientAccumulationWrapper,
+    PartialWindowPolicy,
 )
 from torchrec.distributed.train_pipeline.train_pipelines import TrainPipeline
 
@@ -65,6 +74,37 @@ class _RealForwardPipeline(TrainPipeline[Any, torch.Tensor]):
         self._optimizer.step()
         self._optimizer.zero_grad()
         self._progress_count += 1
+        return loss
+
+
+class _EvalAwareForwardPipeline(TrainPipeline[Any, torch.Tensor]):
+    """Forward/backward/step pipeline that respects model.training (like the real APS
+    pipeline): training micros zero_grad -> forward -> backward -> step (so grads
+    ACCUMULATE across a K-micro window via the GA-wrapped optimizer's gating), while eval
+    micros are forward-only under no_grad (no backward, no optimizer step). Used to exercise
+    the eval-reuse GA-state fix end-to-end."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+    ) -> None:
+        super().__init__()  # pyrefly: ignore[missing-argument]
+        self._model = model
+        self._optimizer = optimizer
+
+    def progress(self, dataloader_iter: Iterator[torch.Tensor]) -> torch.Tensor:
+        batch = next(dataloader_iter)
+        if not self._model.training:
+            with torch.no_grad():
+                return self._model(batch).sum()
+        # zero_grad FIRST (GA-wrapped: only zeros at micro 0 of a window), so backward
+        # accumulates across the K micros; step is GA-wrapped (only at the boundary).
+        self._optimizer.zero_grad()
+        output = self._model(batch)
+        loss = output.sum()
+        loss.backward()
+        self._optimizer.step()
         return loss
 
 
@@ -529,6 +569,141 @@ class StopIterationHandlingTest(unittest.TestCase):
         self.assertEqual(flush_call_count[0], 1)
 
 
+class EvalInterludeGATest(unittest.TestCase):
+    """Eval-reuse GA-state fix (Layer 1: _advance_state gated on model.training; plus the
+    StopIteration flush guard). In-trainer / checkpoint eval reuses the SAME
+    train_step -> progress() dispatch (keyed on _ga_config, not train/eval). Before the fix
+    _advance_state() ran outside the model.training guard, so an eval interlude advanced the
+    GA micro-step counter and desynced the K-micro window boundaries. These tests go RED
+    without the fix (counter advances in eval / post-eval weights diverge / eval flushes) and
+    GREEN with it."""
+
+    def _make_wrapper(
+        self, model: nn.Module, num_steps: int = 2
+    ) -> GradientAccumulationWrapper[Any, torch.Tensor]:
+        optimizer = optim.SGD(model.parameters(), lr=0.1)
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=num_steps, num_warmup_steps=1
+        )
+        pipeline = _EvalAwareForwardPipeline(model, optimizer)
+        return GradientAccumulationWrapper(pipeline, optimizer, model, config)
+
+    def test_eval_interlude_does_not_advance_counter(self) -> None:
+        """Core red/green (Layer 1): an eval interlude must NOT advance the GA counter."""
+        model = nn.Linear(10, 5)
+        wrapper = self._make_wrapper(model, num_steps=2)
+        batch = torch.randn(4, 10)
+
+        model.train()
+        wrapper.progress(iter([batch]))  # micro 0 -> current_step 1
+        wrapper.progress(iter([batch]))  # micro 1 (boundary) -> current_step 2
+        self.assertEqual(wrapper.current_step, 2)
+
+        # Eval interlude: 3 micros (odd, NOT a multiple of K=2). Without the fix the counter
+        # would jump to 5 (misaligned); with the fix it stays frozen at 2.
+        model.eval()
+        for _ in range(3):
+            wrapper.progress(iter([batch]))
+        self.assertEqual(
+            wrapper.current_step,
+            2,
+            "eval advanced the GA micro-step counter -> K-micro window boundaries desynced",
+        )
+
+        # Resume training: the next window starts on a clean K-boundary.
+        model.train()
+        wrapper.progress(iter([batch]))  # current_step 3
+        wrapper.progress(iter([batch]))  # current_step 4
+        self.assertEqual(wrapper.current_step, 4)
+
+    def test_eval_interlude_weight_parity_vs_no_eval(self) -> None:
+        """End-to-end red/green: post-eval training weights are BIT-IDENTICAL to a no-eval
+        control (the eval interlude must not perturb the training trajectory)."""
+        torch.manual_seed(0)
+        control = nn.Linear(10, 5)
+        test = nn.Linear(10, 5)
+        test.load_state_dict(control.state_dict())
+
+        g = torch.Generator().manual_seed(123)
+        train_batches = [torch.randn(4, 10, generator=g) for _ in range(8)]
+        eval_batches = [torch.randn(4, 10, generator=g) for _ in range(3)]
+
+        # Control: 8 training micros, no eval.
+        wc = self._make_wrapper(control, num_steps=2)
+        control.train()
+        for b in train_batches:
+            wc.progress(iter([b]))
+
+        # Test: 4 train micros, eval interlude (3 = odd, non-multiple of K), 4 train micros.
+        wt = self._make_wrapper(test, num_steps=2)
+        test.train()
+        for b in train_batches[:4]:
+            wt.progress(iter([b]))
+        test.eval()
+        for b in eval_batches:
+            wt.progress(iter([b]))
+        test.train()
+        for b in train_batches[4:]:
+            wt.progress(iter([b]))
+
+        # Weight parity FIRST so a regression fails on the actual weight divergence (not just
+        # the counter): without the fix, the eval interlude desyncs the windows and the
+        # post-eval training trajectory diverges from the no-eval control.
+        for (name, pc), (_, pt) in zip(
+            control.named_parameters(), test.named_parameters()
+        ):
+            self.assertTrue(
+                torch.equal(pc, pt),
+                f"post-eval weight divergence on {name}: the eval interlude perturbed training",
+            )
+        self.assertEqual(wt.current_step, 8)
+
+    def test_eval_interlude_does_not_change_weights(self) -> None:
+        """An eval interlude (forward-only) must not modify any training weight."""
+        model = nn.Linear(10, 5)
+        wrapper = self._make_wrapper(model, num_steps=2)
+        batch = torch.randn(4, 10)
+        model.train()
+        for _ in range(2):
+            wrapper.progress(iter([batch]))
+        snapshot = [p.detach().clone() for p in model.parameters()]
+        model.eval()
+        for _ in range(3):
+            wrapper.progress(iter([batch]))
+        for before, p in zip(snapshot, model.parameters()):
+            self.assertTrue(
+                torch.equal(before, p), "eval interlude modified a training weight"
+            )
+
+    def test_eval_stop_iteration_does_not_flush(self) -> None:
+        """D3 guard: an eval StopIteration must NEVER raw-flush / step the optimizer, even
+        with pending mid-window gradients."""
+        model = nn.Linear(10, 5)
+        wrapper = self._make_wrapper(model, num_steps=2)
+        batch = torch.randn(4, 10)
+
+        # One training micro -> mid-window, _pending_uncommitted True.
+        model.train()
+        wrapper.progress(iter([batch]))
+        self.assertTrue(wrapper._pending_uncommitted)
+
+        flush_calls = [0]
+        original_flush = wrapper._flush_accumulated_gradients
+
+        def counting_flush(steps: int) -> bool:
+            flush_calls[0] += 1
+            return original_flush(steps)
+
+        # pyre-ignore[8]: monkeypatch for the test
+        wrapper._flush_accumulated_gradients = counting_flush
+        model.eval()
+        with self.assertRaises(StopIteration):
+            wrapper.progress(iter([]))  # exhausted iter -> StopIteration under eval
+        self.assertEqual(
+            flush_calls[0], 0, "eval StopIteration triggered a raw flush/step"
+        )
+
+
 class FlushGradientsTest(unittest.TestCase):
     """Tests for _flush_accumulated_gradients behavior."""
 
@@ -569,6 +744,332 @@ class FlushGradientsTest(unittest.TestCase):
             wrapper.progress(iter([]))
 
         self.assertFalse(wrapper.optimizer_wrapper._needs_zero_grad)
+
+    def test_flush_partial_window_multi_rank_fails_closed(self) -> None:
+        """ws>1 + a partial (uncommitted) window must FAIL-CLOSED rather than step
+        un-reduced rank-local grads (replica divergence). The divisible-N path never
+        reaches here; this guards the checkpoint-resume runtime-partial hole. Simulated
+        via a mocked world_size=2 (single process)."""
+        model = nn.Linear(10, 5)
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=4, num_warmup_steps=1
+        )
+        pipeline = _RealForwardPipeline(model, optimizer)
+        wrapper = GradientAccumulationWrapper(pipeline, optimizer, model, config)
+        with patch("torch.distributed.is_available", return_value=True), patch(
+            "torch.distributed.is_initialized", return_value=True
+        ), patch("torch.distributed.get_world_size", return_value=2):
+            with self.assertRaisesRegex(RuntimeError, "partial final window"):
+                wrapper._flush_accumulated_gradients(2)  # remaining = 2 % 4 = 2 > 0
+
+
+class GAPartialWindowAbortTest(unittest.TestCase):
+    """A3: a partial-window guard that raises rank-locally at ``world_size > 1`` strands its
+    peers in the next collective until the ~30-minute NCCL watchdog fires, burying the real
+    cause. These guards must abort every process group first.
+
+    The matrix is deliberate about WHICH cells abort:
+
+    * raw flush at ws>1 -- aborts under **both** policies. That branch fires BEFORE policy
+      evaluation and is unconditional, so gating the abort on RAISE would leave the hang in
+      place for every STEP caller.
+    * ws<=1 -- never aborts, under either policy. No peers to strand, so the raise keeps its
+      exact previous behavior.
+    """
+
+    _ABORT = (
+        "torchrec.distributed.train_pipeline.gradient_accumulation"
+        ".torch.distributed.distributed_c10d._abort_process_group"
+    )
+
+    def _wrapper(self, policy: PartialWindowPolicy) -> GradientAccumulationWrapper:
+        model = nn.Linear(10, 5)
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=4, num_warmup_steps=1
+        )
+        pipeline = _RealForwardPipeline(model, optimizer)
+        return GradientAccumulationWrapper(
+            pipeline, optimizer, model, config, partial_window_policy=policy
+        )
+
+    @contextlib.contextmanager
+    def _force_world_size(self, world_size: int) -> Iterator[None]:
+        with patch("torch.distributed.is_available", return_value=True), patch(
+            "torch.distributed.is_initialized", return_value=True
+        ), patch("torch.distributed.get_world_size", return_value=world_size):
+            yield
+
+    def test_raw_flush_ws2_aborts_under_raise(self) -> None:
+        w = self._wrapper(PartialWindowPolicy.RAISE)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(2):
+            with self.assertRaisesRegex(RuntimeError, "partial final window"):
+                w._flush_accumulated_gradients(2)
+            mock_abort.assert_called_once_with(None)
+
+    def test_raw_flush_ws2_aborts_under_step(self) -> None:
+        # The corrected cell. An earlier design gated this abort on RAISE, which would have
+        # preserved the hang for every STEP caller -- and STEP is the default.
+        w = self._wrapper(PartialWindowPolicy.STEP)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(2):
+            with self.assertRaisesRegex(RuntimeError, "partial final window"):
+                w._flush_accumulated_gradients(2)
+            mock_abort.assert_called_once_with(None)
+
+    def test_raw_flush_ws1_raises_without_abort_under_raise(self) -> None:
+        w = self._wrapper(PartialWindowPolicy.RAISE)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(1):
+            with self.assertRaisesRegex(RuntimeError, "world_size <= 1"):
+                w._flush_accumulated_gradients(2)
+            mock_abort.assert_not_called()
+
+    def test_raw_flush_ws1_steps_without_abort_under_step(self) -> None:
+        # Historical single-process behavior: sanctioned local step, no raise, no abort.
+        w = self._wrapper(PartialWindowPolicy.STEP)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(1):
+            self.assertTrue(w._flush_accumulated_gradients(2))
+            mock_abort.assert_not_called()
+
+    def test_full_window_never_aborts(self) -> None:
+        # remaining == 0 -> not a partial window -> no raise and no abort at any world_size.
+        w = self._wrapper(PartialWindowPolicy.RAISE)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(2):
+            self.assertFalse(w._flush_accumulated_gradients(4))
+            mock_abort.assert_not_called()
+
+
+class GAPartialWindowDiscardTest(unittest.TestCase):
+    """``PartialWindowPolicy.DISCARD``: a partial window at exhaustion is thrown away
+    rank-locally -- zeroed, no optimizer step, no collective, no process-group abort -- so a
+    consume-all phase simply ends instead of raising.
+
+    The load-bearing detail is the ZERO. ``_GAOptimizerWrapper.zero_grad`` early-returns when
+    ``_needs_zero_grad`` is False, and False is exactly the mid-window state, so a bare
+    ``zero_grad()`` here is a guaranteed no-op and the discarded gradients would silently
+    survive into the next window. The implementation re-arms the flag first; these tests pin
+    that, not just "the branch was taken".
+    """
+
+    _ABORT = (
+        "torchrec.distributed.train_pipeline.gradient_accumulation"
+        ".torch.distributed.distributed_c10d._abort_process_group"
+    )
+
+    def _make(
+        self, policy: PartialWindowPolicy, accumulate_into_buckets: bool = False
+    ) -> tuple[GradientAccumulationWrapper, nn.Module, optim.Optimizer]:
+        model = nn.Linear(10, 5)
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        config = GradientAccumulationConfig(
+            is_enabled=True,
+            num_steps=4,
+            num_warmup_steps=1,
+            accumulate_into_buckets=accumulate_into_buckets,
+        )
+        pipeline = _RealForwardPipeline(model, optimizer)
+        wrapper = GradientAccumulationWrapper(
+            pipeline, optimizer, model, config, partial_window_policy=policy
+        )
+        return wrapper, model, optimizer
+
+    def _accumulate_partial_window(
+        self, wrapper: GradientAccumulationWrapper, model: nn.Module, micros: int = 2
+    ) -> None:
+        """Run ``micros`` of a K=4 window and assert the trap preconditions actually hold:
+        gradients are non-zero AND ``_needs_zero_grad`` is False."""
+        for _ in range(micros):
+            wrapper.progress(iter([torch.randn(2, 10)]))
+        self.assertFalse(
+            wrapper.optimizer_wrapper._needs_zero_grad,
+            "precondition broken: mid-window _needs_zero_grad should be False -- without "
+            "it the zero_grad no-op trap this test exists for is not being exercised",
+        )
+        self.assertTrue(
+            any(
+                p.grad is not None and torch.count_nonzero(p.grad) > 0
+                for p in model.parameters()
+            ),
+            "precondition broken: expected accumulated non-zero grads before the discard",
+        )
+
+    @contextlib.contextmanager
+    def _force_world_size(self, world_size: int) -> Iterator[None]:
+        with patch("torch.distributed.is_available", return_value=True), patch(
+            "torch.distributed.is_initialized", return_value=True
+        ), patch("torch.distributed.get_world_size", return_value=world_size):
+            yield
+
+    def test_discard_actually_zeroes_the_gradients(self) -> None:
+        """THE regression test for the ``_needs_zero_grad`` no-op: non-zero grads in, zero
+        (or None) grads out."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+
+        self.assertFalse(wrapper._flush_accumulated_gradients(2))
+
+        for name, p in model.named_parameters():
+            self.assertTrue(
+                p.grad is None or torch.count_nonzero(p.grad) == 0,
+                f"discarded gradients survived on {name}",
+            )
+
+    def test_discard_takes_no_optimizer_step(self) -> None:
+        """Weights must be bit-identical across the discard, and the real optimizer's
+        ``step`` must not be called."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        before = [p.detach().clone() for p in model.parameters()]
+
+        with patch.object(
+            wrapper.optimizer_wrapper._optimizer, "step"
+        ) as mock_step, patch.object(
+            wrapper.optimizer_wrapper, "step"
+        ) as mock_wrapper_step:
+            wrapper._flush_accumulated_gradients(2)
+            mock_step.assert_not_called()
+            mock_wrapper_step.assert_not_called()
+
+        for b, p in zip(before, model.parameters()):
+            self.assertTrue(
+                torch.equal(b, p), "DISCARD moved the weights (an optimizer step ran)"
+            )
+
+    def test_discard_never_aborts_process_groups_at_ws2(self) -> None:
+        """The three-way matrix at ``world_size > 1``. STEP and RAISE both abort-then-raise
+        (unchanged); DISCARD does neither -- an exhaustion-time partial window is the normal
+        ending of a consume-all phase, not a fault."""
+        for policy in (PartialWindowPolicy.STEP, PartialWindowPolicy.RAISE):
+            with self.subTest(policy=policy):
+                wrapper, model, _optimizer = self._make(policy)
+                self._accumulate_partial_window(wrapper, model)
+                with patch(self._ABORT) as mock_abort, self._force_world_size(2):
+                    with self.assertRaisesRegex(RuntimeError, "partial final window"):
+                        wrapper._flush_accumulated_gradients(2)
+                    mock_abort.assert_called_once_with(None)
+
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        with patch(self._ABORT) as mock_abort, self._force_world_size(2):
+            self.assertFalse(wrapper._flush_accumulated_gradients(2))
+            mock_abort.assert_not_called()
+
+    def test_discard_does_not_rewind_the_counter_or_replay_warmup(self) -> None:
+        """DISCARD must NOT call ``reset()``. Zeroing ``_current_step`` / ``_window_base``
+        would re-enter GA/DDP warmup on every new iterator."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        step_before = wrapper.optimizer_wrapper._current_step
+        base_before = wrapper.optimizer_wrapper._window_base
+
+        wrapper._flush_accumulated_gradients(2)
+
+        self.assertEqual(wrapper.optimizer_wrapper._current_step, step_before)
+        self.assertEqual(wrapper.optimizer_wrapper._window_base, base_before)
+
+    def test_discard_does_not_realign_the_window_itself(self) -> None:
+        """``realign_window()`` is the CALLER's job (progress() does it right after the
+        flush). Doing it here too would double-anchor."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+
+        with patch.object(
+            wrapper.optimizer_wrapper, "realign_window"
+        ) as mock_realign, patch.object(
+            wrapper.optimizer_wrapper, "reset"
+        ) as mock_reset:
+            wrapper._flush_accumulated_gradients(2)
+            mock_realign.assert_not_called()
+            mock_reset.assert_not_called()
+
+    def test_discard_routes_through_the_wrapper_to_preserve_bucket_views(self) -> None:
+        """Under ``accumulate_into_buckets`` the zero must go through
+        ``_GAOptimizerWrapper.zero_grad`` -> ``_window_start_zero_grad`` (alias-preserving),
+        NOT straight to the real optimizer, or the DDP ``gradient_as_bucket_view`` aliases
+        are dropped."""
+        wrapper, model, _optimizer = self._make(
+            PartialWindowPolicy.DISCARD, accumulate_into_buckets=True
+        )
+        self._accumulate_partial_window(wrapper, model)
+
+        with patch.object(wrapper, "_window_start_zero_grad") as mock_window_zero:
+            wrapper._flush_accumulated_gradients(2)
+            mock_window_zero.assert_called_once_with()
+
+    def test_discard_is_inert_on_a_complete_window(self) -> None:
+        """remaining == 0 is not a partial window: no zero, no step, no branch."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        grads_before = [
+            None if p.grad is None else p.grad.detach().clone()
+            for p in model.parameters()
+        ]
+
+        self.assertFalse(wrapper._flush_accumulated_gradients(4))
+
+        for g, p in zip(grads_before, model.parameters()):
+            if g is None:
+                self.assertIsNone(p.grad)
+            else:
+                self.assertIsNotNone(p.grad)
+                self.assertTrue(torch.equal(g, p.grad))
+
+    def test_explicit_is_last_batch_commits_in_band_rather_than_discarding(
+        self,
+    ) -> None:
+        """Contract pin (raised by an independent critic). DISCARD scopes to the EXHAUSTION
+        path only. An explicit ``is_last_batch=True`` partial window still commits in-band,
+        exactly as under STEP -- ``is_last_batch`` forces ``should_sync``, so the grads are
+        cross-rank reduced and the step is replica-safe AND keeps the data, which is
+        strictly better than discarding it. Asymmetry with RAISE (which DOES fence the
+        explicit path) is intentional, so lock it down."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        before = [p.detach().clone() for p in model.parameters()]
+
+        # Micro 3 of a K=4 window, flagged as the last batch -> forced in-band step.
+        wrapper.progress(iter([torch.randn(2, 10)]), is_last_batch=True)
+
+        moved = any(not torch.equal(b, p) for b, p in zip(before, model.parameters()))
+        self.assertTrue(
+            moved,
+            "explicit is_last_batch under DISCARD must still take the synchronized in-band "
+            "step, not silently discard the window",
+        )
+        self.assertFalse(
+            wrapper._pending_uncommitted,
+            "the in-band commit must clear _pending_uncommitted so a later exhaustion does "
+            "not double-handle the window",
+        )
+
+    def test_explicit_is_last_batch_still_raises_under_raise(self) -> None:
+        """Negative control for the test above: RAISE keeps fencing the explicit path, so
+        the DISCARD carve-out is genuinely policy-scoped and not a blanket removal."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.RAISE)
+        self._accumulate_partial_window(wrapper, model)
+        with patch(self._ABORT):
+            with self.assertRaisesRegex(RuntimeError, "is_last_batch"):
+                wrapper.progress(iter([torch.randn(2, 10)]), is_last_batch=True)
+
+    def test_discard_end_to_end_through_stop_iteration(self) -> None:
+        """The real path: a partial window then an exhausted iterator. StopIteration still
+        propagates, the grads are gone, and the caller's realign leaves the counter
+        monotonic."""
+        wrapper, model, _optimizer = self._make(PartialWindowPolicy.DISCARD)
+        self._accumulate_partial_window(wrapper, model)
+        step_before = wrapper.optimizer_wrapper._current_step
+
+        with self.assertRaises(StopIteration):
+            wrapper.progress(iter([]))
+
+        for name, p in model.named_parameters():
+            self.assertTrue(
+                p.grad is None or torch.count_nonzero(p.grad) == 0,
+                f"discarded gradients survived on {name} via the StopIteration path",
+            )
+        self.assertFalse(wrapper._pending_uncommitted)
+        self.assertEqual(wrapper.optimizer_wrapper._current_step, step_before)
+        self.assertEqual(wrapper.optimizer_wrapper._window_base, step_before)
 
 
 class OptimizerInjectionTest(unittest.TestCase):
@@ -690,6 +1191,70 @@ class FullTrainingLoopTest(unittest.TestCase):
         self.assertEqual(len(results), 3)
         self.assertEqual(model.no_sync_entered, 0)
 
+    def test_disabled_ga_does_not_signal_the_observer(self) -> None:
+        """A disabled wrapper is a pure pass-through: it must leave the caller's own
+        boundary state alone rather than forcing it True every batch."""
+        model = _MockModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        pipeline = _MockPipeline(num_batches=3)
+        observer = MagicMock()
+        ga = GradientAccumulationWrapper(
+            pipeline,
+            optimizer,
+            model,
+            GradientAccumulationConfig(is_enabled=False),
+            window_observer=observer,
+        )
+
+        dummy_iter: Iterator[Any] = iter([])
+        for _ in range(3):
+            ga.progress(dummy_iter)
+
+        observer.assert_not_called()
+        # And the wrapper must not have injected the retired attribute names either.
+        self.assertFalse(hasattr(pipeline, "_ga_should_step"))
+        self.assertFalse(hasattr(pipeline, "_ga_at_window_start"))
+
+    def test_enabled_ga_signals_observer_before_inner_progress(self) -> None:
+        """The boundary must arrive BEFORE the inner progress(), or a sub-step that
+        bypasses the wrapped optimizer would gate on the previous micro's answer."""
+        model = _MockModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        pipeline = _MockPipeline(num_batches=4)
+        seen_at_progress: List[tuple[bool, bool]] = []
+        state: dict[str, bool] = {"should_step": False, "at_window_start": False}
+
+        def observer(*, should_step: bool, at_window_start: bool) -> None:
+            state["should_step"] = should_step
+            state["at_window_start"] = at_window_start
+
+        inner_progress = pipeline.progress
+
+        def recording_progress(dataloader_iter: Iterator[Any]) -> float:
+            seen_at_progress.append((state["should_step"], state["at_window_start"]))
+            return inner_progress(dataloader_iter)
+
+        # pyre-ignore[8]: test double rebinds the bound method on the instance.
+        pipeline.progress = recording_progress
+        ga = GradientAccumulationWrapper(
+            pipeline,
+            optimizer,
+            model,
+            GradientAccumulationConfig(is_enabled=True, num_steps=2),
+            window_observer=observer,
+        )
+        model.train()
+
+        dummy_iter: Iterator[Any] = iter([])
+        for _ in range(4):
+            ga.progress(dummy_iter)
+
+        # K=2: window starts on micros 0 and 2, boundary steps land on micros 1 and 3.
+        self.assertEqual(
+            seen_at_progress,
+            [(False, True), (True, False), (False, True), (True, False)],
+        )
+
     def test_is_last_batch_forces_sync_and_flush(self) -> None:
         model = _MockModel()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
@@ -721,9 +1286,35 @@ class FullTrainingLoopTest(unittest.TestCase):
             ga.progress(dummy_iter)
         self.assertEqual(ga.current_step, 3)
 
-        ga.reset()
+        # Mid-window (3 of 4 micros) => an open partial window; reset must be an
+        # explicit drop_partial opt-in (S2 clean-boundary guard).
+        ga.reset(drop_partial=True)
         self.assertEqual(ga.current_step, 0)
         self.assertEqual(ga.optimizer_wrapper._current_step, 0)
+
+    def test_reset_raises_on_open_partial_window(self) -> None:
+        """S2: reset() with an open partial window fail-closes unless drop_partial."""
+        model = _MockModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        pipeline = _MockPipeline(num_batches=8)
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=4, num_warmup_steps=1
+        )
+        ga = GradientAccumulationWrapper(pipeline, optimizer, model, config)
+
+        dummy_iter: Iterator[Any] = iter([])
+        # 3 of 4 micros -> mid-window, un-stepped grads pending.
+        for _ in range(3):
+            ga.progress(dummy_iter)
+        self.assertTrue(ga._pending_uncommitted)
+        with self.assertRaises(RuntimeError):
+            ga.reset()
+
+        # Complete the window (4th micro commits/steps) -> clean boundary -> reset ok.
+        ga.progress(dummy_iter)
+        self.assertFalse(ga._pending_uncommitted)
+        ga.reset()
+        self.assertEqual(ga.current_step, 0)
 
     def test_gradient_values_accumulated(self) -> None:
         """Gradients are accumulated across micro-batches (not replaced)."""
@@ -768,30 +1359,37 @@ class _MockDDPModule(torch.nn.Module):
 
 
 class _ModelWithNestedDDP(torch.nn.Module):
-    """Model that contains an inner DDP-like module, mimicking the VLE pattern.
+    """Model with a REGISTERED inner DDP-like submodule (in ``_modules``).
 
-    ShardedVariableLengthEmbeddingArch wraps its DATA_PARALLEL lookups in
-    their own DistributedDataParallel instances.  This mock replicates that
-    structure so we can verify that GradientAccumulationWrapper propagates
-    no_sync to those inner DDP modules.
+    This exercises the discovery mechanism for inner DDPs that ARE registered submodules
+    (found by the ``root.modules()`` walk and entered via no_sync).
+
+    NOTE: production ``ShardedVariableLengthEmbeddingArch`` stores its lookup DDPs in a
+    PLAIN Python list (``self._lookups``), NOT a registered submodule/ModuleList, so those
+    DDPs are NOT discovered and reduce every micro (numerically correct, no reclaim). This
+    mock is therefore the structural OPPOSITE of real VLE; the plain-list-not-discovered
+    contract is covered by test_ga_bucket_view_alias.
     """
 
     def __init__(self) -> None:
         super().__init__()
         self.dense_layer = torch.nn.Linear(10, 5)
-        # Simulates VLE's internal DDP wrapper for DP lookup tables
+        # A REGISTERED inner DDP (contrast: real VLE uses an unregistered plain list)
         self.inner_ddp = _MockDDPModule()
 
 
 class NestedDDPNoSyncTest(unittest.TestCase):
-    """Tests that _get_no_sync_context propagates to nested DDP modules.
+    """Tests that _get_no_sync_context propagates to REGISTERED nested DDP modules.
 
-    Regression test for the VLE (Variable Length Embedding) gradient
-    accumulation bug: ShardedVariableLengthEmbeddingArch creates its own
-    internal DDP for DATA_PARALLEL lookups. The original implementation
-    only called no_sync() on the outer DDP, so those inner DDP modules
-    would all-reduce on every backward pass — even intermediate GA
-    micro-batches that should only accumulate locally.
+    Verifies the discovery mechanism for inner DDPs that are registered submodules (in
+    ``_modules``): _get_no_sync_context enters no_sync on them, so intermediate GA
+    micro-batches accumulate locally instead of all-reducing.
+
+    NOTE: this does NOT reflect production VLE. ShardedVariableLengthEmbeddingArch stores
+    its lookup DDPs in an UNREGISTERED plain list, so they are NOT discovered and reduce
+    every micro (numerically correct; no standalone-grad duplication to reclaim). See
+    test_ga_bucket_view_alias for the plain-list contract + the real bucket-view alias
+    lifecycle.
     """
 
     def setUp(self) -> None:
@@ -814,11 +1412,13 @@ class NestedDDPNoSyncTest(unittest.TestCase):
         _MockDDPModule,
         GradientAccumulationWrapper[Any, Any],
     ]:
-        """Create a GradientAccumulationWrapper around a model with nested DDP.
+        """Create a GradientAccumulationWrapper around a model with a REGISTERED nested DDP.
 
-        The model itself does NOT have no_sync (it's not wrapped in an
-        outer DDP), but it contains an inner DDP child module. This is the
-        exact pattern that VLE creates.
+        The model itself does NOT have no_sync (it's not wrapped in an outer DDP), but it
+        contains a REGISTERED inner DDP child module (in ``_modules``), which the discovery
+        walk finds. NOTE: this is the structural OPPOSITE of production VLE, whose lookup
+        DDPs live in an UNREGISTERED plain list and are NOT discovered (see
+        test_ga_bucket_view_alias for the real plain-list contract).
         """
         model = _ModelWithNestedDDP()
         inner_ddp = model.inner_ddp
@@ -1001,3 +1601,567 @@ class NestedDDPNoSyncTest(unittest.TestCase):
                 raise RuntimeError("test error")
 
         self.assertEqual(inner_ddp.no_sync_exited, 1)
+
+
+class _SplitOrDefaultModePipeline(TrainPipeline[Any, torch.Tensor]):
+    """Faithful CPU model of the APS optimizer-step paths for GA cross-window testing.
+
+    APS ``train_pipeline.py`` zeros grads at the top of ``progress()`` through the
+    (GA-wrapper-replaced) ``self._optimizer.zero_grad()`` (train_pipeline.py:1401,
+    gated by ``_needs_zero_grad``), then dispatches the optimizer STEP one of two ways
+    (train_pipeline.py:1461-1470):
+
+    * ``bypass_wrapper_step=False`` (``_step_optimizer_default``): step via the
+      wrapper ``self._optimizer.step()`` -> the wrapper resets ``_needs_zero_grad``
+      at the accumulation boundary (gradient_accumulation.py:101).
+    * ``bypass_wrapper_step=True`` (``_step_optimizer_embedding_lookup_fwd`` /
+      ``_step_optimizer_fp_allreduce``): step a CHILD optimizer directly (mirrors
+      ``self._dense_optimizer``/``self._sparse_optimizer``), gated on the GA consume
+      boundary the wrapper delivers via ``window_observer`` (== ``_ga_at_consume_boundary()``).
+      This path NEVER calls the wrapper ``.step()``, so nothing resets ``_needs_zero_grad``.
+
+    Records the post-backward grad of ``model.weight`` at every micro-batch so a test
+    can detect grads leaking ACROSS logical windows (a stale-grad-reset bug).
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        bypass_wrapper_step: bool,
+    ) -> None:
+        super().__init__()  # pyrefly: ignore[missing-argument]
+        self._model = model
+        # self._optimizer is replaced by the GA wrapper on enable; _child_optimizer
+        # keeps the raw reference the split path would step directly.
+        self._optimizer = optimizer
+        self._child_optimizer = optimizer
+        self._bypass_wrapper_step = bypass_wrapper_step
+        self.post_backward_grads: List[torch.Tensor] = []
+        self.child_step_count: int = 0
+        # Owned by this pipeline, defaulted to the non-GA answer; the wrapper updates it
+        # through window_observer when GA is enabled.
+        self._ga_should_step: bool = True
+        self._ga_at_window_start: bool = True
+
+    def set_ga_window_state(self, *, should_step: bool, at_window_start: bool) -> None:
+        self._ga_should_step = should_step
+        self._ga_at_window_start = at_window_start
+
+    def progress(self, dataloader_iter: Iterator[torch.Tensor]) -> torch.Tensor:
+        batch = next(dataloader_iter)
+        # Top-of-progress zero_grad through the (wrapper-replaced) optimizer.
+        self._optimizer.zero_grad()
+        out = self._model(batch)
+        loss = out.sum()
+        loss.backward()
+        weight = cast(torch.Tensor, self._model.weight)
+        assert weight.grad is not None
+        self.post_backward_grads.append(weight.grad.detach().clone())
+        if self._bypass_wrapper_step:
+            # Split-optimizer path: step the child directly, gated on the GA boundary.
+            if self._ga_should_step:
+                self.child_step_count += 1
+                self._child_optimizer.step()
+        else:
+            # Default path: step through the wrapper (self-gated at the boundary).
+            self._optimizer.step()
+        return loss
+
+
+class SplitModeCrossWindowGradTest(unittest.TestCase):
+    """P1.1 probe / R3 red-green regression for the split-mode cross-window
+    gradient-zeroing contract.
+
+    Uses x==ones so every micro-batch contributes an identical grad (== ones) to a
+    bias-free Linear (grad == input, weight-independent), and lr==0 so weights stay
+    fixed and grads stay input-determined. With K=2 and 4 micro-batches (2 full
+    windows), each window START (micro 0 and micro 2) must see a FRESH single-micro
+    grad if zero_grad fires once per window:
+
+      CORRECT: post_backward_grads == [1g, 2g, 1g, 2g]
+      LEAK:    post_backward_grads == [1g, 2g, 3g, 4g]  (grads never re-zeroed)
+    """
+
+    def _run(
+        self,
+        bypass_wrapper_step: bool,
+        k: int = 2,
+        num_micros: int = 4,
+        mark_last: bool = False,
+    ) -> _SplitOrDefaultModePipeline:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 1, bias=False)
+        optimizer = optim.SGD(model.parameters(), lr=0.0)
+        pipeline = _SplitOrDefaultModePipeline(model, optimizer, bypass_wrapper_step)
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=k, num_warmup_steps=1
+        )
+        wrapper = GradientAccumulationWrapper(
+            pipeline,
+            optimizer,
+            model,
+            config,
+            window_observer=pipeline.set_ga_window_state,
+        )
+        data: Iterator[torch.Tensor] = iter(
+            [torch.ones(1, 4) for _ in range(num_micros)]
+        )
+        for i in range(num_micros):
+            wrapper.progress(data, is_last_batch=(mark_last and i == num_micros - 1))
+        return pipeline
+
+    def test_default_mode_zeros_grad_each_window(self) -> None:
+        """CONTROL: default step path (wrapper.step) resets _needs_zero_grad, so each
+        window start sees a fresh single-micro grad. Must PASS on current code."""
+        pipeline = self._run(bypass_wrapper_step=False)
+        g = pipeline.post_backward_grads
+        self.assertEqual(len(g), 4)
+        # Window starts (micro 0, micro 2) see a fresh single-micro grad.
+        self.assertTrue(
+            torch.allclose(g[2], g[0]),
+            f"default-mode window-2-start grad {g[2].flatten().tolist()} != "
+            f"window-1-start grad {g[0].flatten().tolist()}",
+        )
+        # Within-window accumulation still holds (boundary == 2x window-start).
+        self.assertTrue(torch.allclose(g[1], 2.0 * g[0]))
+        self.assertTrue(torch.allclose(g[3], 2.0 * g[2]))
+
+    def test_split_mode_zeros_grad_each_window(self) -> None:
+        """R3 RED->GREEN: split step path (child.step bypasses the wrapper) must ALSO
+        zero grads once per window. On current code _needs_zero_grad is never reset in
+        split mode, so grads leak across windows and this FAILS (red)."""
+        pipeline = self._run(bypass_wrapper_step=True)
+        g = pipeline.post_backward_grads
+        self.assertEqual(len(g), 4)
+        self.assertTrue(
+            torch.allclose(g[2], g[0]),
+            "CROSS-WINDOW GRAD LEAK in split mode: window-2-start grad "
+            f"{g[2].flatten().tolist()} != window-1-start grad "
+            f"{g[0].flatten().tolist()} (expected equal; unequal => _needs_zero_grad "
+            "never reset because split child-step bypasses _GAOptimizerWrapper.step()).",
+        )
+        self.assertTrue(torch.allclose(g[3], 2.0 * g[2]))
+
+    def test_split_mode_partial_window_commits_in_band(self) -> None:
+        """R3 partial window (N%K!=0): K=2, 3 micros = 1 full window [0,1] + 1 partial
+        window [2] marked is_last_batch. The partial window must commit in-band (the
+        split child steps once) with freshly-zeroed grads and no double-step."""
+        pipeline = self._run(
+            bypass_wrapper_step=True, k=2, num_micros=3, mark_last=True
+        )
+        g = pipeline.post_backward_grads
+        self.assertEqual(len(g), 3)
+        # Window starts (micro 0, micro 2) see a fresh single-micro grad; the full
+        # window boundary (micro 1) sees 2x.
+        self.assertTrue(torch.allclose(g[0], torch.ones_like(g[0])))
+        self.assertTrue(torch.allclose(g[1], 2.0 * torch.ones_like(g[1])))
+        self.assertTrue(torch.allclose(g[2], torch.ones_like(g[2])))
+        # ceil(3/2) == 2 optimizer steps: micro-1 boundary + micro-2 forced last batch.
+        self.assertEqual(pipeline.child_step_count, 2)
+
+    def test_default_mode_partial_window_commits_in_band(self) -> None:
+        """Same partial window for default mode: the one-shot forced wrapper step handles
+        the final r<K window and grads are zeroed per window (no cross-window leak)."""
+        pipeline = self._run(
+            bypass_wrapper_step=False, k=2, num_micros=3, mark_last=True
+        )
+        g = pipeline.post_backward_grads
+        self.assertEqual(len(g), 3)
+        self.assertTrue(torch.allclose(g[0], torch.ones_like(g[0])))
+        self.assertTrue(torch.allclose(g[1], 2.0 * torch.ones_like(g[1])))
+        self.assertTrue(torch.allclose(g[2], torch.ones_like(g[2])))
+
+    def test_partial_window_trailing_stop_iteration_no_double_step(self) -> None:
+        """After an explicit partial window commits in-band (is_last_batch on the final
+        r<K micro), a trailing progress() that raises StopIteration must NOT re-flush /
+        re-step: the window already committed so _pending_uncommitted is False. Covers
+        both split and default modes."""
+        for bypass in (True, False):
+            torch.manual_seed(0)
+            model = nn.Linear(4, 1, bias=False)
+            optimizer = optim.SGD(model.parameters(), lr=0.0)
+            pipeline = _SplitOrDefaultModePipeline(model, optimizer, bypass)
+            config = GradientAccumulationConfig(
+                is_enabled=True, num_steps=2, num_warmup_steps=1
+            )
+            wrapper = GradientAccumulationWrapper(
+                pipeline,
+                optimizer,
+                model,
+                config,
+                window_observer=pipeline.set_ga_window_state,
+            )
+            data: Iterator[torch.Tensor] = iter([torch.ones(1, 4) for _ in range(3)])
+            wrapper.progress(data)  # micro 0 (window-1 start)
+            wrapper.progress(data)  # micro 1 (window-1 boundary)
+            wrapper.progress(data, is_last_batch=True)  # micro 2 (partial, in-band)
+            self.assertFalse(
+                wrapper._pending_uncommitted,
+                f"partial window not committed in-band (bypass={bypass})",
+            )
+            flush_calls = [0]
+            orig_flush = wrapper._flush_accumulated_gradients
+
+            def _counting_flush(steps: int, _o=orig_flush, _c=flush_calls) -> bool:
+                _c[0] += 1
+                return _o(steps)
+
+            wrapper._flush_accumulated_gradients = (
+                _counting_flush  # pyrefly: ignore[bad-assignment]
+            )
+            with self.assertRaises(StopIteration):
+                wrapper.progress(iter([]))  # trailing: exhausted -> StopIteration
+            self.assertEqual(
+                flush_calls[0],
+                0,
+                f"trailing StopIteration re-flushed after in-band commit (bypass={bypass})",
+            )
+
+
+class _IteratorDrivenStepPipeline(TrainPipeline[Any, int]):
+    """Pipeline that consumes from the PASSED iterator and steps the (GA-wrapped) optimizer.
+
+    Consuming the passed iterator -- rather than an internal counter -- is what lets a test
+    exhaust iterator A and then drive iterator B through the SAME wrapper, which is the
+    scenario the window-anchor exists for. ``self._optimizer`` is replaced by the
+    ``_GAOptimizerWrapper`` at wrapper construction, so ``step()`` here is gated and the
+    underlying mock optimizer records only the calls that actually reached it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()  # pyrefly: ignore[missing-argument]
+        self._optimizer = MagicMock()
+        # Owned by this pipeline; the wrapper updates them through window_observer.
+        self._ga_at_window_start: bool = False
+        self._ga_should_step: bool = False
+
+    def set_ga_window_state(self, *, should_step: bool, at_window_start: bool) -> None:
+        self._ga_should_step = should_step
+        self._ga_at_window_start = at_window_start
+
+    def progress(self, dataloader_iter: Iterator[Any]) -> int:
+        value = next(dataloader_iter)  # StopIteration when exhausted
+        self._optimizer.step()
+        return value
+
+
+class WindowRealignmentTest(unittest.TestCase):
+    """Re-anchoring the K-window when a data iterator is exhausted.
+
+    The optimizer-step / grad-sync / window-start boundaries are computed off a
+    free-running micro counter. A phase that consumes a NON-multiple of K micro-batches
+    before exhausting leaves that counter off-modulo, so every SUBSEQUENT window's boundary
+    is shifted off the trainer's logical step. ``realign_window()`` moves the window anchor
+    to the exhaustion point; it deliberately does NOT reset ``current_step`` (which would
+    break the public accessor's monotonic contract and replay ``num_warmup_steps`` on every
+    new iterator).
+    """
+
+    K: int = 4
+
+    def _make(self, num_warmup_steps: int = 1) -> tuple[
+        GradientAccumulationWrapper[Any, int],
+        _IteratorDrivenStepPipeline,
+        _MockModel,
+        MagicMock,
+    ]:
+        model = _MockModel()
+        optimizer = MagicMock(spec=torch.optim.Optimizer)
+        pipeline = _IteratorDrivenStepPipeline()
+        config = GradientAccumulationConfig(
+            is_enabled=True, num_steps=self.K, num_warmup_steps=num_warmup_steps
+        )
+        wrapper: GradientAccumulationWrapper[Any, int] = GradientAccumulationWrapper(
+            pipeline,
+            optimizer,
+            model,
+            config,
+            window_observer=pipeline.set_ga_window_state,
+        )
+        model.train()
+        return wrapper, pipeline, model, optimizer
+
+    @staticmethod
+    def _exhaust(wrapper: GradientAccumulationWrapper[Any, int], n: int) -> None:
+        """Consume n micros from a fresh iterator, then drive it to StopIteration."""
+        it: Iterator[int] = iter(range(n))
+        for _ in range(n):
+            wrapper.progress(it)
+        try:
+            wrapper.progress(it)
+        except StopIteration:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("iterator did not raise StopIteration")
+
+    def test_combined_boundary_moves_together_after_exhaustion(self) -> None:
+        """THE load-bearing test: after a non-K-multiple exhaustion, the optimizer step, the
+        DDP sync decision and the ``at_window_start`` signal must ALL move to the
+        SAME new boundary.
+
+        Asserting optimizer steps alone can pass while grad sync stays on the old boundary,
+        which is precisely the silent replica-divergence bug this guards.
+        """
+        wrapper, pipeline, model, optimizer = self._make()
+
+        # Iterator A: 6 micros, 6 % 4 == 2 -> exhausts OFF the window boundary.
+        self._exhaust(wrapper, 6)
+        # The partial window was committed in-band by the flush (world_size <= 1, policy
+        # STEP), then the window was re-anchored at global micro 6.
+        self.assertEqual(wrapper.steps_in_window, 0)
+        self.assertEqual(wrapper.current_step, 6)
+
+        optimizer.step.reset_mock()
+        sync_before = model.no_sync_entered
+
+        # Iterator B: record all three signals per micro.
+        stepped: list[bool] = []
+        synced: list[bool] = []
+        at_start: list[bool] = []
+        it: Iterator[int] = iter(range(self.K))
+        for _ in range(self.K):
+            n_steps_before = optimizer.step.call_count
+            no_sync_before = model.no_sync_entered
+            wrapper.progress(it)
+            stepped.append(optimizer.step.call_count > n_steps_before)
+            # no_sync NOT entered => this micro ran under nullcontext => DDP synced.
+            synced.append(model.no_sync_entered == no_sync_before)
+            at_start.append(pipeline._ga_at_window_start)
+
+        # Without realignment the boundary would land on iterator B's SECOND micro (global
+        # step 7, since (7 + 1) % 4 == 0) instead of its fourth -- so `stepped` would read
+        # [False, True, False, False] and every one of these assertions would fail.
+        self.assertEqual(
+            stepped, [False, False, False, True], "optimizer-step boundary"
+        )
+        self.assertEqual(synced, [False, False, False, True], "DDP grad-sync boundary")
+        self.assertEqual(at_start, [True, False, False, False], "window-start signal")
+        self.assertGreater(model.no_sync_entered, sync_before)
+
+    def test_partial_flush_after_realignment_uses_window_relative_count(self) -> None:
+        """Mutation guard for the flush CALL-SITE input.
+
+        Every other exhaustion test in this class runs while the anchor is still 0, where
+        ``steps_in_window == current_step`` -- so passing the global counter to
+        ``_flush_accumulated_gradients`` is indistinguishable from passing the
+        window-relative one, and reverting that call site would keep them all green.
+
+        Here the anchor is 6 and 2 micros are accumulated. The correct input is 2
+        (``remaining = 2 % 4 = 2`` -> partial window -> sanctioned in-band step), whereas the
+        global 8 gives ``remaining = 8 % 4 == 0`` -> the flush returns False and the partial
+        window is silently dropped, un-stepped.
+        """
+        wrapper, _pipeline, _model, optimizer = self._make()
+
+        self._exhaust(wrapper, 6)
+        self.assertEqual(wrapper.steps_in_window, 0)
+        self.assertEqual(wrapper.current_step, 6)
+
+        optimizer.step.reset_mock()
+
+        it: Iterator[int] = iter(range(2))
+        wrapper.progress(it)
+        wrapper.progress(it)
+        # Global counter is ON a K boundary; the window-relative one is NOT.
+        self.assertEqual(wrapper.current_step, 8)
+        self.assertEqual(wrapper.steps_in_window, 2)
+        self.assertEqual(
+            optimizer.step.call_count, 0, "no boundary reached inside a partial window"
+        )
+
+        with self.assertRaises(StopIteration):
+            wrapper.progress(it)
+
+        self.assertEqual(
+            optimizer.step.call_count,
+            1,
+            "the partial window (remaining=2) must be committed in-band; feeding the "
+            "flush the GLOBAL counter computes remaining=0 and skips the commit",
+        )
+
+    def test_current_step_stays_monotonic_across_exhaustion(self) -> None:
+        """Anti-regression for the REJECTED counter-reset design: the public accessor's
+        monotonic contract must survive re-anchoring."""
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        self._exhaust(wrapper, 6)
+        self.assertEqual(wrapper.current_step, 6)
+
+        seen = [wrapper.current_step]
+        it: Iterator[int] = iter(range(4))
+        for _ in range(4):
+            wrapper.progress(it)
+            seen.append(wrapper.current_step)
+        self.assertEqual(seen, [6, 7, 8, 9, 10])
+
+    def test_warmup_does_not_replay_on_a_new_iterator(self) -> None:
+        """``num_warmup_steps`` counts against the GLOBAL micro counter, so a re-anchored
+        window must NOT re-enter warmup (a counter reset would have)."""
+        wrapper, _pipeline, model, _optimizer = self._make(num_warmup_steps=3)
+        self._exhaust(wrapper, 6)
+
+        # First micro of the new window: warmup is long over (current_step == 6 >= 3), and
+        # it is not a boundary micro, so it must run under no_sync.
+        before = model.no_sync_entered
+        it: Iterator[int] = iter(range(1))
+        wrapper.progress(it)
+        self.assertEqual(
+            model.no_sync_entered,
+            before + 1,
+            "warmup replayed on the new iterator (forced a sync on a non-boundary micro)",
+        )
+
+    def test_eval_exhaustion_does_not_realign(self) -> None:
+        """An eval interlude whose iterator exhausts must leave GA state untouched, so a
+        mid-window TRAINING window survives it."""
+        wrapper, _pipeline, model, _optimizer = self._make()
+        it: Iterator[int] = iter(range(2))
+        wrapper.progress(it)
+        wrapper.progress(it)
+        self.assertEqual(wrapper.steps_in_window, 2)
+
+        model.eval()
+        with self.assertRaises(StopIteration):
+            wrapper.progress(iter([]))
+        self.assertEqual(
+            wrapper.steps_in_window,
+            2,
+            "an eval StopIteration re-anchored the window and dropped the open training window",
+        )
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, 0)
+
+    def test_bucket_views_ready_survives_realignment(self) -> None:
+        """Re-anchoring is a window-boundary concern; the DDP bucket-view aliases are a
+        property of the (unchanged) model + DDP instances and must not be invalidated.
+        """
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        wrapper._bucket_views_ready = True
+        self._exhaust(wrapper, 6)
+        self.assertTrue(wrapper._bucket_views_ready)
+
+    def test_set_step_after_realignment_uses_raw_step_semantics(self) -> None:
+        """``set_step`` callers place the wrapper at a point in the accumulation cycle and
+        assume ``(step + 1) % K`` on the RAW value, so it must also drop the anchor -- else a
+        prior realignment leaves a stale base and steps_in_window goes negative."""
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        self._exhaust(wrapper, 6)
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, 6)
+
+        wrapper.set_step(3)  # K=4 => (3 + 1) % 4 == 0 => on-boundary FULL window
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, 0)
+        self.assertEqual(wrapper.steps_in_window, 3)
+        self.assertTrue(wrapper.optimizer_wrapper._should_step())
+
+    def test_reset_clears_the_window_anchor(self) -> None:
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        self._exhaust(wrapper, 6)
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, 6)
+        wrapper.reset()
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, 0)
+        self.assertEqual(wrapper.current_step, 0)
+        self.assertEqual(wrapper.steps_in_window, 0)
+
+    def test_clean_boundary_exhaustion_also_realigns(self) -> None:
+        """Exhausting ON a boundary leaves nothing to flush, but the anchor must still track
+        the counter so the two never drift apart."""
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        self._exhaust(wrapper, self.K)
+        self.assertEqual(wrapper.current_step, self.K)
+        self.assertEqual(wrapper._optimizer_wrapper._window_base, self.K)
+        self.assertEqual(wrapper.steps_in_window, 0)
+
+    def test_is_last_batch_realigns_after_advancing(self) -> None:
+        """The generic-caller path: an explicit last batch closes the phase, so the next
+        iterator starts a fresh window even though this one ended off-modulo."""
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        it: Iterator[int] = iter(range(2))
+        wrapper.progress(it)
+        wrapper.progress(it, is_last_batch=True)
+        self.assertEqual(wrapper.current_step, 2)
+        self.assertEqual(wrapper.steps_in_window, 0)
+
+    def test_steps_in_window_never_negative_across_orderings(self) -> None:
+        """Guards the stale-anchor family of bugs across the reachable public orderings."""
+        wrapper, _pipeline, _model, _optimizer = self._make()
+        self._exhaust(wrapper, 6)
+        self.assertGreaterEqual(wrapper.steps_in_window, 0)
+        wrapper.set_step(2)
+        self.assertGreaterEqual(wrapper.steps_in_window, 0)
+        self._exhaust(wrapper, 3)
+        self.assertGreaterEqual(wrapper.steps_in_window, 0)
+        wrapper.reset()
+        self.assertGreaterEqual(wrapper.steps_in_window, 0)
+
+
+class UnsupportedPipelineTest(unittest.TestCase):
+    """C3: an ENABLED GA config plus a pipeline that exposes no ``_optimizer`` at all must
+    fail closed. Previously the injection was silently skipped and that pipeline then
+    stepped on every micro-batch while the caller believed gradients accumulated over K.
+
+    Scope is deliberately narrow: ``hasattr('_optimizer')`` is necessary, not sufficient --
+    a pipeline can expose ``_optimizer``, accept the replacement, and still step a
+    separately captured optimizer. That needs a GA capability/rebind contract and is NOT
+    what this guard claims.
+    """
+
+    class _NoOptimizerPipeline(TrainPipeline[Any, int]):
+        def __init__(self) -> None:
+            super().__init__()  # pyrefly: ignore[missing-argument]
+
+        def progress(self, dataloader_iter: Iterator[Any]) -> int:
+            return 0
+
+    def test_enabled_ga_with_no_optimizer_attr_raises(self) -> None:
+        pipeline = self._NoOptimizerPipeline()
+        model = _MockModel()
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        config = GradientAccumulationConfig(is_enabled=True, num_steps=4)
+        with self.assertRaises(RuntimeError) as ctx:
+            GradientAccumulationWrapper(pipeline, optimizer, model, config)
+        msg = str(ctx.exception)
+        self.assertIn("_NoOptimizerPipeline", msg)
+        self.assertIn("_optimizer", msg)
+
+    def test_disabled_ga_with_no_optimizer_attr_does_not_raise(self) -> None:
+        """The raise lives inside ``if config.is_enabled``: a disabled config keeps the old
+        no-injection behavior for any pipeline."""
+        pipeline = self._NoOptimizerPipeline()
+        model = _MockModel()
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        config = GradientAccumulationConfig(num_steps=1)  # disabled
+        GradientAccumulationWrapper(
+            pipeline, optimizer, model, config
+        )  # must not raise
+        self.assertFalse(hasattr(pipeline, "_optimizer"))
+
+    def test_double_wrapping_the_same_pipeline_raises(self) -> None:
+        """Wrapping a pipeline twice would nest the optimizer gates, stepping once per
+        K**2 micro-batches instead of per K -- silent under-stepping, not a crash."""
+        model = _MockModel()
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        pipeline = _MockPipeline(num_batches=4)
+        config = GradientAccumulationConfig(is_enabled=True, num_steps=4)
+
+        GradientAccumulationWrapper(pipeline, optimizer, model, config)
+        with self.assertRaises(RuntimeError) as ctx:
+            GradientAccumulationWrapper(pipeline, optimizer, model, config)
+        self.assertIn("already has a GA-wrapped", str(ctx.exception))
+
+    def test_disabled_second_wrap_does_not_raise(self) -> None:
+        """The guard sits inside ``if config.is_enabled``: a disabled second wrapper
+        injects nothing, so it cannot nest anything."""
+        model = _MockModel()
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+        pipeline = _MockPipeline(num_batches=4)
+
+        GradientAccumulationWrapper(
+            pipeline,
+            optimizer,
+            model,
+            GradientAccumulationConfig(is_enabled=True, num_steps=4),
+        )
+        first_wrapper = pipeline._optimizer
+        GradientAccumulationWrapper(
+            pipeline, optimizer, model, GradientAccumulationConfig(num_steps=1)
+        )  # must not raise
+        self.assertIs(pipeline._optimizer, first_wrapper)


### PR DESCRIPTION
Summary:
Micro-batching design doc: https://docs.google.com/document/d/106-uga-O_oIYqKi8BSM-nLoOgPkPiI61wtM2Y9GmaDo/edit

## Motivation

The pre-existing `GradientAccumulationWrapper` accumulates over N *steps*. Micro-batching needs a **windowed, micro-batch-aware** form: a window can end early (the last batch of an epoch), a split-optimizer pipeline above needs to know where the boundary is to gate its own sub-steps, and setting gradients to `None` between micros destroys the flat-buffer bucket views that make DDP's gradient buffers cheap to accumulate into.

## Behavior Impact

**Purely opt-in — inert with the feature off.** This is the largest added surface in the stack (2,610 changed lines, 381 of them in code that already exists at the base), so the audit is spelled out rather than asserted.

**The shield is the construction site, not the call sites.** `aps_models/ads/common/train_pipeline.py` constructs `GradientAccumulationWrapper` **only** under `if ga_config.is_enabled`, and `_get_ga_config()` returns `GradientAccumulationConfig(is_enabled=False)` unless `GRADIENT_ACCUMULATION_STEPS` is set. For a production user with the feature off the wrapper is **never constructed**, and not one of the 362 added method-body lines executes.

Per-method breakdown of the 381 lines (362 in methods that exist at the base, 15 in the config dataclass body, 4 import/module bindings):

| method | +lines | verdict |
|---|---:|---|
| `_GAOptimizerWrapper.__init__` | 15 | inert — initialises new state to `0` / `False` / `None` |
| `_GAOptimizerWrapper._should_step` | 1 | inert — at K=1 old and new modulo predicates are both always true |
| `_GAOptimizerWrapper.zero_grad` | 18 | guarded on `accumulate_into_buckets and _ga_wrapper is not None`; default `False` takes the original path |
| `_GAOptimizerWrapper.step` | 5 | inert — adds `or self._force_step`, default `False` |
| `_GAOptimizerWrapper.reset` / `set_step` | 14 | inert — resets new state to identity values |
| `GradientAccumulationWrapper.__init__` | 44 | inert — optimizer replacement stays behind `if config.is_enabled` |
| `_should_sync_grad` | 4 | inert — modulo-one stays always true |
| `_get_no_sync_context` / `_get_ddp_modules` | 16 | comments only, no executable change |
| `_flush_accumulated_gradients` | 58 | guarded — every addition needs `remaining > 0`, and `remaining = steps_accumulated % num_steps` is 0 at K=1 |
| `progress` | 160 | see § Boundary signal |
| `reset` | 27 | inert — off-path `_pending_uncommitted` stays `False`; the new raise predicate is false |

**Arithmetic is unchanged.** No loss scaling, gradient scaling or division by K was added or changed. The three boundary predicates moved from `current_step` to `steps_in_window` (`(x + 1) % K == 0` in both forms) and the flush remainder from `current_step % K` to `steps_in_window % K`; at K=1 every one evaluates identically to the base.

**One schema-visible change**: the new `accumulate_into_buckets` field defaults to `False` (base behaviour) but does alter the dataclass's `repr` / equality / `asdict`. Flagged because anything snapshotting this config sees one extra key.

## Changes

- Window-relative step accounting: `_window_base` / `steps_in_window` replacing the free-running `current_step`.
- Opt-in `accumulate_into_buckets`: zero gradients **bucket-view-preservingly** instead of setting them to `None`.
- A forced-step escape hatch for the last batch of a window.
- Window-start / should-step publication, so a split-optimizer pipeline above can gate its own sub-steps.
- **`PartialWindowPolicy` — caller policy for a partial (`r < K`) final window, now three-valued.** `STEP` (default, preserves historical single-process behaviour) and `RAISE` select only what happens at `world_size <= 1`, where the local grads ARE the full window; at `world_size > 1` both fail closed unconditionally (abort the process groups, then raise), because stepping un-reduced rank-local grads without a cross-rank reduce diverges replicas. **`DISCARD` is different in kind**: it applies at every world size and makes an exhaustion-time partial window a normal, non-fatal ending — the window is zeroed rank-locally with no optimizer step, no collective and deliberately no PG abort, and the caller's `StopIteration` propagates. It is correct only for callers that have established cross-rank exhaustion agreement out of band and accept losing up to K-1 micro-batches; that judgement lives in the caller (APS, higher in this stack), not here. Two implementation details are load-bearing and are pinned by tests rather than left to comments:
  - The `DISCARD` branch sits **ahead of** the world-size block. Every policy check below it is written as `is RAISE / else STEP` with no exhaustive match, so a `DISCARD` that fell through would take a silent local un-reduced step — corruption, not a crash. Early-returning also leaves the unconditional `world_size > 1` abort byte-identical for `STEP` and `RAISE`.
  - The discard **re-arms `_needs_zero_grad` before zeroing**. `_GAOptimizerWrapper.zero_grad` early-returns when that flag is `False`, which is exactly the mid-window state, so a bare `zero_grad()` here would be a guaranteed no-op and the discarded gradients would survive into the next window. The zero routes through the wrapper, not the raw optimizer, so `accumulate_into_buckets` bucket-view aliases are preserved.

  `DISCARD` is scoped to the **exhaustion** path only. An explicit `is_last_batch=True` partial window still commits in-band via the forced step, because `is_last_batch` forces `should_sync` — the grads ARE cross-rank reduced, so the step is replica-safe at any world size AND keeps the data. `RAISE` remains the one policy that also fences the explicit path.
- **Fail-closed on double-wrapping (V11, from review).** The constructor already refused a pipeline with no `_optimizer`; it now also refuses one whose `_optimizer` is *already* a `_GAOptimizerWrapper`. Wrapping the same pipeline twice would nest the gates and step the real optimizer once per K² micro-batches instead of once per K — silent under-stepping rather than a crash. There is no unwrap path, so no legitimate caller reaches it.
- `tests/test_ga_bucket_view_alias.py` (new, 941 lines) and a substantial extension of `tests/test_gradient_accumulation.py`.

## Boundary signal: explicit observer, not attribute injection (revised in V11)

Earlier versions published the window boundary by writing `_ga_should_step` / `_ga_at_window_start` onto the wrapped pipeline, and carried a stated residual risk: the **disabled** branch wrote both unconditionally, so a disabled wrapper would clobber those names on any pipeline that used them.

**That mechanism is gone, and with it the risk.** The wrapper now takes an optional, typed `window_observer` at construction (`GAWindowObserver`, keyword-only so the two booleans cannot be transposed) and calls it once per micro-batch immediately before the inner `progress()`. It never writes state onto the pipeline it wraps, and the disabled path is a pure pass-through that signals nothing. `_GAPipelineHooks` is reduced to `attach`.

This was raised in review: the flags were an underscore-named cross-component contract with no torchrec consumer, about to become a de-facto OSS API. The explicit parameter also converts the previous failure mode from silent to loud — under the old `getattr(..., True)` read, renaming the attribute would have silently defaulted a consumer to "step every micro-batch" (K-fold over-stepping, wrong gradients, no crash); a typed constructor argument makes the same mistake a type error.

A `runtime_checkable` Protocol + `isinstance` gate was considered and rejected: `isinstance` against one checks member *names* only — it passes on a wrong signature and even on a non-callable attribute — and a structural miss would fail **open**, restoring the same per-micro stepping.

## Also in V11 — `attach()` signature fix

`TrainPipelineSparseDist.attach` accepts `sparse_dist` **positionally**, but the wrapper's override was `(model=None, **kwargs)`, so `attach(model, False)` raised `TypeError` — an unintended narrowing of a public protocol. Now forwards `*args`. Latent rather than live: no in-tree caller passes it positionally.

## Configuration

One new field on `GradientAccumulationConfig`: `accumulate_into_buckets: bool = False`. Default reproduces base behaviour exactly. No new environment variable — the existing `GRADIENT_ACCUMULATION_STEPS` (read by the APS construction site, not by this file) remains the only enablement switch.

## Stack Context

Lowest layer of the micro-batching stack, and the only OSS one. Nothing above it is reachable until the APS wiring commits land much higher. Ported from the validated prototype; the `dp_fp32_grad` data-parallel exclusion is already applied upstream of this commit (0 occurrences here).

Reviewed By: meta-anubhav

Differential Revision: D117098239


