### PR TITLE
Enroll non-RecMetric modules in the golden snapshot test (#4693)

### DIFF
--- a/torchrec/checkpoint/__init__.py
+++ b/torchrec/checkpoint/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/checkpoint/schema.py
+++ b/torchrec/checkpoint/schema.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Marks a module's state_dict key set as a compatibility surface.
+
+Adding, removing, or renaming persistent state changes the keys a module writes
+to a checkpoint. Old checkpoints then fail to load. ``@checkpoint_schema_stable``
+marks a class with its stable checkpoint-schema id. A matching ``_GoldenCase``
+row is what enrolls the class in the golden-snapshot test.
+
+The decorator has no effect at load time and registers nothing anywhere. It
+records the id on the class, so the test can check that a row and the class it
+names agree on which id they mean.
+"""
+
+import re
+from typing import Callable, Optional, TypeVar
+
+_C = TypeVar("_C", bound=type)
+
+_STABLE_ID = re.compile(r"[a-z][a-z0-9]*(_[a-z0-9]+)*")
+
+# Set by the decorator. Read with schema_id_of, never with getattr.
+SCHEMA_ID_ATTRIBUTE = "_checkpoint_schema_id"
+
+
+def checkpoint_schema_stable(stable_id: str) -> Callable[[_C], _C]:
+    """Mark a class with the id its golden entry is filed under.
+
+    The id is written by hand rather than derived from the class, so moving a
+    file or renaming a class does not silently change the golden key and abandon
+    the entry it used to match. That is the whole point of it: an id must stay
+    put when its class is renamed.
+    """
+    if not stable_id or stable_id != stable_id.strip():
+        raise ValueError(
+            f"stable_id must be non-empty and unpadded, got {stable_id!r}."
+        )
+    if not _STABLE_ID.fullmatch(stable_id):
+        raise ValueError(
+            f"stable_id must be lowercase snake_case, got {stable_id!r}. A "
+            "class-shaped id invites the next person to rename it along with "
+            "the class, which abandons the golden entry it was filed under."
+        )
+
+    def decorate(cls: _C) -> _C:
+        setattr(cls, SCHEMA_ID_ATTRIBUTE, stable_id)
+        return cls
+
+    return decorate
+
+
+def schema_id_of(cls: type) -> Optional[str]:
+    """The id this class was marked with, or None.
+
+    Reads the class's own namespace. A subclass of a marked class inherits the
+    attribute, so getattr would report the parent's id and hide a subclass that
+    was never marked at all.
+    """
+    return vars(cls).get(SCHEMA_ID_ATTRIBUTE)

--- a/torchrec/checkpoint/tests/test_schema.py
+++ b/torchrec/checkpoint/tests/test_schema.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""The decorator's contracts, none of which importing a marked class exercises.
+
+A stable id is the name a golden entry is filed under. If one can be blank or
+carry stray whitespace, the entry it points at stops describing the class that
+wrote it. And because every enrolled module here subclasses another marked
+class, reading the mark has to ignore inheritance or a subclass that was never
+marked reports its parent's id.
+"""
+
+import unittest
+from typing import Type
+
+from torchrec.checkpoint.schema import (
+    checkpoint_schema_stable,
+    SCHEMA_ID_ATTRIBUTE,
+    schema_id_of,
+)
+
+
+def _make_class(qualname: str, module: str = "torchrec.fake") -> Type[object]:
+    """A class with a controlled identity."""
+    cls = type(qualname, (), {})
+    cls.__module__ = module
+    cls.__qualname__ = qualname
+    return cls
+
+
+class CheckpointSchemaStableTest(unittest.TestCase):
+    def test_rejects_an_empty_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-empty and unpadded"):
+            checkpoint_schema_stable("")
+
+    def test_rejects_a_padded_id(self) -> None:
+        for stable_id in (" widget", "widget ", "\twidget", "widget\n"):
+            with self.subTest(stable_id=stable_id):
+                with self.assertRaisesRegex(ValueError, "non-empty and unpadded"):
+                    checkpoint_schema_stable(stable_id)
+
+    def test_rejects_ids_that_are_not_snake_case(self) -> None:
+        for stable_id in (
+            "RecMetricModule",
+            "Widget",
+            "wid-get",
+            "wid get",
+            "widget__gadget",
+            "_widget",
+            "widget_",
+            "widget2X",
+        ):
+            with self.subTest(stable_id=stable_id):
+                with self.assertRaisesRegex(ValueError, "lowercase snake_case"):
+                    checkpoint_schema_stable(stable_id)
+
+    def test_accepts_the_ids_in_use(self) -> None:
+        for stable_id in (
+            "tensor_pool",
+            "cpu_offloaded_rec_metric_module",
+            "hash_zch_managed_collision_module",
+            "widget2",
+        ):
+            with self.subTest(stable_id=stable_id):
+                cls = _make_class("Widget")
+                checkpoint_schema_stable(stable_id)(cls)
+                self.assertEqual(schema_id_of(cls), stable_id)
+
+    def test_marks_the_class_with_its_id(self) -> None:
+        cls = _make_class("Widget")
+        checkpoint_schema_stable("widget")(cls)
+        self.assertEqual(schema_id_of(cls), "widget")
+
+    def test_returns_the_class_unchanged(self) -> None:
+        cls = _make_class("Widget")
+        self.assertIs(checkpoint_schema_stable("widget")(cls), cls)
+
+    def test_an_unmarked_class_has_no_id(self) -> None:
+        self.assertIsNone(schema_id_of(_make_class("Widget")))
+
+    def test_a_subclass_does_not_inherit_its_parent_id(self) -> None:
+        # The real subject: CPUCommsRecMetricModule and friends all subclass
+        # RecMetricModule, which is marked. Reading with getattr would report
+        # the parent's id and hide a subclass nobody marked.
+        parent = _make_class("Widget")
+        checkpoint_schema_stable("widget")(parent)
+        child = type("Gadget", (parent,), {})
+
+        self.assertEqual(getattr(child, SCHEMA_ID_ATTRIBUTE), "widget")
+        self.assertIsNone(schema_id_of(child))
+
+    def test_a_marked_subclass_reports_its_own_id(self) -> None:
+        parent = _make_class("Widget")
+        checkpoint_schema_stable("widget")(parent)
+        child = checkpoint_schema_stable("gadget")(type("Gadget", (parent,), {}))
+
+        self.assertEqual(schema_id_of(child), "gadget")
+        self.assertEqual(schema_id_of(parent), "widget")

--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -13,6 +13,7 @@ import torch.distributed as dist
 from torch import nn
 from torch.distributed.tensor import DeviceMesh
 from torch.profiler import record_function
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.metric_module import PreComputeStates, RecMetricModule
 from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
 from torchrec.metrics.rec_metric import (
@@ -25,6 +26,7 @@ from torchrec.metrics.rec_metric import (
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@checkpoint_schema_stable("cpu_comms_rec_metric_module")
 class CPUCommsRecMetricModule(RecMetricModule):
     """
     A submodule of CPUOffloadedRecMetricModule.

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -61,6 +61,7 @@ except Exception:
                 pass
 
 
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.distributed.logging_utils import EventType
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.deferrable_metrics import (
@@ -297,6 +298,7 @@ def _foreach_clone_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
     return out
 
 
+@checkpoint_schema_stable("cpu_offloaded_rec_metric_module")
 class CPUOffloadedRecMetricModule(RecMetricModule):
     """
     RecMetricModule that offloads metric update() and compute() to CPU using background threads.

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -62,6 +62,7 @@ except Exception:
                 pass
 
 
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.accuracy import AccuracyMetric
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.auprc import AUPRCMetric
@@ -196,6 +197,7 @@ class StateMetric(abc.ABC):
         pass
 
 
+@checkpoint_schema_stable("rec_metric_module")
 class RecMetricModule(nn.Module):
     r"""
     For the current recommendation models, we assume there will be three

--- a/torchrec/metrics/noop_metric_module.py
+++ b/torchrec/metrics/noop_metric_module.py
@@ -13,10 +13,12 @@ from typing import Any, Dict, List, Optional, Union
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DeviceMesh
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.metrics.deferrable_metrics import DeferrableMetrics
 from torchrec.metrics.metric_module import MetricValue, RecMetricModule
 
 
+@checkpoint_schema_stable("noop_metric_module")
 class NoOpMetricModule(RecMetricModule):
     """
     A no-op implementation of RecMetricModule for when metrics

--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -143,17 +143,6 @@
     ],
     "variant": "with_r_squared"
   },
-  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
-    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
-    "metric_class": "MulticlassRecallMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "_metrics_computations.0.total_weights",
-      "_metrics_computations.0.tp_at_k"
-    ],
-    "variant": ""
-  },
   "MultiLabelPrecisionMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "MultiLabelPrecisionMetric",
