### PR TITLE
Rename the four hand-written golden keys to snake_case (#4699)

### DIFF
--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -143,17 +143,6 @@
     ],
     "variant": "with_r_squared"
   },
-  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
-    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
-    "metric_class": "MulticlassRecallMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "_metrics_computations.0.total_weights",
-      "_metrics_computations.0.tp_at_k"
-    ],
-    "variant": ""
-  },
   "MultiLabelPrecisionMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "MultiLabelPrecisionMetric",
@@ -162,6 +151,17 @@
     "state_dict_keys": [
       "_metrics_computations.0.false_pos_sum_label_0",
       "_metrics_computations.0.true_pos_sum_label_0"
+    ],
+    "variant": ""
+  },
+  "MulticlassRecallMetric_UNFUSED_TASKS_COMPUTATION": {
+    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
+    "metric_class": "MulticlassRecallMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "_metrics_computations.0.total_weights",
+      "_metrics_computations.0.tp_at_k"
     ],
     "variant": ""
   },
@@ -298,33 +298,6 @@
     "state_dict_keys": [],
     "variant": ""
   },
-  "RecMetricModule": {
-    "metric_class": "RecMetricModule",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
-    ],
-    "variant": ""
-  },
-  "RecMetricModule_with_throughput": {
-    "metric_class": "RecMetricModule",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
-      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples",
-      "throughput_metric.time_lapse_after_warmup",
-      "throughput_metric.total_examples",
-      "throughput_metric.warmup_examples"
-    ],
-    "variant": "with_throughput"
-  },
   "RecalibratedCalibrationMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "RecalibratedCalibrationMetric",
@@ -439,29 +412,6 @@
     ],
     "variant": ""
   },
-  "ThroughputMetric": {
-    "metric_class": "ThroughputMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "time_lapse_after_warmup",
-      "total_examples",
-      "warmup_examples"
-    ],
-    "variant": ""
-  },
-  "ThroughputMetric_with_batch_size_stages": {
-    "metric_class": "ThroughputMetric",
-    "non_persistent_buffer_fqns": [],
-    "persistent_buffer_fqns": [],
-    "state_dict_keys": [
-      "num_batch",
-      "time_lapse_after_warmup",
-      "total_examples",
-      "warmup_examples"
-    ],
-    "variant": "with_batch_size_stages"
-  },
   "TowerQPSMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "TowerQPSMetric",
@@ -529,5 +479,55 @@
       "_metrics_computations.0.weighted_num_pairs"
     ],
     "variant": ""
+  },
+  "rec_metric_module": {
+    "metric_class": "RecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples"
+    ],
+    "variant": ""
+  },
+  "rec_metric_module_with_throughput": {
+    "metric_class": "RecMetricModule",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.neg_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.pos_labels",
+      "rec_metrics.rec_metrics.0._metrics_computations.0.weighted_num_samples",
+      "throughput_metric.time_lapse_after_warmup",
+      "throughput_metric.total_examples",
+      "throughput_metric.warmup_examples"
+    ],
+    "variant": "with_throughput"
+  },
+  "throughput_metric": {
+    "metric_class": "ThroughputMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "time_lapse_after_warmup",
+      "total_examples",
+      "warmup_examples"
+    ],
+    "variant": ""
+  },
+  "throughput_metric_with_batch_size_stages": {
+    "metric_class": "ThroughputMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "num_batch",
+      "time_lapse_after_warmup",
+      "total_examples",
+      "warmup_examples"
+    ],
+    "variant": "with_batch_size_stages"
   }
 }

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -1089,7 +1089,9 @@ class RecMetricModuleBackwardCompatibilityTest(unittest.TestCase):
         state_dict["_trained_batches"] = torch.tensor(100)
 
         fresh_module = self._create_rec_metric_module()
-        fresh_module.load_state_dict(state_dict, strict=False)
+        # strict=True matches production. Under strict=False this test passes
+        # even without the pop hook.
+        fresh_module.load_state_dict(state_dict, strict=True)
 
 
 class MetricCoverageTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -777,11 +777,12 @@ class MetricStateSnapshotTest(unittest.TestCase):
         self._test_metric_state_roundtrip(WeightedAvgMetric)
 
 
-# Golden snapshot keys for ThroughputMetric and RecMetricModule
-THROUGHPUT_SNAPSHOT_KEY = "ThroughputMetric"
-THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY = "ThroughputMetric_with_batch_size_stages"
-REC_METRIC_MODULE_SNAPSHOT_KEY = "RecMetricModule"
-REC_METRIC_MODULE_WITH_THROUGHPUT_KEY = "RecMetricModule_with_throughput"
+# Golden snapshot keys for ThroughputMetric and RecMetricModule. These are
+# hand-written and must outlive the class names, so they are not class names.
+THROUGHPUT_SNAPSHOT_KEY = "throughput_metric"
+THROUGHPUT_WITH_STAGES_SNAPSHOT_KEY = "throughput_metric_with_batch_size_stages"
+REC_METRIC_MODULE_SNAPSHOT_KEY = "rec_metric_module"
+REC_METRIC_MODULE_WITH_THROUGHPUT_KEY = "rec_metric_module_with_throughput"
 
 
 class ThroughputMetricBackwardCompatibilityTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

This diff renames four golden snapshot keys to snake_case.

Four golden snapshot keys are written by hand. Each one copies its class
name today. That wrongly implies a class rename should rename the key.

This diff switches the four keys to snake_case. The names no longer track
any class name. The regenerated file also sorts correctly. The checked-in
copy had drifted from its own generator.

Differential Revision: D119400432


