### PR TITLE
Demonstrate same-PG collective serialization

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -557,6 +557,96 @@ def multi_async_comms(
 
 
 @dataclass
+class SamePGAsyncA2ASyncAllReduceConfig(CommsConfig):
+    """
+    run commands:
+    > python -m torchrec.distributed.benchmark.benchmark_comms \
+        same_pg_async_a2a_sync_all_reduce
+
+    use case:
+        show the ordering between an async all_to_all_single and a synchronous
+        all_reduce on the same process group, with independent compute between
+        them. The profiler trace shows the compute overlapping the async a2a and
+        whether the collectives overlap, while the logged completion state shows
+        whether the all_reduce call waits for the earlier all-to-all on the CPU.
+    """
+
+    all_rank_traces: bool = True
+
+
+@register_benchmark(SamePGAsyncA2ASyncAllReduceConfig)
+def same_pg_async_a2a_sync_all_reduce(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Issue an async a2a, overlapping compute, and a sync all-reduce on ctx.pg,
+    without an explicit wait between the collectives. Every rank must issue the
+    collectives in this same order because they share one communicator.
+    """
+    with record_function("## pre-comms compute ##"):
+        input_a = _compute(
+            dim=dim,
+            num_mul=num_mul,
+            num_concat=num_concat,
+            ctx=ctx,
+        )
+        input_b = _compute(
+            dim=dim,
+            num_mul=num_mul,
+            num_concat=num_concat,
+            ctx=ctx,
+        )
+
+    with record_function("## async a2a on shared pg ##"):
+        out_a = torch.zeros_like(input_a)
+        req_a = dist.all_to_all_single(
+            output=out_a,
+            input=input_a,
+            group=ctx.pg,
+            async_op=True,
+        )
+        assert req_a is not None
+
+    with record_function("## compute overlapping async a2a ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## sync all_reduce on shared pg ##"):
+        dist.all_reduce(
+            input_b,
+            op=dist.ReduceOp.SUM,
+            group=ctx.pg,
+            async_op=False,
+        )
+
+    with record_function("## a2a completion probe after sync all_reduce ##"):
+        a2a_completed_after_all_reduce = req_a.is_completed()
+
+    with record_function("## wait and validate ##"):
+        req_a.wait()
+        checks_a = _validate(out_a, ctx)
+        expected_sum = ctx.world_size * (ctx.world_size - 1) // 2
+        checks_b = torch.all(input_b.to(torch.int) >= expected_sum)
+        checks = DeviceToHostTensorAwaitable(checks_a & checks_b)
+
+    with record_function(
+        f"## async a2a completed when sync all_reduce returned: "
+        f"{a2a_completed_after_all_reduce} ##"
+    ):
+        logger.info(
+            f"[rank-{ctx.rank}] async a2a completed when sync all_reduce returned: "
+            f"{a2a_completed_after_all_reduce}"
+        )
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
+@dataclass
 class CompetingCommsConfig(CommsConfig):
     """
     run commands:


### PR DESCRIPTION
Summary:
This adds a focused benchmark for an asynchronous all-to-all followed by independent GPU compute and a synchronous all-reduce on the same process group. It separates two questions that are easy to conflate: whether communication can overlap computation, and whether two communication operations issued through one process group can execute independently.

The NCCL and ProcessGroupNCCL mechanism is:

- An NCCL communicator represents a fixed rank-to-CUDA-device membership. Every rank constructs its local communicator object from the same unique ID, and that communicator object is passed to each collective. It is therefore the shared identity through which the participants agree on the communication sequence.
- ProcessGroupNCCL normally caches and reuses a communicator for a process-group/device key. Both benchmark collectives use the same process group and consequently resolve to the same cached communicator. This is a ProcessGroupNCCL mapping and lifecycle choice, not an NCCL restriction that a rank set may own only one communicator.
- NCCL explicitly supports duplicating a communicator with ncclCommSplit and running multiple communicators per device. A second process group is the PyTorch-level way to obtain another communicator and hence another communication execution domain over the same ranks.
- NCCL requires every GPU to issue operations in a matching order. Its group-ordering documentation states that this requirement applies even when calls use different communicators; changing the order on one rank can produce incorrect results or a hang. Different CUDA streams therefore do not remove the distributed ordering requirement.
- NCCL calls are CUDA-asynchronous: a call returns after the operation is enqueued to its stream, while device execution continues. In this benchmark, async_op=True places the A2A on the ProcessGroupNCCL communication stream and returns a Work handle, so independent GEMM and elementwise compute on the caller stream can overlap it.
- The subsequent async_op=False all-reduce does not create a second communicator. It establishes the expected CUDA-stream dependency for synchronous ProcessGroupNCCL use, but does not imply a device-wide host wait. The A2A completion probe can therefore still be false when the all-reduce API returns, while the all-reduce GPU kernel remains ordered after the A2A on the shared communicator.
- NCCL documents concurrent kernel execution specifically for multiple communicators. Before NCCL 2.26, applications had to serialize launches from different communicators into a consistent global order to avoid deadlock. Starting with NCCL 2.26, NCCL_LAUNCH_ORDER_IMPLICIT can derive that order from deterministic host launch order; with CUDA 12.3 or newer, launch-completion events can still permit kernels from two communicators to execute in parallel.

<img width="1433" height="354" alt="image" src="https://github.com/user-attachments/assets/0cc86405-8c23-4303-bc6e-5df2781ffcae" />


The two-rank H100 trace confirms the expected behavior: main-stream GEMM and elementwise kernels overlap the NCCL-stream A2A, the A2A completion probe is false after the synchronous all-reduce API returns, and the all-reduce kernel starts only after the A2A kernel finishes. The benchmark is opt-in and does not alter TorchRec runtime behavior.

References:

- NVIDIA NCCL communicator lifecycle, duplication, and multiple-communicator concurrency: https://github.com/NVIDIA/nccl/blob/HEAD/docs/userguide/source/usage/communicators.rst
- NVIDIA NCCL group operation ordering semantics: https://github.com/NVIDIA/nccl/blob/HEAD/docs/userguide/source/usage/groups.rst
- NVIDIA NCCL CUDA stream semantics: https://github.com/NVIDIA/nccl/blob/HEAD/docs/userguide/source/usage/streams.rst
- NVIDIA NCCL environment documentation for NCCL_LAUNCH_ORDER_IMPLICIT: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html

Reviewed By: spmex

Differential Revision: D119626021