@@ -162,6 +151,17 @@
     "state_dict_keys": [
       "_metrics_computations.0.false_pos_sum_label_0",
       "_metrics_computations.0.true_pos_sum_label_0"
+    ],
+    "variant": ""
+  },
+  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
+    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
+    "metric_class": "MulticlassRecallMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "_metrics_computations.0.total_weights",
+      "_metrics_computations.0.tp_at_k"
     ],
     "variant": ""
   },
@@ -298,33 +298,6 @@
     "state_dict_keys": [],
     "variant": ""
   },
-  "RecMetricModule": {
-    "metric_class": "RecMetricModule",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
-    ],
-    "variant": ""
-  },
-  "RecMetricModule_with_throughput": {
-    "metric_class": "RecMetricModule",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples",
-      "throughput_metric.time_lapse_after_warmup",
-      "throughput_metric.total_examples",
-      "throughput_metric.warmup_examples"
-    ],
-    "variant": "with_throughput"
-  },
   "RecalibratedCalibrationMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "RecalibratedCalibrationMetric",
@@ -439,29 +412,6 @@
     ],
     "variant": ""
   },
-  "ThroughputMetric": {
-    "metric_class": "ThroughputMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "time_lapse_after_warmup",
-      "total_examples",
-      "warmup_examples"
-    ],
-    "variant": ""
-  },
-  "ThroughputMetric_with_batch_size_stages": {
-    "metric_class": "ThroughputMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "num_batch",
-      "time_lapse_after_warmup",
-      "total_examples",
-      "warmup_examples"
-    ],
-    "variant": "with_batch_size_stages"
-  },
   "TowerQPSMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "TowerQPSMetric",
@@ -529,5 +479,55 @@
       "_metrics_computations.0.weighted_num_pairs"
     ],
     "variant": ""
+  },
+  "rec_metric_module": {
+    "metric_class": "RecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "rec_metric_module_with_throughput": {
+    "metric_class": "RecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples",
+      "throughput_metric.time_lapse_after_warmup",
+      "throughput_metric.total_examples",
+      "throughput_metric.warmup_examples"
+    ],
+    "variant": "with_throughput"
+  },
+  "throughput_metric": {
+    "metric_class": "ThroughputMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "time_lapse_after_warmup",
+      "total_examples",
+      "warmup_examples"
+    ],
+    "variant": ""
+  },
+  "throughput_metric_with_batch_size_stages": {
+    "metric_class": "ThroughputMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "num_batch",
+      "time_lapse_after_warmup",
+      "total_examples",
+      "warmup_examples"
+    ],
+    "variant": "with_batch_size_stages"
   }
 }

--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -480,6 +480,37 @@
     ],
     "variant": ""
   },
