### PR TITLE
Run the offloaded save/load test without a GPU (#4706)

### DIFF
--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -749,10 +749,6 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 self.cpu_module.async_compute()
 
-    @unittest.skipIf(
-        torch.cuda.device_count() < 1,
-        "Not enough GPUs, this test requires at least one GPU",
-    )
     def test_state_dict_save_load(self) -> None:
         """
         Test state_dict() method. Generated from comms module, loaded into offloaded module
@@ -775,8 +771,10 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 "state_3": torch.tensor([3.0]),
             },
         )
+        # model_out_device only selects the GPU-to-CPU transfer path inside
+        # _process_update_job. This test never calls update(), so it never
+        # reads the flag and the assertions below hold on any device.
         offloaded_module = self._make_module(
-            model_out_device=torch.device("cuda"),
             rec_metrics=RecMetricList([offloaded_metric]),
         )
 


### PR DESCRIPTION
Summary:

This diff removes a GPU gate from a test that never uses a GPU.

`test_state_dict_save_load` covers the one asymmetry in `CPUOffloadedRecMetricModule`: `state_dict()` reads the comms module, while `load_state_dict()` writes the offloaded module. It sets different values on each side, so the routing cannot pass by coincidence. It is also skipped on any host without a GPU.

Nothing in it needs one. `model_out_device` selects the GPU-to-CPU transfer path inside `_process_update_job`, and this test never calls `update()`, so the flag is never read. The test passed `torch.device("cuda")` and gated itself on that argument alone. It now takes `_make_module`'s existing CPU default, and the gate is gone.

Differential Revision: D119351969


