### PR TITLE
Reproduce uneven all2all error (#4704)

### DIFF
--- a/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py
+++ b/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+"""Reproduce the 128-rank TorchTPU uneven all-to-all failure."""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import torch
+import torch.distributed as dist
+
+
+BASE_ELEMENTS = 8
+VARIATIONS = 8
+
+
+def _run_case(case: str) -> None:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if case == "equal":
+        # Each rank gets same number of elements
+        split_sizes = [BASE_ELEMENTS] * world_size
+    else:
+        # Different ranks get different number of elements
+        split_sizes = [BASE_ELEMENTS + rank % VARIATIONS for rank in range(world_size)]
+
+    local_split = split_sizes[rank]
+    input_splits = [local_split] * world_size
+    output_splits = split_sizes
+
+    # Create a tensor such that each rank r_i is assigned a certain range [r_i * 1M, (r_i +1) * 1M)
+    input_tensor = rank * 1_000_000 + torch.arange(
+        world_size * local_split, device="tpu", dtype=torch.int32
+    )
+    output_tensor = torch.empty(sum(output_splits), device="tpu", dtype=torch.int32)
+
+    print(
+        f"rank={rank} case={case} start input_splits={input_splits[:8]} "
+        f"output_splits={output_splits[:8]}",
+        flush=True,
+    )
+    dist.all_to_all_single(
+        output_tensor,
+        input_tensor,
+        output_split_sizes=output_splits,
+        input_split_sizes=input_splits,
+    )
+    print(f"rank={rank} case={case} collective complete", flush=True)
+    actual = output_tensor.cpu()
+
+    expected = torch.cat(
+        [
+            r_i * 1_000_000
+            + torch.arange(rank * size, (rank + 1) * size, dtype=torch.int32)
+            for r_i, size in enumerate(split_sizes)
+        ]
+    )
+    torch.testing.assert_close(actual, expected)
+    print(f"rank={rank} case={case} PASS", flush=True)
+
+
+def main() -> None:
+    import torch_tpu  # noqa: F401  # pyre-ignore[21]
+
+    dist.init_process_group(backend="tpu_dist")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if rank == 0:
+        print(
+            "torch="
+            + str(torch.__version__)
+            + "; torch_tpu="
+            + importlib.metadata.version("torch-tpu"),
+            flush=True,
+        )
+        print(
+            f"world_size={world_size}; equal is the non-VBE control, uneven is "
+            "the VBE-like collective",
+            flush=True,
+        )
+
+    for case in ("equal", "uneven"):
+        _run_case(case)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall_128rank_full.md
+++ b/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall_128rank_full.md
@@ -1,0 +1,26 @@
+Source: torch_tpu=aa6805461b6f7216140ea8e4cb5ea6564d389574
+Multi-host launch: node_rank=0/16 master=gem-alitehrani-tpu-64chip-worker-0-0.gem-alitehrani-tpu-64chip:29500
+  topology=4,4,4,2  nproc_per_node=8  (world=128)
+  launching /workspace/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py 
+  stack rlimit: 8388608 KB
+torch=2.15.0.dev20260910+cpu; torch_tpu=0.1.1
+world_size=128; equal is the non-VBE control, uneven is the VBE-like collective
+rank=0 case=equal start input_splits=[8, 8, 8, 8, 8, 8, 8, 8] output_splits=[8, 8, 8, 8, 8, 8, 8, 8]
+rank=0 case=equal collective complete
+rank=0 case=equal PASS
+rank=0 case=uneven start input_splits=[8, 8, 8, 8, 8, 8, 8, 8] output_splits=[8, 9, 10, 11, 12, 13, 14, 15]
+rank=0 case=uneven collective complete
+[rank0]: Traceback (most recent call last):
+[rank0]:   File "/workspace/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py", line 94, in <module>
+[rank0]:     main()
+[rank0]:   File "/workspace/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py", line 89, in main
+[rank0]:     _run_case(case)
+[rank0]:   File "/workspace/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py", line 64, in _run_case
+[rank0]:     torch.testing.assert_close(actual, expected)
+[rank0]:   File "/usr/local/lib/python3.12/site-packages/torch/testing/_comparison.py", line 1689, in assert_close
+[rank0]:     raise error_metas[0].to_error(msg)
+[rank0]: AssertionError: Tensor-likes are not equal!
+[rank0]: Mismatched elements: 1389 / 1472 (94.4%)
+[rank0]: Greatest absolute difference: 2146483647 at index (8,)
+[rank0]: Greatest relative difference: 2146.483642578125 at index (8,)
+[rank0]:[W910 18:38:24.800725968 env_vars.h:296] Warning: the TORCH_SHOW_CPP_STACKTRACES environment variable is an experimental feature and may change or be removed without notice. (function operator())

--- a/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall_8rank_full.md
+++ b/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall_8rank_full.md
@@ -1,0 +1,15 @@
+Kernel pushed to trec-alitehrani-tpu.
+Ensuring jax-tpu-embedding is installed in the pod ...
+Running experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py ...
+Source: torch_tpu=aa6805461b6f7216140ea8e4cb5ea6564d389574
+TPU topology: 2,2,1,2
+World size: 8
+Launching: /workspace/torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py
+torch=2.15.0.dev20260910+cpu; torch_tpu=0.1.1
+world_size=8; equal is the non-VBE control, uneven is the VBE-like collective
+rank=0 case=equal start input_splits=[8, 8, 8, 8, 8, 8, 8, 8] output_splits=[8, 8, 8, 8, 8, 8, 8, 8]
+rank=0 case=equal collective complete
+rank=0 case=equal PASS
+rank=0 case=uneven start input_splits=[8, 8, 8, 8, 8, 8, 8, 8] output_splits=[8, 9, 10, 11, 12, 13, 14, 15]
+rank=0 case=uneven collective complete
+rank=0 case=uneven PASS


### PR DESCRIPTION
Summary:

Add an uneven all-to-all TPU repro with complete 8- and 128-rank logs.

The uneven all2all on this simple example works with 8 ranks but not with 128-ranks. See the corresponding .md files for reference, and note that only rank 0 is reported. Note this was tested on NVIDIA H100 and was successful.

Run-Script Single-Host:

```
eval "$(python3 -m torch_tpu._internal.distributed.launchers.singlehost_wrapper)"
export TORCH_TPU_TOPOLOGY TORCH_TPU_SLICEBUILDER_ADDRESSES WORLD_SIZE

python3 -m torch.distributed.run \
  --nproc_per_node="$WORLD_SIZE" \
  ./torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py
```

Run-Script Multi-Host:

```
eval "$(python3 -m torch_tpu._internal.distributed.launchers.multihost_wrapper)"
export TORCH_TPU_SLICEBUILDER_ADDRESSES
export NNODES NODE_RANK MASTER_ADDR MASTER_PORT
export TORCH_TPU_TOPOLOGY="${TPU_TOPOLOGY//x/,},2"

python3 -m torch.distributed.run \
  --nnodes="$NNODES" \
  --node_rank="$NODE_RANK" \
  --master_addr="$MASTER_ADDR" \
  --master_port="$MASTER_PORT" \
  --nproc_per_node=8 \
  ./torchrec/experimental/torch_tpu/scripts/uneven_all2all/repro_tpu_vbe_alltoall.py
```

Reviewed By: kausv

Differential Revision: D119541029