+  "cpu_comms_rec_metric_module": {
+    "metric_class": "CPUCommsRecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "cpu_offloaded_rec_metric_module": {
+    "metric_class": "CPUOffloadedRecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "noop_metric_module": {
+    "metric_class": "NoOpMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [],
+    "variant": ""
+  },
   "rec_metric_module": {
     "metric_class": "RecMetricModule",
     "non_persistent_buffer_fqns": [],

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -1089,7 +1089,9 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         state_dict["_trained_batches"] = torch.tensor(100)
 
         fresh_module = self._create_rec_metric_module()
-        fresh_module.load_state_dict(state_dict, strict=False)
+        # strict=True matches production. Under strict=False this test passes
+        # even without the pop hook.
+        fresh_module.load_state_dict(state_dict, strict=True)
 
 
 class MetricCoverageTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -31,8 +31,9 @@ import json
 import os
 import sys
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set, Tuple, Type
 
 import torch
 from torchrec.metrics.accuracy import AccuracyMetric
@@ -359,6 +360,23 @@ def load_golden_snapshot() -> Dict[str, Dict[str, Any]]:
         return json.load(f)
 
 
+def load_required_golden_snapshot() -> Dict[str, Dict[str, Any]]:
+    """The snapshot, for callers that say nothing useful without one.
+
+    Regenerating here instead would write whatever the code produces today and
+    call it the baseline, which is the change these tests exist to catch. It
+    would also write only this class's entries, leaving every schema case
+    failing against a file that had just been created.
+    """
+    snapshot = load_golden_snapshot()
+    if not snapshot:
+        raise RuntimeError(
+            f"{GOLDEN_SNAPSHOT_PATH} is missing or empty. It is checked in, so "
+            "restore it from source control rather than writing a new one."
+        )
+    return snapshot
+
+
 def save_golden_snapshot(snapshot: Dict[str, Dict[str, Any]]) -> None:
     with open(GOLDEN_SNAPSHOT_PATH, "w") as f:
         json.dump(snapshot, f, indent=2, sort_keys=True)
@@ -379,12 +397,7 @@ class MetricFQNBackwardCompatibilityTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
-        if not cls.golden_snapshot:
-            print("No golden snapshot found. Generating initial snapshot...")
-            cls.golden_snapshot = generate_golden_snapshot()
-            save_golden_snapshot(cls.golden_snapshot)
-            print(f"Golden snapshot saved to {GOLDEN_SNAPSHOT_PATH}")
+        cls.golden_snapshot = load_required_golden_snapshot()
         cls.current_snapshot = None
 
     def _check_metric_compatibility(
@@ -777,139 +790,293 @@ class MetricStateSnapshotTest(unittest.TestCase):
         self._test_metric_state_roundtrip(WeightedAvgMetric)
 
 
-# Golden snapshot keys for ThroughputMetric and RecMetricModule
-THROUGHPUT_SNAPSHOT_KEY = "ThroughputMetric"
-THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY = "ThroughputMetric_with_batch_size_stages"
-REC_METRIC_MODULE_SNAPSHOT_KEY = "RecMetricModule"
-REC_METRIC_MODULE_WITH_THROUGHPUT_KEY = "RecMetricModule_with_throughput"
+# Fixture values for the golden cases.
+_THROUGHPUT_BATCH_SIZE_STAGES: List[BatchSizeStage] = [
+    BatchSizeStage(batch_size=32, max_iters=100),
+    BatchSizeStage(batch_size=64, max_iters=None),
+]
 
 
-class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
+def _make_throughput_metric(
+    batch_size_stages: Optional[List[BatchSizeStage]] = None,
+) -> ThroughputMetric:
+    return ThroughputMetric(
+        batch_size=32,
+        world_size=1,
+        window_seconds=100,
+        warmup_steps=10,
+        batch_size_stages=batch_size_stages,
+    )
+
+
+def _make_rec_metric_module(
+    throughput_metric: Optional[ThroughputMetric] = None,
+) -> RecMetricModule:
+    tasks = [create_test_task("task1")]
+    return RecMetricModule(
+        batch_size=32,
+        world_size=1,
+        rec_tasks=tasks,
+        rec_metrics=RecMetricList(
+            [
+                NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=32,
+                    tasks=tasks,
+                    compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+                    window_size=100,
+                )
+            ]
+        ),
+        throughput_metric=throughput_metric,
+    )
+
+
+@dataclass(frozen=True)
+class _GoldenCase:
+    """One golden snapshot: which entry it is, and how to build it.
+
+    The builder is self-contained, so a case cannot be paired with another
+    case's configuration. `stable_id` is written by hand rather than derived
+    from the class, so moving a file does not silently change the key and
+    abandon the entry it used to match.
     """
-    Test suite for ThroughputMetric FQN backward compatibility.
 
-    ThroughputMetric is an nn.Module (not RecMetric) with its own state_dict structure.
+    # Lowercase snake_case, deliberately not the class name. The id is the
+    # golden file's key, so it has to survive a class rename untouched.
+    stable_id: str
+    expected_class: Type[torch.nn.Module]
+    variant: str
+    build: Callable[[], torch.nn.Module]
+
+    @property
+    def key(self) -> str:
+        return f"{self.stable_id}_{self.variant}" if self.variant else self.stable_id
+
+
+_REC_METRIC_MODULE_DEFAULT = _GoldenCase(
+    "rec_metric_module", RecMetricModule, "", _make_rec_metric_module
+)
+
+_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
+    _GoldenCase("throughput_metric", ThroughputMetric, "", _make_throughput_metric),
+    _GoldenCase(
+        "throughput_metric",
+        ThroughputMetric,
+        "with_batch_size_stages",
+        lambda: _make_throughput_metric(_THROUGHPUT_BATCH_SIZE_STAGES),
+    ),
+    _REC_METRIC_MODULE_DEFAULT,
+    _GoldenCase(
+        "rec_metric_module",
+        RecMetricModule,
+        "with_throughput",
+        lambda: _make_rec_metric_module(_make_throughput_metric()),
+    ),
+)
+
+
+class _ModuleWithKnownKeys(torch.nn.Module):
+    """Two buffers and nothing else, so a test can state the exact key set."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("alpha", torch.zeros(1))
+        self.register_buffer("beta", torch.zeros(1))
+
+
+_KNOWN_KEYS_CASE = _GoldenCase(
+    "known_keys_probe", _ModuleWithKnownKeys, "", _ModuleWithKnownKeys
+)
+
+
+def _agreeing_entry(**overrides: Any) -> Dict[str, Any]:
+    """The entry `_KNOWN_KEYS_CASE` expects, with any field replaced."""
+    entry: Dict[str, Any] = {
+        "metric_class": _ModuleWithKnownKeys.__name__,
+        "variant": _KNOWN_KEYS_CASE.variant,
+        "state_dict_keys": ["alpha", "beta"],
+        "persistent_buffer_fqns": [],
+        "non_persistent_buffer_fqns": [],
+    }
+    entry.update(overrides)
+    return entry
+
+
+class GoldenCaseTest(unittest.TestCase):
+    """Compares each golden case against its recorded entry.
+
+    Checking the stored metadata matters as much as the keys. Comparing one
+    case against another's baseline can otherwise pass: the extra keys look
+    like an addition, and the addition check loads them away.
     """
+
+    golden_snapshot: Dict[str, Dict[str, Any]]
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
+        cls.golden_snapshot = load_required_golden_snapshot()
 
-    def _create_throughput_metric(
-        self, with_batch_size_stages: bool = False
-    ) -> ThroughputMetric:
-        from torchrec.metrics.metrics_config import BatchSizeStage
+    def _check_case(self, case: _GoldenCase) -> None:
+        module = case.build()
+        self.assertIs(type(module), case.expected_class)
 
-        batch_size_stages = None
-        if with_batch_size_stages:
-            batch_size_stages = [
-                BatchSizeStage(batch_size=32, max_iters=100),
-                BatchSizeStage(batch_size=64, max_iters=None),
-            ]
+        if case.key not in self.golden_snapshot:
+            self.fail(
+                f"No golden entry for {case.key}. Run with --update-golden "
+                "to create it. Writing one here would bless whatever the "
+                "code currently produces, and concurrent tests writing the "
+                "whole file at once corrupt it."
+            )
 
-        return ThroughputMetric(
-            batch_size=32,
-            world_size=1,
-            window_seconds=100,
-            warmup_steps=10,
-            batch_size_stages=batch_size_stages,
+        entry = self.golden_snapshot[case.key]
+        self.assertEqual(
+            entry["metric_class"],
+            case.expected_class.__name__,
+            f"Golden entry {case.key} was written by a different class.",
+        )
+        self.assertEqual(
+            entry["variant"],
+            case.variant,
+            f"Golden entry {case.key} was written by a different variant.",
         )
 
-    def _get_state_dict_keys(self, with_batch_size_stages: bool = False) -> List[str]:
-        metric = self._create_throughput_metric(with_batch_size_stages)
-        return sorted(metric.state_dict().keys())
+        current_keys = set(module.state_dict().keys())
 
-    def test_throughput_metric_compatibility(self) -> None:
-        key = THROUGHPUT_SNAPSHOT_KEY
+        baseline_keys = set(entry["state_dict_keys"])
 
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_batch_size_stages=False)
-            self.golden_snapshot[key] = {
-                "metric_class": "ThroughputMetric",
-                "variant": "",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
+        removed = baseline_keys - current_keys
+        if removed:
+            self.fail(
+                f"BREAKING CHANGE in {case.key}: state_dict keys removed: "
+                f"{sorted(removed)}."
+            )
+
+        added = current_keys - baseline_keys
+        if not added:
             return
 
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_batch_size_stages=False))
-        baseline_keys = set(baseline["state_dict_keys"])
+        self.fail(
+            f"BREAKING CHANGE in {case.key}: state_dict keys added: "
+            f"{sorted(added)}.\n"
+            "DCP validates every model FQN against checkpoint metadata before "
+            "load_state_dict runs, so the planner rejects a checkpoint written "
+            "before these keys existed. Loading one in process proves nothing: "
+            "state torchmetrics holds by setattr is invisible to the strict "
+            "check and still demanded by the planner."
+        )
 
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}. "
-                "This will cause old checkpoints to fail loading."
-            )
+    def test_golden_cases(self) -> None:
+        for case in _SCHEMA_CASES:
+            with self.subTest(case.key):
+                self._check_case(case)
 
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(added_keys):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
+    def test_metadata_mismatch_is_rejected(self) -> None:
+        """The stored metric_class and variant must match the case asking.
+
+        Without this, a case can compare against an entry another case wrote:
+        the extra keys read as an addition and the addition check loads them
+        away. Injecting each mismatch pins both guards, which are otherwise
+        only exercised when the golden is already wrong.
+        """
+        for field_name, wrong_value in (
+            ("metric_class", "SomeOtherClass"),
+            ("variant", "some_other_variant"),
+        ):
+            with self.subTest(field_name):
+                # Writing to self hides the class attribute instead of
+                # changing it. The real snapshot is safe, so del is enough.
+                self.golden_snapshot = {
+                    _KNOWN_KEYS_CASE.key: _agreeing_entry(**{field_name: wrong_value})
+                }
+                try:
+                    with self.assertRaisesRegex(
+                        AssertionError, "written by a different"
+                    ):
+                        self._check_case(_KNOWN_KEYS_CASE)
+                finally:
+                    del self.golden_snapshot
+
+    def test_key_drift_is_rejected(self) -> None:
+        """Checks that the drift check works.
+
+        `_check_case` fails two ways: a golden key the module lost, or a module
+        key the golden lacks. Neither fires in a green run. This test makes
+        both fire.
+        """
+        for label, keys, expected in (
+            ("removed", ["alpha", "beta", "gamma"], "state_dict keys removed"),
+            ("added", ["alpha"], "state_dict keys added"),
+        ):
+            with self.subTest(label):
+                self.golden_snapshot = {
+                    _KNOWN_KEYS_CASE.key: _agreeing_entry(state_dict_keys=keys)
+                }
+                try:
+                    with self.assertRaisesRegex(AssertionError, expected):
+                        self._check_case(_KNOWN_KEYS_CASE)
+                finally:
+                    del self.golden_snapshot
+
+    def test_case_keys_are_unique(self) -> None:
+        keys = [case.key for case in _SCHEMA_CASES]
+        self.assertEqual(sorted(keys), sorted(set(keys)))
+
+    def test_one_class_per_stable_id(self) -> None:
+        """A stable id names one class, however many variants it has.
+
+        The key carries the variant, so two classes could share an id and still
+        keep distinct keys. Anything that maps id to class would then silently
+        keep whichever row it read last.
+        """
+        classes_by_id: Dict[str, Set[Type[torch.nn.Module]]] = {}
+        for case in _SCHEMA_CASES:
+            classes_by_id.setdefault(case.stable_id, set()).add(case.expected_class)
+
+        for stable_id, classes in classes_by_id.items():
+            with self.subTest(stable_id):
+                self.assertEqual(
+                    len(classes),
+                    1,
+                    f"{stable_id} is claimed by "
+                    f"{sorted(c.__name__ for c in classes)}.",
                 )
 
-    def test_throughput_metric_with_stages_compatibility(self) -> None:
-        key = THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY
+    def test_cases_for_same_id_have_distinct_key_sets(self) -> None:
+        """Every case under one id must snapshot a different key set.
 
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_batch_size_stages=True)
-            self.golden_snapshot[key] = {
-                "metric_class": "ThroughputMetric",
-                "variant": "with_batch_size_stages",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_batch_size_stages=True))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}. "
-                "This will cause old checkpoints to fail loading."
+        The unnamed case counts too, so this catches a named variant whose
+        builder forgot the argument that distinguishes it. The key and the
+        stored metadata both agree with themselves in that case; only the
+        resulting shape disagrees.
+        """
+        by_id: Dict[str, List[FrozenSet[str]]] = {}
+        for case in _SCHEMA_CASES:
+            module = case.build()
+            by_id.setdefault(case.stable_id, []).append(
+                frozenset(module.state_dict().keys())
             )
 
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(added_keys, with_stages=True):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
+        for stable_id, entries in by_id.items():
+            with self.subTest(stable_id):
+                self.assertEqual(
+                    len(set(entries)),
+                    len(entries),
+                    f"{stable_id} has {len(entries)} cases but "
+                    f"{len(set(entries))} distinct key sets. One builder is carrying "
+                    "another's configuration.",
                 )
 
-    def _verify_backward_compatibility(
-        self, added_keys: Set[str], with_stages: bool = False
-    ) -> bool:
-        try:
-            metric = self._create_throughput_metric(with_batch_size_stages=with_stages)
-            state_dict = metric.state_dict()
-            old_checkpoint = {
-                k: v for k, v in state_dict.items() if k not in added_keys
-            }
 
-            fresh_metric = self._create_throughput_metric(
-                with_batch_size_stages=with_stages
-            )
-            fresh_metric.load_state_dict(old_checkpoint, strict=True)
-            return True
-        except Exception:
-            return False
+class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
+    """Round-trip checks for ThroughputMetric that are not golden comparisons."""
 
     def test_throughput_metric_state_roundtrip(self) -> None:
-        metric = self._create_throughput_metric()
+        metric = _make_throughput_metric()
         initial_state = metric.state_dict()
 
-        fresh_metric = self._create_throughput_metric()
+        fresh_metric = _make_throughput_metric()
         fresh_metric.load_state_dict(initial_state, strict=True)
 
         restored_state = fresh_metric.state_dict()
@@ -924,152 +1091,13 @@ class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):
 
 
 class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
-    """
-    Test suite for RecMetricModule FQN backward compatibility.
-
-    RecMetricModule is a container that holds RecMetrics, ThroughputMetric, and StateMetrics.
-    """
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Load the golden snapshot."""
-        cls.golden_snapshot = load_golden_snapshot()
-
-    def _create_rec_metric_module(
-        self, with_throughput: bool = False, with_metrics: bool = True
-    ) -> RecMetricModule:
-        tasks = [create_test_task("task1")]
-
-        rec_metrics = None
-        if with_metrics:
-            ne_metric = NEMetric(
-                world_size=1,
-                my_rank=0,
-                batch_size=32,
-                tasks=tasks,
-                compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-                window_size=100,
-            )
-            rec_metrics = RecMetricList([ne_metric])
-
-        throughput_metric = None
-        if with_throughput:
-            throughput_metric = ThroughputMetric(
-                batch_size=32,
-                world_size=1,
-                window_seconds=100,
-                warmup_steps=10,
-            )
-
-        return RecMetricModule(
-            batch_size=32,
-            world_size=1,
-            rec_tasks=tasks,
-            rec_metrics=rec_metrics,
-            throughput_metric=throughput_metric,
-        )
-
-    def _get_state_dict_keys(
-        self, with_throughput: bool = False, with_metrics: bool = True
-    ) -> List[str]:
-        module = self._create_rec_metric_module(
-            with_throughput=with_throughput, with_metrics=with_metrics
-        )
-        return sorted(module.state_dict().keys())
-
-    def test_rec_metric_module_compatibility(self) -> None:
-        key = REC_METRIC_MODULE_SNAPSHOT_KEY
-
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_throughput=False)
-            self.golden_snapshot[key] = {
-                "metric_class": "RecMetricModule",
-                "variant": "",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_throughput=False))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}."
-            )
-
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(
-                added_keys, with_throughput=False
-            ):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
-                )
-
-    def test_rec_metric_module_with_throughput_compatibility(self) -> None:
-        key = REC_METRIC_MODULE_WITH_THROUGHPUT_KEY
-
-        if key not in self.golden_snapshot:
-            current_keys = self._get_state_dict_keys(with_throughput=True)
-            self.golden_snapshot[key] = {
-                "metric_class": "RecMetricModule",
-                "variant": "with_throughput",
-                "state_dict_keys": current_keys,
-                "persistent_buffer_fqns": [],
-                "non_persistent_buffer_fqns": [],
-            }
-            save_golden_snapshot(self.golden_snapshot)
-            return
-
-        baseline = self.golden_snapshot[key]
-        current_keys = set(self._get_state_dict_keys(with_throughput=True))
-        baseline_keys = set(baseline["state_dict_keys"])
-
-        removed_keys = baseline_keys - current_keys
-        if removed_keys:
-            self.fail(
-                f"BREAKING CHANGE in {key}: state_dict keys removed: {sorted(removed_keys)}."
-            )
-
-        added_keys = current_keys - baseline_keys
-        if added_keys:
-            if not self._verify_backward_compatibility(
-                added_keys, with_throughput=True
-            ):
-                self.fail(
-                    f"BREAKING CHANGE in {key}: state_dict keys added: {sorted(added_keys)}. "
-                    "Implement load_state_dict hooks to handle missing keys."
-                )
-
-    def _verify_backward_compatibility(
-        self, added_keys: Set[str], with_throughput: bool = False
-    ) -> bool:
-        try:
-            module = self._create_rec_metric_module(with_throughput=with_throughput)
-            state_dict = module.state_dict()
-            old_checkpoint = {
-                k: v for k, v in state_dict.items() if k not in added_keys
-            }
-
-            fresh_module = self._create_rec_metric_module(
-                with_throughput=with_throughput
-            )
-            fresh_module.load_state_dict(old_checkpoint, strict=True)
-            return True
-        except Exception:
-            return False
+    """Round-trip checks for RecMetricModule that are not golden comparisons."""
 
     def test_rec_metric_module_state_roundtrip(self) -> None:
-        module = self._create_rec_metric_module(with_throughput=True)
+        module = _make_rec_metric_module(_make_throughput_metric())
         initial_state = module.state_dict()
 
-        fresh_module = self._create_rec_metric_module(with_throughput=True)
+        fresh_module = _make_rec_metric_module(_make_throughput_metric())
         fresh_module.load_state_dict(initial_state, strict=True)
 
         restored_state = fresh_module.state_dict()
@@ -1083,12 +1111,12 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
             )
 
     def test_rec_metric_module_backward_compat_trained_batches(self) -> None:
-        module = self._create_rec_metric_module()
+        module = _make_rec_metric_module()
         state_dict = module.state_dict()
 
         state_dict["_trained_batches"] = torch.tensor(100)
 
-        fresh_module = self._create_rec_metric_module()
+        fresh_module = _make_rec_metric_module()
         # strict=True matches production. Under strict=False this test passes
         # even without the pop hook.
         fresh_module.load_state_dict(state_dict, strict=True)
@@ -1658,7 +1686,7 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.golden_snapshot = load_golden_snapshot()
+        cls.golden_snapshot = load_required_golden_snapshot()
 
     def _simulate_dcp_fqn_validation(
         self,
@@ -1716,27 +1744,16 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
             )
 
     def test_rec_metric_module_dcp_validation(self) -> None:
-        key = REC_METRIC_MODULE_SNAPSHOT_KEY
+        key = _REC_METRIC_MODULE_DEFAULT.key
         if key not in self.golden_snapshot:
-            self.skipTest(f"No golden snapshot for {key}")
+            self.fail(
+                f"No golden entry for {key}. This simulation needs one; run "
+                "with --update-golden."
+            )
 
-        tasks = [create_test_task("task1")]
-        ne_metric = NEMetric(
-            world_size=1,
-            my_rank=0,
-            batch_size=32,
-            tasks=tasks,
-            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            window_size=100,
-        )
-        rec_metrics = RecMetricList([ne_metric])
-
-        module = RecMetricModule(
-            batch_size=32,
-            world_size=1,
-            rec_tasks=tasks,
-            rec_metrics=rec_metrics,
-        )
+        # Built by the same builder that wrote the entry above, so the two
+        # cannot drift into comparing differently configured modules.
+        module = _REC_METRIC_MODULE_DEFAULT.build()
 
         current_fqns = set(module.state_dict().keys())
         checkpoint_fqns = set(self.golden_snapshot[key]["state_dict_keys"])
@@ -1755,9 +1772,41 @@ class DCPCheckpointClientSimulationTest(unittest.TestCase):
             )
 
 
+def generate_schema_case_entries() -> Dict[str, Dict[str, Any]]:
+    """Golden entries for the _SCHEMA_CASES table.
+
+    The comparison path fails rather than writing a missing entry, so this is
+    the only way a new case gets one.
+    """
+    entries: Dict[str, Dict[str, Any]] = {}
+    for case in _SCHEMA_CASES:
+        if case.key in entries:
+            raise ValueError(
+                f"Two cases share the key {case.key!r}. One would overwrite the "
+                "other's golden entry."
+            )
+        module = case.build()
+        entries[case.key] = {
+            "metric_class": case.expected_class.__name__,
+            "variant": case.variant,
+            "state_dict_keys": sorted(module.state_dict().keys()),
+            "persistent_buffer_fqns": [],
+            "non_persistent_buffer_fqns": [],
+        }
+    return entries
+
+
 def update_golden_snapshot() -> None:
     print("Generating golden snapshot...")
     snapshot = generate_golden_snapshot()
+    case_entries = generate_schema_case_entries()
+    collisions = sorted(set(snapshot) & set(case_entries))
+    if collisions:
+        raise ValueError(
+            f"Case keys collide with metric snapshot keys: {collisions}. "
+            "One generator would overwrite the other."
+        )
+    snapshot.update(case_entries)
     save_golden_snapshot(snapshot)
     print(f"Golden snapshot saved to {GOLDEN_SNAPSHOT_PATH}")
     print(f"Total metrics captured: {len(snapshot)}")

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -26,6 +26,7 @@ To update the golden snapshot after intentional changes:
     python -m torchrec.metrics.tests.test_metric_fqn_backward_compatibility --update-golden
 """
 
+import contextlib
 import inspect
 import json
 import os
@@ -33,9 +34,22 @@ import sys
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set, Tuple, Type
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
 
 import torch
+import torch.distributed as dist
+from torchrec.checkpoint.schema import schema_id_of
 from torchrec.metrics.accuracy import AccuracyMetric
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.auprc import AUPRCMetric
@@ -45,6 +59,8 @@ from torchrec.metrics.calibration import CalibrationMetric
 from torchrec.metrics.calibration_with_recalibration import (
     RecalibratedCalibrationMetric,
 )
+from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
+from torchrec.metrics.cpu_offloaded_metric_module import CPUOffloadedRecMetricModule
 from torchrec.metrics.ctr import CTRMetric
 from torchrec.metrics.gauc import GAUCMetric
 from torchrec.metrics.hindsight_target_pr import HindsightTargetPRMetric
@@ -59,6 +75,7 @@ from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.ne_positive import NEPositiveMetric
 from torchrec.metrics.ne_with_recalibration import RecalibratedNEMetric
 from torchrec.metrics.nmse import NMSEMetric
+from torchrec.metrics.noop_metric_module import NoOpMetricModule
 from torchrec.metrics.num_missing_labels import NumMissingLabelsMetric
 from torchrec.metrics.num_positive_samples import NumPositiveSamplesMetric
 from torchrec.metrics.output import OutputMetric
@@ -80,6 +97,7 @@ from torchrec.metrics.unweighted_ne import UnweightedNEMetric
 from torchrec.metrics.weighted_avg import WeightedAvgMetric
 from torchrec.metrics.weighted_sum_predictions import WeightedSumPredictionsMetric
 from torchrec.metrics.xauc import XAUCMetric
+from torchrec.test_utils import init_process_group_single_rank
 
 
 # Path to the golden snapshot file
@@ -812,23 +830,8 @@ def _make_throughput_metric(
 def _make_rec_metric_module(
     throughput_metric: Optional[ThroughputMetric] = None,
 ) -> RecMetricModule:
-    tasks = [create_test_task("task1")]
     return RecMetricModule(
-        batch_size=32,
-        world_size=1,
-        rec_tasks=tasks,
-        rec_metrics=RecMetricList(
-            [
-                NEMetric(
-                    world_size=1,
-                    my_rank=0,
-                    batch_size=32,
-                    tasks=tasks,
-                    compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-                    window_size=100,
-                )
-            ]
-        ),
+        **_module_fixture_kwargs(),
         throughput_metric=throughput_metric,
     )
 
@@ -849,6 +852,9 @@ class _GoldenCase:
     expected_class: Type[torch.nn.Module]
     variant: str
     build: Callable[[], torch.nn.Module]
+    # Called on every module this case builds. A case whose module owns threads
+    # or other process state declares how to release it.
+    cleanup: Optional[Callable[[torch.nn.Module], None]] = None
 
     @property
     def key(self) -> str:
@@ -859,7 +865,7 @@ _REC_METRIC_MODULE_DEFAULT = _GoldenCase(
     "rec_metric_module", RecMetricModule, "", _make_rec_metric_module
 )
 
-_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
+_CORE_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
     _GoldenCase("throughput_metric", ThroughputMetric, "", _make_throughput_metric),
     _GoldenCase(
         "throughput_metric",
@@ -875,6 +881,90 @@ _SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
         lambda: _make_rec_metric_module(_make_throughput_metric()),
     ),
 )
+
+
+def _module_fixture_kwargs() -> Dict[str, Any]:
+    """Construction args shared by every RecMetricModule case.
+
+    One real metric, because an empty RecMetricList produces an empty
+    state_dict. Shared so the enrolled modules keep describing comparable
+    shapes.
+    """
+    tasks = [create_test_task("task1")]
+    return {
+        "batch_size": 32,
+        "world_size": 1,
+        "rec_tasks": tasks,
+        "rec_metrics": RecMetricList(
+            [
+                NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=32,
+                    tasks=tasks,
+                    compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+                    window_size=100,
+                )
+            ]
+        ),
+    }
+
+
+def _shutdown(module: torch.nn.Module) -> None:
+    """Release a CPUOffloadedRecMetricModule's worker threads.
+
+    Two threads plus an atexit hook per instance, and one case builds three.
+    shutdown() is idempotent.
+    """
+    # pyre-ignore[16]
+    module.shutdown()
+
+
+@contextlib.contextmanager
+def _single_rank_process_group() -> Iterator[None]:
+    """A process group for CPUOffloadedRecMetricModule's compute worker.
+
+    shutdown() wakes that worker, which calls dist.new_group and then re-raises
+    whatever it caught. So building a module without a group succeeds and its
+    teardown throws, which is why generation needs this as much as the tests do.
+
+    Only destroys a group it created, so a caller that brought its own keeps it.
+    """
+    created = not dist.is_initialized()
+    if created:
+        init_process_group_single_rank("gloo")
+    try:
+        yield
+    finally:
+        if created:
+            dist.destroy_process_group()
+
+
+# Enrolled with @checkpoint_schema_stable under these same ids. Not RecMetric
+# subclasses, so _discover_all_recmetric_subclasses cannot see them.
+_MODULE_SCHEMA_CASES: Tuple[_GoldenCase, ...] = (
+    _GoldenCase("noop_metric_module", NoOpMetricModule, "", NoOpMetricModule),
+    _GoldenCase(
+        "cpu_comms_rec_metric_module",
+        CPUCommsRecMetricModule,
+        "",
+        lambda: CPUCommsRecMetricModule(**_module_fixture_kwargs()),
+    ),
+    # state_dict() reads the comms tree and load_state_dict() writes the offloaded
+    # one, but both carry the same keys, so this pins the shape and not which tree
+    # a load reached. test_cpu_offloaded_metric_module covers the load direction.
+    _GoldenCase(
+        "cpu_offloaded_rec_metric_module",
+        CPUOffloadedRecMetricModule,
+        "",
+        lambda: CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"), **_module_fixture_kwargs()
+        ),
+        cleanup=_shutdown,
+    ),
+)
+
+_SCHEMA_CASES: Tuple[_GoldenCase, ...] = _CORE_SCHEMA_CASES + _MODULE_SCHEMA_CASES
 
 
 class _ModuleWithKnownKeys(torch.nn.Module):
@@ -918,31 +1008,48 @@ class GoldenCaseTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.golden_snapshot = load_required_golden_snapshot()
 
-    def _check_case(self, case: _GoldenCase) -> None:
-        module = case.build()
-        self.assertIs(type(module), case.expected_class)
+    def setUp(self) -> None:
+        # Registered before any module is built, so under addCleanup's LIFO
+        # order the group is torn down last. Destroying it ahead of a module
+        # would make that module's shutdown throw.
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(_single_rank_process_group())
 
-        if case.key not in self.golden_snapshot:
-            self.fail(
-                f"No golden entry for {case.key}. Run with --update-golden "
-                "to create it. Writing one here would bless whatever the "
-                "code currently produces, and concurrent tests writing the "
-                "whole file at once corrupt it."
+    @contextlib.contextmanager
+    def _built(self, case: _GoldenCase) -> Iterator[torch.nn.Module]:
+        module = case.build()
+        try:
+            yield module
+        finally:
+            if case.cleanup is not None:
+                case.cleanup(module)
+
+    def _check_case(self, case: _GoldenCase) -> None:
+        with self._built(case) as module:
+            self.assertIs(type(module), case.expected_class)
+
+            if case.key not in self.golden_snapshot:
+                self.fail(
+                    f"No golden entry for {case.key}. Run with --update-golden "
+                    "to create it. Writing one here would bless whatever the "
+                    "code currently produces, and concurrent tests writing the "
+                    "whole file at once corrupt it."
+                )
+
+            entry = self.golden_snapshot[case.key]
+            self.assertEqual(
+                entry["metric_class"],
+                case.expected_class.__name__,
+                f"Golden entry {case.key} was written by a different class.",
+            )
+            self.assertEqual(
+                entry["variant"],
+                case.variant,
+                f"Golden entry {case.key} was written by a different variant.",
             )
 
-        entry = self.golden_snapshot[case.key]
-        self.assertEqual(
-            entry["metric_class"],
-            case.expected_class.__name__,
-            f"Golden entry {case.key} was written by a different class.",
-        )
-        self.assertEqual(
-            entry["variant"],
-            case.variant,
-            f"Golden entry {case.key} was written by a different variant.",
-        )
-
-        current_keys = set(module.state_dict().keys())
+            current_keys = set(module.state_dict().keys())
 
         baseline_keys = set(entry["state_dict_keys"])
 
@@ -1053,10 +1160,10 @@ class GoldenCaseTest(unittest.TestCase):
         """
         by_id: Dict[str, List[FrozenSet[str]]] = {}
         for case in _SCHEMA_CASES:
-            module = case.build()
-            by_id.setdefault(case.stable_id, []).append(
-                frozenset(module.state_dict().keys())
-            )
+            with self._built(case) as module:
+                by_id.setdefault(case.stable_id, []).append(
+                    frozenset(module.state_dict().keys())
+                )
 
         for stable_id, entries in by_id.items():
             with self.subTest(stable_id):
@@ -1120,6 +1227,26 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         # strict=True matches production. Under strict=False this test passes
         # even without the pop hook.
         fresh_module.load_state_dict(state_dict, strict=True)
+
+
+class SchemaStableCoverageTest(unittest.TestCase):
+    """Every enrolled case and the class it names must agree on the id.
+
+    The case row is what enrolls a class. The mark on the class is what says
+    which id its golden entry is filed under. If they disagree, the row checks
+    an entry the class never claimed.
+    """
+
+    def test_each_case_class_carries_its_id(self) -> None:
+        for case in _SCHEMA_CASES:
+            with self.subTest(case.key):
+                self.assertEqual(
+                    schema_id_of(case.expected_class),
+                    case.stable_id,
+                    f"{case.expected_class.__name__} is not marked with "
+                    f"{case.stable_id!r}. Add @checkpoint_schema_stable to the "
+                    "class, or correct the id on the row.",
+                )
 
 
 class MetricCoverageTest(unittest.TestCase):
@@ -1777,22 +1904,30 @@ def generate_schema_case_entries() -> Dict[str, Dict[str, Any]]:
 
     The comparison path fails rather than writing a missing entry, so this is
     the only way a new case gets one.
+
+    Owns the process group rather than leaving it to the caller: the tests get
+    one from setUp, and --update-golden runs outside unittest entirely.
     """
     entries: Dict[str, Dict[str, Any]] = {}
-    for case in _SCHEMA_CASES:
-        if case.key in entries:
-            raise ValueError(
-                f"Two cases share the key {case.key!r}. One would overwrite the "
-                "other's golden entry."
-            )
-        module = case.build()
-        entries[case.key] = {
-            "metric_class": case.expected_class.__name__,
-            "variant": case.variant,
-            "state_dict_keys": sorted(module.state_dict().keys()),
-            "persistent_buffer_fqns": [],
-            "non_persistent_buffer_fqns": [],
-        }
+    with _single_rank_process_group():
+        for case in _SCHEMA_CASES:
+            if case.key in entries:
+                raise ValueError(
+                    f"Two cases share the key {case.key!r}. One would overwrite "
+                    "the other's golden entry."
+                )
+            module = case.build()
+            try:
+                entries[case.key] = {
+                    "metric_class": case.expected_class.__name__,
+                    "variant": case.variant,
+                    "state_dict_keys": sorted(module.state_dict().keys()),
+                    "persistent_buffer_fqns": [],
+                    "non_persistent_buffer_fqns": [],
+                }
+            finally:
+                if case.cleanup is not None:
+                    case.cleanup(module)
     return entries
 
 

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -18,6 +18,7 @@ from typing import Any, Deque, Dict, List, Optional
 
 import torch
 import torch.nn as nn
+from torchrec.checkpoint.schema import checkpoint_schema_stable
 from torchrec.distributed.utils import none_throws
 from torchrec.metrics.metrics_config import BatchSizeStage
 from torchrec.metrics.metrics_namespace import (
@@ -32,6 +33,7 @@ MAX_WINDOW_TS: int = 2 * 60 * 60  # 2 hours
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@checkpoint_schema_stable("throughput_metric")
 class ThroughputMetric(nn.Module):
     """
     The module to calculate throughput. Throughput is defined as the trained examples


### PR DESCRIPTION
Summary:

This diff enrolls three `RecMetricModule` subclasses in golden-snapshot CI.

`_discover_all_recmetric_subclasses` matches only `RecMetric` subclasses. `CPUOffloadedRecMetricModule`, `CPUCommsRecMetricModule`, and `NoOpMetricModule` subclass `RecMetricModule`, so discovery misses them.

This diff adds `torchrec/checkpoint/schema.py` and the `checkpoint_schema_stable` decorator. The decorator files a class under a hand-written id. The three modules then join the existing `_GoldenCase` table. `SchemaStableCoverageTest` asserts the registry and that table agree. Golden generation now owns the process group `shutdown` requires.

Differential Revision: D118975307


